### PR TITLE
feat(config): add basic config page

### DIFF
--- a/public/static/schema.json
+++ b/public/static/schema.json
@@ -1,0 +1,6470 @@
+{
+    "components": {
+        "schemas": {
+            "limiter.bucket": {
+                "properties": {
+                    "zone": {
+                        "description": "The bucket's zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "aggregated": {
+                        "description": "TODO(Rquired description): aggregated",
+                        "label": "aggregated",
+                        "$ref": "#/components/schemas/limiter.bucket_aggregated"
+                    },
+                    "per_client": {
+                        "description": "TODO(Rquired description): per_client",
+                        "label": "per_client",
+                        "$ref": "#/components/schemas/limiter.client_bucket"
+                    }
+                },
+                "type": "object"
+            },
+            "modules.rewrite": {
+                "properties": {
+                    "action": {
+                        "description": "Action",
+                        "example": "publish",
+                        "label": "action",
+                        "symbols": [
+                            "subscribe",
+                            "publish",
+                            "all"
+                        ],
+                        "type": "enum"
+                    },
+                    "source_topic": {
+                        "description": "Origin Topic",
+                        "example": "x/#",
+                        "label": "source_topic",
+                        "type": "string"
+                    },
+                    "dest_topic": {
+                        "description": "Destination Topic",
+                        "example": "z/y/$1",
+                        "label": "dest_topic",
+                        "type": "string"
+                    },
+                    "re": {
+                        "description": "Regular expressions",
+                        "example": "^x/y/(.+)$",
+                        "label": "re",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "dashboard.http": {
+                "required": [
+                    "bind",
+                    "protocol"
+                ],
+                "properties": {
+                    "protocol": {
+                        "default": "http",
+                        "description": "HTTP/HTTPS protocol.",
+                        "label": "protocol",
+                        "symbols": [
+                            "http",
+                            "https"
+                        ],
+                        "type": "enum"
+                    },
+                    "bind": {
+                        "default": 18083,
+                        "description": "Port without IP(18083) or port with specified IP(127.0.0.1:18083).",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "ip_port"
+                            },
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "num_acceptors": {
+                        "default": 4,
+                        "description": "Socket acceptor pool for TCP protocols.",
+                        "label": "num_acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": 512,
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "type": "number"
+                    },
+                    "backlog": {
+                        "default": 1024,
+                        "description": "Defines the maximum length that the queue of pending connections can grow to.",
+                        "label": "backlog",
+                        "type": "number"
+                    },
+                    "send_timeout": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): send_timeout",
+                        "label": "send_timeout",
+                        "type": "duration"
+                    },
+                    "inet6": {
+                        "default": false,
+                        "description": "TODO(Rquired description): inet6",
+                        "label": "inet6",
+                        "type": "boolean"
+                    },
+                    "ipv6_v6only": {
+                        "default": false,
+                        "description": "TODO(Rquired description): ipv6_v6only",
+                        "label": "ipv6_v6only",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-mysql.authentication": {
+                "required": [
+                    "database",
+                    "server",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "mysql"
+                        ],
+                        "type": "enum"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "query": {
+                        "description": "TODO(Rquired description): query",
+                        "label": "query",
+                        "type": "string"
+                    },
+                    "query_timeout": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): query_timeout",
+                        "label": "query_timeout",
+                        "type": "duration"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "server": {
+                        "description": "\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe MySQL default port 3306 is used if '[:Port]' isn't present",
+                        "label": "server",
+                        "type": "ip_port"
+                    },
+                    "database": {
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "string"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "username": {
+                        "description": "TODO(Rquired description): username",
+                        "label": "username",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "auto_reconnect": {
+                        "default": true,
+                        "description": "TODO(Rquired description): auto_reconnect",
+                        "label": "auto_reconnect",
+                        "type": "boolean"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "configuration.node": {
+                "required": [
+                    "data_dir"
+                ],
+                "properties": {
+                    "name": {
+                        "default": "emqx@127.0.0.1",
+                        "description": "Unique name of the EMQX node. It must follow <code>%name%@FQDN</code> or\n <code>%name%@IP</code> format.",
+                        "label": "name",
+                        "type": "string"
+                    },
+                    "cookie": {
+                        "default": "emqxsecretcookie",
+                        "description": "Secret cookie is a random string that should be the same on all nodes in\n the given EMQX cluster, but unique per EMQX cluster. It is used to prevent EMQX nodes that\n belong to different clusters from accidentally connecting to each other.",
+                        "label": "cookie",
+                        "type": "string"
+                    },
+                    "data_dir": {
+                        "description": "Path to the persistent data directory. It must be unique per broker instance.",
+                        "label": "data_dir",
+                        "type": "string"
+                    },
+                    "config_files": {
+                        "description": "List of configuration files that are read during startup. The order is\n significant: later configuration files override the previous ones.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "config_files",
+                        "type": "array"
+                    },
+                    "global_gc_interval": {
+                        "default": "15m",
+                        "description": "Periodic garbage collection interval.",
+                        "label": "global_gc_interval",
+                        "type": "duration"
+                    },
+                    "crash_dump_file": {
+                        "description": "Location of the crash dump file",
+                        "label": "crash_dump_file",
+                        "type": "string"
+                    },
+                    "crash_dump_seconds": {
+                        "default": "30s",
+                        "description": "The number of seconds that the broker is allowed to spend writing\na crash dump",
+                        "label": "crash_dump_seconds",
+                        "type": "duration"
+                    },
+                    "crash_dump_bytes": {
+                        "default": "100MB",
+                        "description": "The maximum size of a crash dump file in bytes.",
+                        "label": "crash_dump_bytes",
+                        "type": "byteSize"
+                    },
+                    "dist_net_ticktime": {
+                        "default": "2m",
+                        "description": "This is the approximate time an EMQX node may be unresponsive until it is considered down and thereby disconnected.",
+                        "label": "dist_net_ticktime",
+                        "type": "duration"
+                    },
+                    "dist_listen_min": {
+                        "default": 6369,
+                        "description": "Lower bound for the port range where EMQX broker listens for peer connections.",
+                        "label": "dist_listen_min",
+                        "maximum": 65535,
+                        "minimum": 1024,
+                        "type": "number"
+                    },
+                    "dist_listen_max": {
+                        "default": 6369,
+                        "description": "Upper bound for the port range where EMQX broker listens for peer connections.",
+                        "label": "dist_listen_max",
+                        "maximum": 65535,
+                        "minimum": 1024,
+                        "type": "number"
+                    },
+                    "backtrace_depth": {
+                        "default": 23,
+                        "description": "Maximum depth of the call stack printed in error messages and\n <code>process_info</code>.",
+                        "label": "backtrace_depth",
+                        "type": "number"
+                    },
+                    "applications": {
+                        "default": "",
+                        "description": "List of Erlang applications that shall be rebooted when the EMQX broker joins\n the cluster.",
+                        "label": "applications",
+                        "type": "comma_separated_string"
+                    },
+                    "etc_dir": {
+                        "description": "<code>etc</code> dir for the node",
+                        "label": "etc_dir",
+                        "type": "string"
+                    },
+                    "cluster_call": {
+                        "description": "TODO(Rquired description): cluster_call",
+                        "label": "cluster_call",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_call"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.force_shutdown": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_message_queue_len": {
+                        "default": 1000,
+                        "description": "TODO(Rquired description): max_message_queue_len",
+                        "label": "max_message_queue_len",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "max_heap_size": {
+                        "default": "32MB",
+                        "description": "TODO(Rquired description): max_heap_size",
+                        "label": "max_heap_size",
+                        "type": "byteSize"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.ssl_client_opts": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "cacertfile": {
+                        "description": "Trusted PEM format CA certificates bundle file.<br>\nThe certificates in this file are used to verify the TLS peer's certificates.\nAppend new certificates to the file if new CAs are to be trusted.\nThere is no need to restart EMQX to have the updated file loaded, because\nthe system regularly checks if file has been updated (and reload).<br>\nNOTE: invalidating (deleting) a certificate from the file will not affect\nalready established connections.\n",
+                        "label": "cacertfile",
+                        "type": "string"
+                    },
+                    "certfile": {
+                        "description": "PEM format certificates chain file.<br>\nThe certificates in this file should be in reversed order of the certificate\nissue chain. That is, the host's certificate should be placed in the beginning\nof the file, followed by the immediate issuer certificate and so on.\nAlthough the root CA certificate is optional, it should be placed at the end of\nthe file if it is to be added.\n",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "PEM format private key file.<br>\n",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "verify": {
+                        "default": "verify_none",
+                        "description": "TODO(Rquired description): verify",
+                        "label": "verify",
+                        "symbols": [
+                            "verify_peer",
+                            "verify_none"
+                        ],
+                        "type": "enum"
+                    },
+                    "reuse_sessions": {
+                        "default": true,
+                        "description": "TODO(Rquired description): reuse_sessions",
+                        "label": "reuse_sessions",
+                        "type": "boolean"
+                    },
+                    "depth": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): depth",
+                        "label": "depth",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "String containing the user's password. Only used if the private\nkey file is password-protected.",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "versions": {
+                        "default": [
+                            "tlsv1.3",
+                            "tlsv1.2",
+                            "tlsv1.1",
+                            "tlsv1"
+                        ],
+                        "description": "All TLS/DTLS versions to be supported.<br>\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIn case PSK cipher suites are intended, make sure to configured\n<code>['tlsv1.2', 'tlsv1.1']</code> here.\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "versions",
+                        "type": "array"
+                    },
+                    "ciphers": {
+                        "default": [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_CHACHA20_POLY1305_SHA256",
+                            "TLS_AES_128_CCM_SHA256",
+                            "TLS_AES_128_CCM_8_SHA256",
+                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                            "ECDHE-RSA-AES256-GCM-SHA384",
+                            "ECDHE-ECDSA-AES256-SHA384",
+                            "ECDHE-RSA-AES256-SHA384",
+                            "ECDH-ECDSA-AES256-GCM-SHA384",
+                            "ECDH-RSA-AES256-GCM-SHA384",
+                            "ECDH-ECDSA-AES256-SHA384",
+                            "ECDH-RSA-AES256-SHA384",
+                            "DHE-DSS-AES256-GCM-SHA384",
+                            "DHE-DSS-AES256-SHA256",
+                            "AES256-GCM-SHA384",
+                            "AES256-SHA256",
+                            "ECDHE-ECDSA-AES128-GCM-SHA256",
+                            "ECDHE-RSA-AES128-GCM-SHA256",
+                            "ECDHE-ECDSA-AES128-SHA256",
+                            "ECDHE-RSA-AES128-SHA256",
+                            "ECDH-ECDSA-AES128-GCM-SHA256",
+                            "ECDH-RSA-AES128-GCM-SHA256",
+                            "ECDH-ECDSA-AES128-SHA256",
+                            "ECDH-RSA-AES128-SHA256",
+                            "DHE-DSS-AES128-GCM-SHA256",
+                            "DHE-DSS-AES128-SHA256",
+                            "AES128-GCM-SHA256",
+                            "AES128-SHA256",
+                            "ECDHE-ECDSA-AES256-SHA",
+                            "ECDHE-RSA-AES256-SHA",
+                            "DHE-DSS-AES256-SHA",
+                            "ECDH-ECDSA-AES256-SHA",
+                            "ECDH-RSA-AES256-SHA",
+                            "ECDHE-ECDSA-AES128-SHA",
+                            "ECDHE-RSA-AES128-SHA",
+                            "DHE-DSS-AES128-SHA",
+                            "ECDH-ECDSA-AES128-SHA",
+                            "ECDH-RSA-AES128-SHA",
+                            "RSA-PSK-AES256-GCM-SHA384",
+                            "RSA-PSK-AES256-CBC-SHA384",
+                            "RSA-PSK-AES128-GCM-SHA256",
+                            "RSA-PSK-AES128-CBC-SHA256",
+                            "RSA-PSK-AES256-CBC-SHA",
+                            "RSA-PSK-AES128-CBC-SHA"
+                        ],
+                        "description": "This config holds TLS cipher suite names separated by comma,\nor as an array of strings. e.g.\n<code>\"TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256\"</code> or\n<code>[\"TLS_AES_256_GCM_SHA384\",\"TLS_AES_128_GCM_SHA256\"]</code>.\n<br>\nCiphers (and their ordering) define the way in which the\nclient and server encrypts information over the network connection.\nSelecting a good cipher suite is critical for the\napplication's data security, confidentiality and performance.\n\nThe names should be in OpenSSL string format (not RFC format).\nAll default values and examples provided by EMQX config\ndocumentation are all in OpenSSL format.<br>\n\nNOTE: Certain cipher suites are only compatible with\nspecific TLS <code>versions</code> ('tlsv1.1', 'tlsv1.2' or 'tlsv1.3')\nincompatible cipher suites will be silently dropped.\nFor instance, if only 'tlsv1.3' is given in the <code>versions</code>,\nconfiguring cipher suites for other versions will have no effect.\n<br>\n\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIf PSK cipher suites are intended, 'tlsv1.3' should be disabled from <code>versions</code>.<br>\nPSK cipher suites: <code>\"RSA-PSK-AES256-GCM-SHA384,RSA-PSK-AES256-CBC-SHA384,\nRSA-PSK-AES128-GCM-SHA256,RSA-PSK-AES128-CBC-SHA256,\nRSA-PSK-AES256-CBC-SHA,RSA-PSK-AES128-CBC-SHA,\nRSA-PSK-DES-CBC3-SHA,RSA-PSK-RC4-SHA\"</code><br>\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "ciphers",
+                        "type": "array"
+                    },
+                    "user_lookup_fun": {
+                        "default": "emqx_tls_psk:lookup",
+                        "description": "TODO(Rquired description): user_lookup_fun",
+                        "label": "user_lookup_fun",
+                        "type": "string"
+                    },
+                    "secure_renegotiate": {
+                        "default": true,
+                        "description": "\nSSL parameter renegotiation is a feature that allows a client and a server\nto renegotiate the parameters of the SSL connection on the fly.\nRFC 5746 defines a more secure way of doing this. By enabling secure renegotiation,\nyou drop support for the insecure renegotiation, prone to MitM attacks.\n",
+                        "label": "secure_renegotiate",
+                        "type": "boolean"
+                    },
+                    "server_name_indication": {
+                        "description": "Specify the host name to be used in TLS Server Name Indication extension.<br>\nFor instance, when connecting to \"server.example.net\", the genuine server\nwhich accepts the connection and performs TLS handshake may differ from the\nhost the TLS client initially connects to, e.g. when connecting to an IP address\nor when the host has multiple resolvable DNS records <br>\nIf not specified, it will default to the host name string which is used\nto establish the connection, unless it is IP addressed used.<br>\nThe host name is then also used in the host name verification of the peer\ncertificate.<br> The special value 'disable' prevents the Server Name\nIndication extension from being sent and disables the hostname\nverification check.",
+                        "label": "server_name_indication",
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "symbols": [
+                                    "disable"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_etcd": {
+                "properties": {
+                    "server": {
+                        "description": "TODO(Rquired description): server",
+                        "label": "server",
+                        "type": "comma_separated_string"
+                    },
+                    "prefix": {
+                        "default": "emqxcl",
+                        "description": "TODO(Rquired description): prefix",
+                        "label": "prefix",
+                        "type": "string"
+                    },
+                    "node_ttl": {
+                        "default": "1m",
+                        "description": "TODO(Rquired description): node_ttl",
+                        "label": "node_ttl",
+                        "type": "duration"
+                    },
+                    "ssl": {
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.flapping_detect": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_count": {
+                        "default": 15,
+                        "description": "TODO(Rquired description): max_count",
+                        "label": "max_count",
+                        "type": "number"
+                    },
+                    "window_time": {
+                        "default": "1m",
+                        "description": "TODO(Rquired description): window_time",
+                        "label": "window_time",
+                        "type": "duration"
+                    },
+                    "ban_time": {
+                        "default": "5m",
+                        "description": "TODO(Rquired description): ban_time",
+                        "label": "ban_time",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.tcp_opts": {
+                "properties": {
+                    "active_n": {
+                        "default": 100,
+                        "description": "TODO(Rquired description): active_n",
+                        "label": "active_n",
+                        "type": "number"
+                    },
+                    "backlog": {
+                        "default": 1024,
+                        "description": "TODO(Rquired description): backlog",
+                        "label": "backlog",
+                        "type": "number"
+                    },
+                    "send_timeout": {
+                        "default": "15s",
+                        "description": "TODO(Rquired description): send_timeout",
+                        "label": "send_timeout",
+                        "type": "duration"
+                    },
+                    "send_timeout_close": {
+                        "default": true,
+                        "description": "TODO(Rquired description): send_timeout_close",
+                        "label": "send_timeout_close",
+                        "type": "boolean"
+                    },
+                    "recbuf": {
+                        "description": "TODO(Rquired description): recbuf",
+                        "label": "recbuf",
+                        "type": "byteSize"
+                    },
+                    "sndbuf": {
+                        "description": "TODO(Rquired description): sndbuf",
+                        "label": "sndbuf",
+                        "type": "byteSize"
+                    },
+                    "buffer": {
+                        "description": "TODO(Rquired description): buffer",
+                        "label": "buffer",
+                        "type": "byteSize"
+                    },
+                    "high_watermark": {
+                        "default": "1MB",
+                        "description": "TODO(Rquired description): high_watermark",
+                        "label": "high_watermark",
+                        "type": "byteSize"
+                    },
+                    "nodelay": {
+                        "default": false,
+                        "description": "TODO(Rquired description): nodelay",
+                        "label": "nodelay",
+                        "type": "boolean"
+                    },
+                    "reuseaddr": {
+                        "default": true,
+                        "description": "TODO(Rquired description): reuseaddr",
+                        "label": "reuseaddr",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt_wss_listener": {
+                "required": [
+                    "bind"
+                ],
+                "properties": {
+                    "tcp": {
+                        "description": "TODO(Rquired description): tcp",
+                        "label": "tcp",
+                        "$ref": "#/components/schemas/emqx_schema.tcp_opts"
+                    },
+                    "ssl": {
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.listener_wss_opts"
+                    },
+                    "websocket": {
+                        "description": "TODO(Rquired description): websocket",
+                        "label": "websocket",
+                        "$ref": "#/components/schemas/emqx_schema.ws_opts"
+                    },
+                    "bind": {
+                        "description": "TODO(Rquired description): bind",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "ip_port"
+                            }
+                        ]
+                    },
+                    "acceptors": {
+                        "default": 16,
+                        "description": "TODO(Rquired description): acceptors",
+                        "label": "acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "mountpoint": {
+                        "default": "",
+                        "description": "TODO(Rquired description): mountpoint",
+                        "label": "mountpoint",
+                        "type": "string"
+                    },
+                    "zone": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "limiter": {
+                        "default": {},
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "properties": {
+                            "$ratelimit bucket's name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "access_rules": {
+                        "description": "TODO(Rquired description): access_rules",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "access_rules",
+                        "type": "array"
+                    },
+                    "proxy_protocol": {
+                        "default": false,
+                        "description": "TODO(Rquired description): proxy_protocol",
+                        "label": "proxy_protocol",
+                        "type": "boolean"
+                    },
+                    "proxy_protocol_timeout": {
+                        "description": "TODO(Rquired description): proxy_protocol_timeout",
+                        "label": "proxy_protocol_timeout",
+                        "type": "duration"
+                    },
+                    "authentication": {
+                        "description": "Per-listener authentication override\nAuthentication can be one single authenticator instance or a chain of authenticators as an array.\nWhen authenticating a login (username, client ID, etc.) the authenticators are checked\nin the configured order.<br>\n",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/authn-scram-builtin_db.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.jwks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.public-key"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.hmac-based"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.post"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.get"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.sentinel"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.sharded-cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.replica-set"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-postgresql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mysql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-builtin_db.authentication"
+                                }
+                            ]
+                        },
+                        "label": "authentication",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.persistent_session_store": {
+                "properties": {
+                    "enabled": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enabled",
+                        "label": "enabled",
+                        "type": "boolean"
+                    },
+                    "storage_type": {
+                        "default": "disc",
+                        "description": "TODO(Rquired description): storage_type",
+                        "label": "storage_type",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disc"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "symbols": [
+                                    "ram"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "max_retain_undelivered": {
+                        "default": "1h",
+                        "description": "TODO(Rquired description): max_retain_undelivered",
+                        "label": "max_retain_undelivered",
+                        "type": "duration"
+                    },
+                    "message_gc_interval": {
+                        "default": "1h",
+                        "description": "TODO(Rquired description): message_gc_interval",
+                        "label": "message_gc_interval",
+                        "type": "duration"
+                    },
+                    "session_message_gc_interval": {
+                        "default": "1m",
+                        "description": "TODO(Rquired description): session_message_gc_interval",
+                        "label": "session_message_gc_interval",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "auto_subscribe.auto_subscribe": {
+                "properties": {
+                    "topics": {
+                        "description": "TODO(Rquired description): topics",
+                        "items": {
+                            "$ref": "#/components/schemas/auto_subscribe.topic"
+                        },
+                        "label": "topics",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "connector-http.request": {
+                "properties": {
+                    "method": {
+                        "description": "TODO(Rquired description): method",
+                        "label": "method",
+                        "symbols": [
+                            "post",
+                            "put",
+                            "get",
+                            "delete"
+                        ],
+                        "type": "enum"
+                    },
+                    "path": {
+                        "description": "TODO(Rquired description): path",
+                        "label": "path",
+                        "type": "string"
+                    },
+                    "body": {
+                        "description": "TODO(Rquired description): body",
+                        "label": "body",
+                        "type": "string"
+                    },
+                    "headers": {
+                        "description": "TODO(Rquired description): headers",
+                        "label": "headers",
+                        "type": "string"
+                    },
+                    "request_timeout": {
+                        "description": "The timeout when sending request to the HTTP server",
+                        "label": "request_timeout",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.overload_protection": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "React on system overload or not",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "backoff_delay": {
+                        "default": 1,
+                        "description": "Some unimportant tasks could be delayed for execution, here set the delays in ms",
+                        "label": "backoff_delay",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "backoff_gc": {
+                        "default": false,
+                        "description": "Skip forceful GC if necessary",
+                        "label": "backoff_gc",
+                        "type": "boolean"
+                    },
+                    "backoff_hibernation": {
+                        "default": true,
+                        "description": "Skip process hibernation if necessary",
+                        "label": "backoff_hibernation",
+                        "type": "boolean"
+                    },
+                    "backoff_new_conn": {
+                        "default": true,
+                        "description": "Close new incoming connections if necessary",
+                        "label": "backoff_new_conn",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.zone": {
+                "properties": {
+                    "mqtt": {
+                        "description": "TODO(Rquired description): mqtt",
+                        "label": "mqtt",
+                        "$ref": "#/components/schemas/zone.mqtt"
+                    },
+                    "stats": {
+                        "description": "TODO(Rquired description): stats",
+                        "label": "stats",
+                        "$ref": "#/components/schemas/zone.stats"
+                    },
+                    "flapping_detect": {
+                        "description": "TODO(Rquired description): flapping_detect",
+                        "label": "flapping_detect",
+                        "$ref": "#/components/schemas/zone.flapping_detect"
+                    },
+                    "force_shutdown": {
+                        "description": "TODO(Rquired description): force_shutdown",
+                        "label": "force_shutdown",
+                        "$ref": "#/components/schemas/zone.force_shutdown"
+                    },
+                    "conn_congestion": {
+                        "description": "TODO(Rquired description): conn_congestion",
+                        "label": "conn_congestion",
+                        "$ref": "#/components/schemas/zone.conn_congestion"
+                    },
+                    "force_gc": {
+                        "description": "TODO(Rquired description): force_gc",
+                        "label": "force_gc",
+                        "$ref": "#/components/schemas/zone.force_gc"
+                    },
+                    "overload_protection": {
+                        "description": "TODO(Rquired description): overload_protection",
+                        "label": "overload_protection",
+                        "$ref": "#/components/schemas/zone.overload_protection"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.listener_ssl_opts": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "cacertfile": {
+                        "description": "Trusted PEM format CA certificates bundle file.<br>\nThe certificates in this file are used to verify the TLS peer's certificates.\nAppend new certificates to the file if new CAs are to be trusted.\nThere is no need to restart EMQX to have the updated file loaded, because\nthe system regularly checks if file has been updated (and reload).<br>\nNOTE: invalidating (deleting) a certificate from the file will not affect\nalready established connections.\n",
+                        "label": "cacertfile",
+                        "type": "string"
+                    },
+                    "certfile": {
+                        "description": "PEM format certificates chain file.<br>\nThe certificates in this file should be in reversed order of the certificate\nissue chain. That is, the host's certificate should be placed in the beginning\nof the file, followed by the immediate issuer certificate and so on.\nAlthough the root CA certificate is optional, it should be placed at the end of\nthe file if it is to be added.\n",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "PEM format private key file.<br>\n",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "verify": {
+                        "default": "verify_none",
+                        "description": "TODO(Rquired description): verify",
+                        "label": "verify",
+                        "symbols": [
+                            "verify_peer",
+                            "verify_none"
+                        ],
+                        "type": "enum"
+                    },
+                    "reuse_sessions": {
+                        "default": true,
+                        "description": "TODO(Rquired description): reuse_sessions",
+                        "label": "reuse_sessions",
+                        "type": "boolean"
+                    },
+                    "depth": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): depth",
+                        "label": "depth",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "String containing the user's password. Only used if the private\nkey file is password-protected.",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "versions": {
+                        "default": [
+                            "tlsv1.3",
+                            "tlsv1.2",
+                            "tlsv1.1",
+                            "tlsv1"
+                        ],
+                        "description": "All TLS/DTLS versions to be supported.<br>\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIn case PSK cipher suites are intended, make sure to configured\n<code>['tlsv1.2', 'tlsv1.1']</code> here.\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "versions",
+                        "type": "array"
+                    },
+                    "ciphers": {
+                        "default": [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_CHACHA20_POLY1305_SHA256",
+                            "TLS_AES_128_CCM_SHA256",
+                            "TLS_AES_128_CCM_8_SHA256",
+                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                            "ECDHE-RSA-AES256-GCM-SHA384",
+                            "ECDHE-ECDSA-AES256-SHA384",
+                            "ECDHE-RSA-AES256-SHA384",
+                            "ECDH-ECDSA-AES256-GCM-SHA384",
+                            "ECDH-RSA-AES256-GCM-SHA384",
+                            "ECDH-ECDSA-AES256-SHA384",
+                            "ECDH-RSA-AES256-SHA384",
+                            "DHE-DSS-AES256-GCM-SHA384",
+                            "DHE-DSS-AES256-SHA256",
+                            "AES256-GCM-SHA384",
+                            "AES256-SHA256",
+                            "ECDHE-ECDSA-AES128-GCM-SHA256",
+                            "ECDHE-RSA-AES128-GCM-SHA256",
+                            "ECDHE-ECDSA-AES128-SHA256",
+                            "ECDHE-RSA-AES128-SHA256",
+                            "ECDH-ECDSA-AES128-GCM-SHA256",
+                            "ECDH-RSA-AES128-GCM-SHA256",
+                            "ECDH-ECDSA-AES128-SHA256",
+                            "ECDH-RSA-AES128-SHA256",
+                            "DHE-DSS-AES128-GCM-SHA256",
+                            "DHE-DSS-AES128-SHA256",
+                            "AES128-GCM-SHA256",
+                            "AES128-SHA256",
+                            "ECDHE-ECDSA-AES256-SHA",
+                            "ECDHE-RSA-AES256-SHA",
+                            "DHE-DSS-AES256-SHA",
+                            "ECDH-ECDSA-AES256-SHA",
+                            "ECDH-RSA-AES256-SHA",
+                            "ECDHE-ECDSA-AES128-SHA",
+                            "ECDHE-RSA-AES128-SHA",
+                            "DHE-DSS-AES128-SHA",
+                            "ECDH-ECDSA-AES128-SHA",
+                            "ECDH-RSA-AES128-SHA",
+                            "RSA-PSK-AES256-GCM-SHA384",
+                            "RSA-PSK-AES256-CBC-SHA384",
+                            "RSA-PSK-AES128-GCM-SHA256",
+                            "RSA-PSK-AES128-CBC-SHA256",
+                            "RSA-PSK-AES256-CBC-SHA",
+                            "RSA-PSK-AES128-CBC-SHA"
+                        ],
+                        "description": "This config holds TLS cipher suite names separated by comma,\nor as an array of strings. e.g.\n<code>\"TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256\"</code> or\n<code>[\"TLS_AES_256_GCM_SHA384\",\"TLS_AES_128_GCM_SHA256\"]</code>.\n<br>\nCiphers (and their ordering) define the way in which the\nclient and server encrypts information over the network connection.\nSelecting a good cipher suite is critical for the\napplication's data security, confidentiality and performance.\n\nThe names should be in OpenSSL string format (not RFC format).\nAll default values and examples provided by EMQX config\ndocumentation are all in OpenSSL format.<br>\n\nNOTE: Certain cipher suites are only compatible with\nspecific TLS <code>versions</code> ('tlsv1.1', 'tlsv1.2' or 'tlsv1.3')\nincompatible cipher suites will be silently dropped.\nFor instance, if only 'tlsv1.3' is given in the <code>versions</code>,\nconfiguring cipher suites for other versions will have no effect.\n<br>\n\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIf PSK cipher suites are intended, 'tlsv1.3' should be disabled from <code>versions</code>.<br>\nPSK cipher suites: <code>\"RSA-PSK-AES256-GCM-SHA384,RSA-PSK-AES256-CBC-SHA384,\nRSA-PSK-AES128-GCM-SHA256,RSA-PSK-AES128-CBC-SHA256,\nRSA-PSK-AES256-CBC-SHA,RSA-PSK-AES128-CBC-SHA,\nRSA-PSK-DES-CBC3-SHA,RSA-PSK-RC4-SHA\"</code><br>\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "ciphers",
+                        "type": "array"
+                    },
+                    "user_lookup_fun": {
+                        "default": "emqx_tls_psk:lookup",
+                        "description": "TODO(Rquired description): user_lookup_fun",
+                        "label": "user_lookup_fun",
+                        "type": "string"
+                    },
+                    "secure_renegotiate": {
+                        "default": true,
+                        "description": "\nSSL parameter renegotiation is a feature that allows a client and a server\nto renegotiate the parameters of the SSL connection on the fly.\nRFC 5746 defines a more secure way of doing this. By enabling secure renegotiation,\nyou drop support for the insecure renegotiation, prone to MitM attacks.\n",
+                        "label": "secure_renegotiate",
+                        "type": "boolean"
+                    },
+                    "dhfile": {
+                        "description": "Path to a file containing PEM-encoded Diffie Hellman parameters\nto be used by the server if a cipher suite using Diffie Hellman\nkey exchange is negotiated. If not specified, default parameters\nare used.<br>\nNOTE: The <code>dhfile</code> option is not supported by TLS 1.3.",
+                        "label": "dhfile",
+                        "type": "string"
+                    },
+                    "fail_if_no_peer_cert": {
+                        "default": false,
+                        "description": "\nUsed together with {verify, verify_peer} by an TLS/DTLS server.\nIf set to true, the server fails if the client does not have a\ncertificate to send, that is, sends an empty certificate.\nIf set to false, it fails only if the client sends an invalid\ncertificate (an empty certificate is considered valid).\n",
+                        "label": "fail_if_no_peer_cert",
+                        "type": "boolean"
+                    },
+                    "honor_cipher_order": {
+                        "default": true,
+                        "description": "TODO(Rquired description): honor_cipher_order",
+                        "label": "honor_cipher_order",
+                        "type": "boolean"
+                    },
+                    "client_renegotiation": {
+                        "default": true,
+                        "description": "\nIn protocols that support client-initiated renegotiation,\nthe cost of resources of such an operation is higher for the server than the client.\nThis can act as a vector for denial of service attacks.\nThe SSL application already takes measures to counter-act such attempts,\nbut client-initiated renegotiation can be strictly disabled by setting this option to false.\nThe default value is true. Note that disabling renegotiation can result in\nlong-lived connections becoming unusable due to limits on\nthe number of messages the underlying cipher suite can encipher.\n",
+                        "label": "client_renegotiation",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.trace": {
+                "properties": {
+                    "payload_encode": {
+                        "default": "text",
+                        "description": "\nDetermine the format of the payload format in the trace file.<br>\n`text`: Text-based protocol or plain text protocol. It is recommended when payload is JSON encoded.<br>\n`hex`: Binary hexadecimal encode. It is recommended when payload is a custom binary protocol.<br>\n`hidden`: payload is obfuscated as `******`\n        ",
+                        "label": "payload_encode",
+                        "symbols": [
+                            "hex",
+                            "text",
+                            "hidden"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.deflate_opts": {
+                "properties": {
+                    "level": {
+                        "description": "TODO(Rquired description): level",
+                        "label": "level",
+                        "symbols": [
+                            "none",
+                            "default",
+                            "best_compression",
+                            "best_speed"
+                        ],
+                        "type": "enum"
+                    },
+                    "mem_level": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): mem_level",
+                        "label": "mem_level",
+                        "maximum": 9,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "strategy": {
+                        "description": "TODO(Rquired description): strategy",
+                        "label": "strategy",
+                        "symbols": [
+                            "default",
+                            "filtered",
+                            "huffman_only",
+                            "rle"
+                        ],
+                        "type": "enum"
+                    },
+                    "server_context_takeover": {
+                        "description": "TODO(Rquired description): server_context_takeover",
+                        "label": "server_context_takeover",
+                        "symbols": [
+                            "takeover",
+                            "no_takeover"
+                        ],
+                        "type": "enum"
+                    },
+                    "client_context_takeover": {
+                        "description": "TODO(Rquired description): client_context_takeover",
+                        "label": "client_context_takeover",
+                        "symbols": [
+                            "takeover",
+                            "no_takeover"
+                        ],
+                        "type": "enum"
+                    },
+                    "server_max_window_bits": {
+                        "default": 15,
+                        "description": "TODO(Rquired description): server_max_window_bits",
+                        "label": "server_max_window_bits",
+                        "maximum": 15,
+                        "minimum": 8,
+                        "type": "number"
+                    },
+                    "client_max_window_bits": {
+                        "default": 15,
+                        "description": "TODO(Rquired description): client_max_window_bits",
+                        "label": "client_max_window_bits",
+                        "maximum": 15,
+                        "minimum": 8,
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.log_burst_limit": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_count": {
+                        "default": 10000,
+                        "description": "TODO(Rquired description): max_count",
+                        "label": "max_count",
+                        "type": "number"
+                    },
+                    "window_time": {
+                        "default": "1s",
+                        "description": "TODO(Rquired description): window_time",
+                        "label": "window_time",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.sysmon_os": {
+                "properties": {
+                    "cpu_check_interval": {
+                        "default": "60s",
+                        "description": "TODO(Rquired description): cpu_check_interval",
+                        "label": "cpu_check_interval",
+                        "type": "duration"
+                    },
+                    "cpu_high_watermark": {
+                        "default": "80%",
+                        "description": "TODO(Rquired description): cpu_high_watermark",
+                        "label": "cpu_high_watermark",
+                        "type": "percent"
+                    },
+                    "cpu_low_watermark": {
+                        "default": "60%",
+                        "description": "TODO(Rquired description): cpu_low_watermark",
+                        "label": "cpu_low_watermark",
+                        "type": "percent"
+                    },
+                    "mem_check_interval": {
+                        "default": "60s",
+                        "description": "TODO(Rquired description): mem_check_interval",
+                        "label": "mem_check_interval",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "sysmem_high_watermark": {
+                        "default": "70%",
+                        "description": "TODO(Rquired description): sysmem_high_watermark",
+                        "label": "sysmem_high_watermark",
+                        "type": "percent"
+                    },
+                    "procmem_high_watermark": {
+                        "default": "5%",
+                        "description": "TODO(Rquired description): procmem_high_watermark",
+                        "label": "procmem_high_watermark",
+                        "type": "percent"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_k8s": {
+                "properties": {
+                    "apiserver": {
+                        "description": "TODO(Rquired description): apiserver",
+                        "label": "apiserver",
+                        "type": "string"
+                    },
+                    "service_name": {
+                        "default": "emqx",
+                        "description": "TODO(Rquired description): service_name",
+                        "label": "service_name",
+                        "type": "string"
+                    },
+                    "address_type": {
+                        "description": "TODO(Rquired description): address_type",
+                        "label": "address_type",
+                        "symbols": [
+                            "ip",
+                            "dns",
+                            "hostname"
+                        ],
+                        "type": "enum"
+                    },
+                    "app_name": {
+                        "default": "emqx",
+                        "description": "TODO(Rquired description): app_name",
+                        "label": "app_name",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): namespace",
+                        "label": "namespace",
+                        "type": "string"
+                    },
+                    "suffix": {
+                        "default": "pod.local",
+                        "description": "TODO(Rquired description): suffix",
+                        "label": "suffix",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "statsd.statsd": {
+                "required": [
+                    "flush_time_interval",
+                    "sample_time_interval",
+                    "server",
+                    "enable"
+                ],
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "server": {
+                        "default": "127.0.0.1:8125",
+                        "description": "TODO(Rquired description): server",
+                        "label": "server",
+                        "type": "ip_port"
+                    },
+                    "sample_time_interval": {
+                        "default": "10s",
+                        "description": "TODO(Rquired description): sample_time_interval",
+                        "label": "sample_time_interval",
+                        "type": "duration"
+                    },
+                    "flush_time_interval": {
+                        "default": "10s",
+                        "description": "TODO(Rquired description): flush_time_interval",
+                        "label": "flush_time_interval",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt_ssl_listener": {
+                "required": [
+                    "bind"
+                ],
+                "properties": {
+                    "tcp": {
+                        "description": "TODO(Rquired description): tcp",
+                        "label": "tcp",
+                        "$ref": "#/components/schemas/emqx_schema.tcp_opts"
+                    },
+                    "ssl": {
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.listener_ssl_opts"
+                    },
+                    "bind": {
+                        "description": "TODO(Rquired description): bind",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "ip_port"
+                            }
+                        ]
+                    },
+                    "acceptors": {
+                        "default": 16,
+                        "description": "TODO(Rquired description): acceptors",
+                        "label": "acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "mountpoint": {
+                        "default": "",
+                        "description": "TODO(Rquired description): mountpoint",
+                        "label": "mountpoint",
+                        "type": "string"
+                    },
+                    "zone": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "limiter": {
+                        "default": {},
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "properties": {
+                            "$ratelimit bucket's name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "access_rules": {
+                        "description": "TODO(Rquired description): access_rules",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "access_rules",
+                        "type": "array"
+                    },
+                    "proxy_protocol": {
+                        "default": false,
+                        "description": "TODO(Rquired description): proxy_protocol",
+                        "label": "proxy_protocol",
+                        "type": "boolean"
+                    },
+                    "proxy_protocol_timeout": {
+                        "description": "TODO(Rquired description): proxy_protocol_timeout",
+                        "label": "proxy_protocol_timeout",
+                        "type": "duration"
+                    },
+                    "authentication": {
+                        "description": "Per-listener authentication override\nAuthentication can be one single authenticator instance or a chain of authenticators as an array.\nWhen authenticating a login (username, client ID, etc.) the authenticators are checked\nin the configured order.<br>\n",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/authn-scram-builtin_db.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.jwks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.public-key"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.hmac-based"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.post"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.get"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.sentinel"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.sharded-cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.replica-set"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-postgresql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mysql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-builtin_db.authentication"
+                                }
+                            ]
+                        },
+                        "label": "authentication",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "retainer.mnesia_config": {
+                "properties": {
+                    "type": {
+                        "description": "TODO(Rquired description): type",
+                        "label": "type",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "built_in_database"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "storage_type": {
+                        "default": "ram",
+                        "description": "TODO(Rquired description): storage_type",
+                        "label": "storage_type",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disc"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "symbols": [
+                                    "ram"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "max_retained_messages": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): max_retained_messages",
+                        "label": "max_retained_messages",
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.console_handler": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "level": {
+                        "default": "warning",
+                        "description": "Global log level. This includes the primary log level and all log handlers.",
+                        "label": "level",
+                        "symbols": [
+                            "debug",
+                            "info",
+                            "notice",
+                            "warning",
+                            "error",
+                            "critical",
+                            "alert",
+                            "emergency",
+                            "all"
+                        ],
+                        "type": "enum"
+                    },
+                    "time_offset": {
+                        "default": "system",
+                        "description": "TODO(Rquired description): time_offset",
+                        "label": "time_offset",
+                        "type": "string"
+                    },
+                    "chars_limit": {
+                        "default": "unlimited",
+                        "description": "Set the maximum length of a single log message. If this length is exceeded, the log message will be truncated.",
+                        "label": "chars_limit",
+                        "oneOf": [
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "unlimited"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "formatter": {
+                        "default": "text",
+                        "description": "Choose log format. <code>text</code> for free text, and <code>json</code> for structured logging.",
+                        "label": "formatter",
+                        "symbols": [
+                            "text",
+                            "json"
+                        ],
+                        "type": "enum"
+                    },
+                    "single_line": {
+                        "default": true,
+                        "description": "Print logs in a single line if set to true. Otherwise, log messages may span multiple lines.",
+                        "label": "single_line",
+                        "type": "boolean"
+                    },
+                    "sync_mode_qlen": {
+                        "default": 100,
+                        "description": "TODO(Rquired description): sync_mode_qlen",
+                        "label": "sync_mode_qlen",
+                        "type": "number"
+                    },
+                    "drop_mode_qlen": {
+                        "default": 3000,
+                        "description": "TODO(Rquired description): drop_mode_qlen",
+                        "label": "drop_mode_qlen",
+                        "type": "number"
+                    },
+                    "flush_qlen": {
+                        "default": 8000,
+                        "description": "TODO(Rquired description): flush_qlen",
+                        "label": "flush_qlen",
+                        "type": "number"
+                    },
+                    "overload_kill": {
+                        "description": "TODO(Rquired description): overload_kill",
+                        "label": "overload_kill",
+                        "$ref": "#/components/schemas/emqx_conf_schema.log_overload_kill"
+                    },
+                    "burst_limit": {
+                        "description": "TODO(Rquired description): burst_limit",
+                        "label": "burst_limit",
+                        "$ref": "#/components/schemas/emqx_conf_schema.log_burst_limit"
+                    },
+                    "supervisor_reports": {
+                        "default": "error",
+                        "description": "TODO(Rquired description): supervisor_reports",
+                        "label": "supervisor_reports",
+                        "symbols": [
+                            "error",
+                            "progress"
+                        ],
+                        "type": "enum"
+                    },
+                    "max_depth": {
+                        "default": 100,
+                        "description": "Maximum depth for Erlang term log formatting and Erlang process message queue inspection.",
+                        "label": "max_depth",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "unlimited"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt": {
+                "properties": {
+                    "idle_timeout": {
+                        "default": "15s",
+                        "description": "Close TCP connections from the clients that have not sent MQTT CONNECT\nmessage within this interval.",
+                        "label": "idle_timeout",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "max_packet_size": {
+                        "default": "1MB",
+                        "description": "Maximum MQTT packet size allowed.",
+                        "label": "max_packet_size",
+                        "type": "byteSize"
+                    },
+                    "max_clientid_len": {
+                        "default": 65535,
+                        "description": "Maximum allowed length of MQTT clientId.",
+                        "label": "max_clientid_len",
+                        "maximum": 65535,
+                        "minimum": 23,
+                        "type": "number"
+                    },
+                    "max_topic_levels": {
+                        "default": 65535,
+                        "description": "Maximum topic levels allowed.",
+                        "label": "max_topic_levels",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "max_qos_allowed": {
+                        "default": 2,
+                        "description": "Maximum QoS allowed.",
+                        "label": "max_qos_allowed",
+                        "symbols": [
+                            0,
+                            1,
+                            2
+                        ],
+                        "type": "enum"
+                    },
+                    "max_topic_alias": {
+                        "default": 65535,
+                        "description": "Maximum Topic Alias, 0 means no topic alias supported.",
+                        "label": "max_topic_alias",
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "retain_available": {
+                        "default": true,
+                        "description": "Support MQTT retained messages.",
+                        "label": "retain_available",
+                        "type": "boolean"
+                    },
+                    "wildcard_subscription": {
+                        "default": true,
+                        "description": "Support MQTT Wildcard Subscriptions.",
+                        "label": "wildcard_subscription",
+                        "type": "boolean"
+                    },
+                    "shared_subscription": {
+                        "default": true,
+                        "description": "Support MQTT Shared Subscriptions.",
+                        "label": "shared_subscription",
+                        "type": "boolean"
+                    },
+                    "ignore_loop_deliver": {
+                        "default": false,
+                        "description": "Ignore loop delivery of messages for MQTT v3.1.1.",
+                        "label": "ignore_loop_deliver",
+                        "type": "boolean"
+                    },
+                    "strict_mode": {
+                        "default": false,
+                        "description": "Parse the MQTT frame in strict mode.",
+                        "label": "strict_mode",
+                        "type": "boolean"
+                    },
+                    "response_information": {
+                        "default": "",
+                        "description": "Specify the response information returned to the client\nThis feature is disabled if is set to \"\".",
+                        "label": "response_information",
+                        "type": "string"
+                    },
+                    "server_keepalive": {
+                        "default": "disabled",
+                        "description": "'Server Keep Alive' of MQTT 5.0.\nIf the server returns a 'Server Keep Alive' in the CONNACK packet,\nthe client MUST use that value instead of the value it sent as the 'Keep Alive'.",
+                        "label": "server_keepalive",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "keepalive_backoff": {
+                        "default": 0.75,
+                        "description": "The backoff for MQTT keepalive timeout. The broker will close the connection\nafter idling for 'Keepalive * backoff * 2'.",
+                        "label": "keepalive_backoff",
+                        "type": "number"
+                    },
+                    "max_subscriptions": {
+                        "default": "infinity",
+                        "description": "Maximum number of subscriptions allowed.",
+                        "label": "max_subscriptions",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "upgrade_qos": {
+                        "default": false,
+                        "description": "Force upgrade of QoS level according to subscription.",
+                        "label": "upgrade_qos",
+                        "type": "boolean"
+                    },
+                    "max_inflight": {
+                        "default": 32,
+                        "description": "Maximum size of the Inflight Window storing QoS1/2 messages delivered but un-acked.",
+                        "label": "max_inflight",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "retry_interval": {
+                        "default": "30s",
+                        "description": "Retry interval for QoS1/2 message delivering.",
+                        "label": "retry_interval",
+                        "type": "duration"
+                    },
+                    "max_awaiting_rel": {
+                        "default": 100,
+                        "description": "Maximum QoS2 packets (Client -> Broker) awaiting PUBREL.",
+                        "label": "max_awaiting_rel",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "await_rel_timeout": {
+                        "default": "300s",
+                        "description": "The QoS2 messages (Client -> Broker) will be dropped if awaiting PUBREL timeout.",
+                        "label": "await_rel_timeout",
+                        "type": "duration"
+                    },
+                    "session_expiry_interval": {
+                        "default": "2h",
+                        "description": "Default session expiry interval for MQTT V3.1.1 connections.",
+                        "label": "session_expiry_interval",
+                        "type": "duration"
+                    },
+                    "max_mqueue_len": {
+                        "default": 1000,
+                        "description": "Maximum queue length. Enqueued messages when persistent client disconnected,\nor inflight window is full.",
+                        "label": "max_mqueue_len",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "minimum": 0,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "mqueue_priorities": {
+                        "default": "disabled",
+                        "description": "Topic priorities.<br>\nThere's no priority table by default, hence all messages are treated equal.<br>\nPriority number [1-255]<br>\n\n**NOTE**: Comma and equal signs are not allowed for priority topic names.<br>\n**NOTE**: Messages for topics not in the priority table are treated as\neither highest or lowest priority depending on the configured value for\n<code>mqtt.mqueue_default_priority</code>.\n<br><br>\n**Examples**:\nTo configure <code>\"topic/1\" > \"topic/2\"</code>:<br/>\n<code>mqueue_priorities: {\"topic/1\": 10, \"topic/2\": 8}</code>",
+                        "label": "mqueue_priorities",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "mqueue_default_priority": {
+                        "default": "lowest",
+                        "description": "Default to the highest priority for topics not matching priority table.",
+                        "label": "mqueue_default_priority",
+                        "symbols": [
+                            "highest",
+                            "lowest"
+                        ],
+                        "type": "enum"
+                    },
+                    "mqueue_store_qos0": {
+                        "default": true,
+                        "description": "Support enqueue QoS0 messages.",
+                        "label": "mqueue_store_qos0",
+                        "type": "boolean"
+                    },
+                    "use_username_as_clientid": {
+                        "default": false,
+                        "description": "Replace client ID with the username.",
+                        "label": "use_username_as_clientid",
+                        "type": "boolean"
+                    },
+                    "peer_cert_as_username": {
+                        "default": "disabled",
+                        "description": "Use the CN, DN or CRT field from the client certificate as a username.\nOnly works for the TLS connection.",
+                        "label": "peer_cert_as_username",
+                        "symbols": [
+                            "disabled",
+                            "cn",
+                            "dn",
+                            "crt",
+                            "pem",
+                            "md5"
+                        ],
+                        "type": "enum"
+                    },
+                    "peer_cert_as_clientid": {
+                        "default": "disabled",
+                        "description": "Use the CN, DN or CRT field from the client certificate as a clientid.\nOnly works for the TLS connection.",
+                        "label": "peer_cert_as_clientid",
+                        "symbols": [
+                            "disabled",
+                            "cn",
+                            "dn",
+                            "crt",
+                            "pem",
+                            "md5"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "limiter.rate_burst": {
+                "properties": {
+                    "rate": {
+                        "description": "TODO(Rquired description): rate",
+                        "label": "rate",
+                        "type": "string"
+                    },
+                    "burst": {
+                        "default": "0/0s",
+                        "description": "TODO(Rquired description): burst",
+                        "label": "burst",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-hash.bcrypt_rw": {
+                "properties": {
+                    "name": {
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "symbols": [
+                            "bcrypt"
+                        ],
+                        "type": "enum"
+                    },
+                    "salt_rounds": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): salt_rounds",
+                        "label": "salt_rounds",
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-http.post": {
+                "required": [
+                    "url",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "method": {
+                        "default": "post",
+                        "description": "TODO(Rquired description): method",
+                        "label": "method",
+                        "symbols": [
+                            "post"
+                        ],
+                        "type": "enum"
+                    },
+                    "headers": {
+                        "default": {
+                            "accept": "application/json",
+                            "cache-control": "no-cache",
+                            "connection": "keep-alive",
+                            "content-type": "application/json",
+                            "keep-alive": "timeout=30, max=1000"
+                        },
+                        "description": "TODO(Rquired description): headers",
+                        "label": "headers",
+                        "type": "string"
+                    },
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "http"
+                        ],
+                        "type": "enum"
+                    },
+                    "url": {
+                        "description": "TODO(Rquired description): url",
+                        "label": "url",
+                        "type": "string"
+                    },
+                    "body": {
+                        "description": "TODO(Rquired description): body",
+                        "label": "body",
+                        "type": "string"
+                    },
+                    "request_timeout": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): request_timeout",
+                        "label": "request_timeout",
+                        "type": "duration"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "connect_timeout": {
+                        "default": "15s",
+                        "description": "The timeout when connecting to the HTTP server",
+                        "label": "connect_timeout",
+                        "type": "duration"
+                    },
+                    "enable_pipelining": {
+                        "default": true,
+                        "description": "Enable the HTTP pipeline",
+                        "label": "enable_pipelining",
+                        "type": "boolean"
+                    },
+                    "max_retries": {
+                        "default": 5,
+                        "description": "Max retry times if error on sending request",
+                        "label": "max_retries",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "The pool size",
+                        "label": "pool_size",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "request": {
+                        "description": "\nIf the request is provided, the caller can send HTTP requests via\n<code>emqx_resource:query(ResourceId, {send_message, BridgeId, Message})</code>\n",
+                        "label": "request",
+                        "$ref": "#/components/schemas/connector-http.request"
+                    },
+                    "retry_interval": {
+                        "default": "1s",
+                        "description": "Interval before next retry if error on sending request",
+                        "label": "retry_interval",
+                        "type": "duration"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.sysmon_vm": {
+                "properties": {
+                    "process_check_interval": {
+                        "default": "30s",
+                        "description": "TODO(Rquired description): process_check_interval",
+                        "label": "process_check_interval",
+                        "type": "duration"
+                    },
+                    "process_high_watermark": {
+                        "default": "80%",
+                        "description": "TODO(Rquired description): process_high_watermark",
+                        "label": "process_high_watermark",
+                        "type": "percent"
+                    },
+                    "process_low_watermark": {
+                        "default": "60%",
+                        "description": "TODO(Rquired description): process_low_watermark",
+                        "label": "process_low_watermark",
+                        "type": "percent"
+                    },
+                    "long_gc": {
+                        "description": "TODO(Rquired description): long_gc",
+                        "label": "long_gc",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "long_schedule": {
+                        "default": "240ms",
+                        "description": "TODO(Rquired description): long_schedule",
+                        "label": "long_schedule",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "large_heap": {
+                        "default": "32MB",
+                        "description": "TODO(Rquired description): large_heap",
+                        "label": "large_heap",
+                        "oneOf": [
+                            {
+                                "type": "byteSize"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "busy_dist_port": {
+                        "default": true,
+                        "description": "TODO(Rquired description): busy_dist_port",
+                        "label": "busy_dist_port",
+                        "type": "boolean"
+                    },
+                    "busy_port": {
+                        "default": true,
+                        "description": "TODO(Rquired description): busy_port",
+                        "label": "busy_port",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.force_gc": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "count": {
+                        "description": "GC the process after this many received messages.",
+                        "label": "count",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "bytes": {
+                        "description": "GC the process after specified number of bytes have passed through.",
+                        "label": "bytes",
+                        "type": "byteSize"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_dns": {
+                "properties": {
+                    "name": {
+                        "default": "localhost",
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "type": "string"
+                    },
+                    "app": {
+                        "default": "emqx",
+                        "description": "TODO(Rquired description): app",
+                        "label": "app",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "modules.delayed": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_delayed_messages": {
+                        "description": "TODO(Rquired description): max_delayed_messages",
+                        "label": "max_delayed_messages",
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_connector_mongo.topology": {
+                "properties": {
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "max_overflow": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): max_overflow",
+                        "label": "max_overflow",
+                        "type": "number"
+                    },
+                    "overflow_ttl": {
+                        "description": "TODO(Rquired description): overflow_ttl",
+                        "label": "overflow_ttl",
+                        "type": "duration"
+                    },
+                    "overflow_check_period": {
+                        "description": "TODO(Rquired description): overflow_check_period",
+                        "label": "overflow_check_period",
+                        "type": "duration"
+                    },
+                    "local_threshold_ms": {
+                        "description": "TODO(Rquired description): local_threshold_ms",
+                        "label": "local_threshold_ms",
+                        "type": "duration"
+                    },
+                    "connect_timeout_ms": {
+                        "description": "TODO(Rquired description): connect_timeout_ms",
+                        "label": "connect_timeout_ms",
+                        "type": "duration"
+                    },
+                    "socket_timeout_ms": {
+                        "description": "TODO(Rquired description): socket_timeout_ms",
+                        "label": "socket_timeout_ms",
+                        "type": "duration"
+                    },
+                    "server_selection_timeout_ms": {
+                        "description": "TODO(Rquired description): server_selection_timeout_ms",
+                        "label": "server_selection_timeout_ms",
+                        "type": "duration"
+                    },
+                    "wait_queue_timeout_ms": {
+                        "description": "TODO(Rquired description): wait_queue_timeout_ms",
+                        "label": "wait_queue_timeout_ms",
+                        "type": "duration"
+                    },
+                    "heartbeat_frequency_ms": {
+                        "description": "TODO(Rquired description): heartbeat_frequency_ms",
+                        "label": "heartbeat_frequency_ms",
+                        "type": "duration"
+                    },
+                    "min_heartbeat_frequency_ms": {
+                        "description": "TODO(Rquired description): min_heartbeat_frequency_ms",
+                        "label": "min_heartbeat_frequency_ms",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "retainer.flow_control": {
+                "properties": {
+                    "max_read_number": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): max_read_number",
+                        "label": "max_read_number",
+                        "type": "number"
+                    },
+                    "msg_deliver_quota": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): msg_deliver_quota",
+                        "label": "msg_deliver_quota",
+                        "type": "number"
+                    },
+                    "quota_release_interval": {
+                        "default": "0ms",
+                        "description": "TODO(Rquired description): quota_release_interval",
+                        "label": "quota_release_interval",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-redis.cluster": {
+                "required": [
+                    "servers",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "redis"
+                        ],
+                        "type": "enum"
+                    },
+                    "cmd": {
+                        "description": "TODO(Rquired description): cmd",
+                        "label": "cmd",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "servers": {
+                        "description": "A Node list for Cluster to connect to. The nodes should be split with ',', such as: 'Node[,Node]'<br>\nFor each Node should be:<br>\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe Redis default port 6379 is used if '[:Port]' isn't present",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "servers",
+                        "type": "array"
+                    },
+                    "redis_type": {
+                        "default": "cluster",
+                        "description": "TODO(Rquired description): redis_type",
+                        "label": "redis_type",
+                        "symbols": [
+                            "cluster"
+                        ],
+                        "type": "enum"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "database": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "number"
+                    },
+                    "auto_reconnect": {
+                        "default": true,
+                        "description": "TODO(Rquired description): auto_reconnect",
+                        "label": "auto_reconnect",
+                        "type": "boolean"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.ws_opts": {
+                "properties": {
+                    "mqtt_path": {
+                        "default": "/mqtt",
+                        "description": "TODO(Rquired description): mqtt_path",
+                        "label": "mqtt_path",
+                        "type": "string"
+                    },
+                    "mqtt_piggyback": {
+                        "default": "multiple",
+                        "description": "TODO(Rquired description): mqtt_piggyback",
+                        "label": "mqtt_piggyback",
+                        "symbols": [
+                            "single",
+                            "multiple"
+                        ],
+                        "type": "enum"
+                    },
+                    "compress": {
+                        "default": false,
+                        "description": "TODO(Rquired description): compress",
+                        "label": "compress",
+                        "type": "boolean"
+                    },
+                    "idle_timeout": {
+                        "default": "15s",
+                        "description": "TODO(Rquired description): idle_timeout",
+                        "label": "idle_timeout",
+                        "type": "duration"
+                    },
+                    "max_frame_size": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_frame_size",
+                        "label": "max_frame_size",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "fail_if_no_subprotocol": {
+                        "default": true,
+                        "description": "TODO(Rquired description): fail_if_no_subprotocol",
+                        "label": "fail_if_no_subprotocol",
+                        "type": "boolean"
+                    },
+                    "supported_subprotocols": {
+                        "default": "mqtt, mqtt-v3, mqtt-v3.1.1, mqtt-v5",
+                        "description": "TODO(Rquired description): supported_subprotocols",
+                        "label": "supported_subprotocols",
+                        "type": "comma_separated_string"
+                    },
+                    "check_origin_enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): check_origin_enable",
+                        "label": "check_origin_enable",
+                        "type": "boolean"
+                    },
+                    "allow_origin_absence": {
+                        "default": true,
+                        "description": "TODO(Rquired description): allow_origin_absence",
+                        "label": "allow_origin_absence",
+                        "type": "boolean"
+                    },
+                    "check_origins": {
+                        "default": "",
+                        "description": "TODO(Rquired description): check_origins",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "check_origins",
+                        "type": "array"
+                    },
+                    "proxy_address_header": {
+                        "default": "x-forwarded-for",
+                        "description": "TODO(Rquired description): proxy_address_header",
+                        "label": "proxy_address_header",
+                        "type": "string"
+                    },
+                    "proxy_port_header": {
+                        "default": "x-forwarded-port",
+                        "description": "TODO(Rquired description): proxy_port_header",
+                        "label": "proxy_port_header",
+                        "type": "string"
+                    },
+                    "deflate_opts": {
+                        "description": "TODO(Rquired description): deflate_opts",
+                        "label": "deflate_opts",
+                        "$ref": "#/components/schemas/emqx_schema.deflate_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.log_file_handler": {
+                "properties": {
+                    "file": {
+                        "description": "TODO(Rquired description): file",
+                        "label": "file",
+                        "type": "string"
+                    },
+                    "rotation": {
+                        "description": "TODO(Rquired description): rotation",
+                        "label": "rotation",
+                        "$ref": "#/components/schemas/emqx_conf_schema.log_rotation"
+                    },
+                    "max_size": {
+                        "default": "10MB",
+                        "description": "TODO(Rquired description): max_size",
+                        "label": "max_size",
+                        "oneOf": [
+                            {
+                                "type": "byteSize"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "level": {
+                        "default": "warning",
+                        "description": "Global log level. This includes the primary log level and all log handlers.",
+                        "label": "level",
+                        "symbols": [
+                            "debug",
+                            "info",
+                            "notice",
+                            "warning",
+                            "error",
+                            "critical",
+                            "alert",
+                            "emergency",
+                            "all"
+                        ],
+                        "type": "enum"
+                    },
+                    "time_offset": {
+                        "default": "system",
+                        "description": "TODO(Rquired description): time_offset",
+                        "label": "time_offset",
+                        "type": "string"
+                    },
+                    "chars_limit": {
+                        "default": "unlimited",
+                        "description": "Set the maximum length of a single log message. If this length is exceeded, the log message will be truncated.",
+                        "label": "chars_limit",
+                        "oneOf": [
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "unlimited"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "formatter": {
+                        "default": "text",
+                        "description": "Choose log format. <code>text</code> for free text, and <code>json</code> for structured logging.",
+                        "label": "formatter",
+                        "symbols": [
+                            "text",
+                            "json"
+                        ],
+                        "type": "enum"
+                    },
+                    "single_line": {
+                        "default": true,
+                        "description": "Print logs in a single line if set to true. Otherwise, log messages may span multiple lines.",
+                        "label": "single_line",
+                        "type": "boolean"
+                    },
+                    "sync_mode_qlen": {
+                        "default": 100,
+                        "description": "TODO(Rquired description): sync_mode_qlen",
+                        "label": "sync_mode_qlen",
+                        "type": "number"
+                    },
+                    "drop_mode_qlen": {
+                        "default": 3000,
+                        "description": "TODO(Rquired description): drop_mode_qlen",
+                        "label": "drop_mode_qlen",
+                        "type": "number"
+                    },
+                    "flush_qlen": {
+                        "default": 8000,
+                        "description": "TODO(Rquired description): flush_qlen",
+                        "label": "flush_qlen",
+                        "type": "number"
+                    },
+                    "overload_kill": {
+                        "description": "TODO(Rquired description): overload_kill",
+                        "label": "overload_kill",
+                        "$ref": "#/components/schemas/emqx_conf_schema.log_overload_kill"
+                    },
+                    "burst_limit": {
+                        "description": "TODO(Rquired description): burst_limit",
+                        "label": "burst_limit",
+                        "$ref": "#/components/schemas/emqx_conf_schema.log_burst_limit"
+                    },
+                    "supervisor_reports": {
+                        "default": "error",
+                        "description": "TODO(Rquired description): supervisor_reports",
+                        "label": "supervisor_reports",
+                        "symbols": [
+                            "error",
+                            "progress"
+                        ],
+                        "type": "enum"
+                    },
+                    "max_depth": {
+                        "default": 100,
+                        "description": "Maximum depth for Erlang term log formatting and Erlang process message queue inspection.",
+                        "label": "max_depth",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "unlimited"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "retainer.retainer": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "msg_expiry_interval": {
+                        "default": "0s",
+                        "description": "TODO(Rquired description): msg_expiry_interval",
+                        "label": "msg_expiry_interval",
+                        "type": "duration"
+                    },
+                    "msg_clear_interval": {
+                        "default": "0s",
+                        "description": "TODO(Rquired description): msg_clear_interval",
+                        "label": "msg_clear_interval",
+                        "type": "duration"
+                    },
+                    "flow_control": {
+                        "description": "TODO(Rquired description): flow_control",
+                        "label": "flow_control",
+                        "$ref": "#/components/schemas/retainer.flow_control"
+                    },
+                    "max_payload_size": {
+                        "default": "1MB",
+                        "description": "TODO(Rquired description): max_payload_size",
+                        "label": "max_payload_size",
+                        "type": "byteSize"
+                    },
+                    "stop_publish_clear_msg": {
+                        "default": false,
+                        "description": "TODO(Rquired description): stop_publish_clear_msg",
+                        "label": "stop_publish_clear_msg",
+                        "type": "boolean"
+                    },
+                    "config": {
+                        "description": "TODO(Rquired description): config",
+                        "label": "config",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/retainer.mnesia_config"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "authn-jwt.hmac-based": {
+                "required": [
+                    "mechanism"
+                ],
+                "properties": {
+                    "use_jwks": {
+                        "description": "TODO(Rquired description): use_jwks",
+                        "label": "use_jwks",
+                        "symbols": [
+                            false
+                        ],
+                        "type": "enum"
+                    },
+                    "algorithm": {
+                        "description": "TODO(Rquired description): algorithm",
+                        "label": "algorithm",
+                        "symbols": [
+                            "hmac-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "secret": {
+                        "description": "TODO(Rquired description): secret",
+                        "label": "secret",
+                        "type": "string"
+                    },
+                    "secret_base64_encoded": {
+                        "default": false,
+                        "description": "TODO(Rquired description): secret_base64_encoded",
+                        "label": "secret_base64_encoded",
+                        "type": "boolean"
+                    },
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "jwt"
+                        ],
+                        "type": "enum"
+                    },
+                    "verify_claims": {
+                        "default": {},
+                        "description": "TODO(Rquired description): verify_claims",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "verify_claims",
+                        "type": "array"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.flapping_detect": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_count": {
+                        "description": "TODO(Rquired description): max_count",
+                        "label": "max_count",
+                        "type": "number"
+                    },
+                    "window_time": {
+                        "description": "TODO(Rquired description): window_time",
+                        "label": "window_time",
+                        "type": "duration"
+                    },
+                    "ban_time": {
+                        "description": "TODO(Rquired description): ban_time",
+                        "label": "ban_time",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.stats": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-mongodb.replica-set": {
+                "required": [
+                    "database",
+                    "servers",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "mongodb"
+                        ],
+                        "type": "enum"
+                    },
+                    "collection": {
+                        "description": "TODO(Rquired description): collection",
+                        "label": "collection",
+                        "type": "string"
+                    },
+                    "selector": {
+                        "description": "TODO(Rquired description): selector",
+                        "label": "selector",
+                        "type": "string"
+                    },
+                    "password_hash_field": {
+                        "description": "TODO(Rquired description): password_hash_field",
+                        "label": "password_hash_field",
+                        "type": "string"
+                    },
+                    "salt_field": {
+                        "description": "TODO(Rquired description): salt_field",
+                        "label": "salt_field",
+                        "type": "string"
+                    },
+                    "is_superuser_field": {
+                        "description": "TODO(Rquired description): is_superuser_field",
+                        "label": "is_superuser_field",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "mongo_type": {
+                        "default": "rs",
+                        "description": "TODO(Rquired description): mongo_type",
+                        "label": "mongo_type",
+                        "symbols": [
+                            "rs"
+                        ],
+                        "type": "enum"
+                    },
+                    "servers": {
+                        "description": "A Node list for Cluster to connect to. The nodes should be split with ',', such as: 'Node[,Node]'<br>\nFor each Node should be:<br>\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe MongoDB default port 27017 is used if '[:Port]' isn't present",
+                        "label": "servers",
+                        "type": "string"
+                    },
+                    "w_mode": {
+                        "default": "unsafe",
+                        "description": "TODO(Rquired description): w_mode",
+                        "label": "w_mode",
+                        "symbols": [
+                            "unsafe",
+                            "safe"
+                        ],
+                        "type": "enum"
+                    },
+                    "r_mode": {
+                        "default": "master",
+                        "description": "TODO(Rquired description): r_mode",
+                        "label": "r_mode",
+                        "symbols": [
+                            "master",
+                            "slave_ok"
+                        ],
+                        "type": "enum"
+                    },
+                    "replica_set_name": {
+                        "description": "TODO(Rquired description): replica_set_name",
+                        "label": "replica_set_name",
+                        "type": "string"
+                    },
+                    "srv_record": {
+                        "default": false,
+                        "description": "TODO(Rquired description): srv_record",
+                        "label": "srv_record",
+                        "type": "boolean"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "username": {
+                        "description": "TODO(Rquired description): username",
+                        "label": "username",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "auth_source": {
+                        "description": "TODO(Rquired description): auth_source",
+                        "label": "auth_source",
+                        "type": "string"
+                    },
+                    "database": {
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "string"
+                    },
+                    "topology": {
+                        "description": "TODO(Rquired description): topology",
+                        "label": "topology",
+                        "$ref": "#/components/schemas/emqx_connector_mongo.topology"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.stats": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.log_overload_kill": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "mem_size": {
+                        "default": "30MB",
+                        "description": "TODO(Rquired description): mem_size",
+                        "label": "mem_size",
+                        "type": "byteSize"
+                    },
+                    "qlen": {
+                        "default": 20000,
+                        "description": "TODO(Rquired description): qlen",
+                        "label": "qlen",
+                        "type": "number"
+                    },
+                    "restart_after": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): restart_after",
+                        "label": "restart_after",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "duration"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.rate_limit": {
+                "properties": {
+                    "max_conn_rate": {
+                        "default": 1000,
+                        "description": "TODO(Rquired description): max_conn_rate",
+                        "label": "max_conn_rate",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "conn_messages_in": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): conn_messages_in",
+                        "label": "conn_messages_in",
+                        "oneOf": [
+                            {
+                                "type": "comma_separated_string"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "conn_bytes_in": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): conn_bytes_in",
+                        "label": "conn_bytes_in",
+                        "oneOf": [
+                            {
+                                "type": "comma_separated_string"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.sysmon_top": {
+                "properties": {
+                    "num_items": {
+                        "default": 10,
+                        "description": "The number of top processes per monitoring group",
+                        "label": "num_items",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "sample_interval": {
+                        "default": "2s",
+                        "description": "Specifies how often process top should be collected",
+                        "label": "sample_interval",
+                        "type": "duration"
+                    },
+                    "max_procs": {
+                        "default": 1000000,
+                        "description": "Stop collecting data when the number of processes\nin the VM exceeds this value",
+                        "label": "max_procs",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "db_hostname": {
+                        "default": "",
+                        "description": "Hostname of the PostgreSQL database that collects the data points",
+                        "label": "db_hostname",
+                        "type": "string"
+                    },
+                    "db_port": {
+                        "default": 5432,
+                        "description": "Port of the PostgreSQL database that collects the data points",
+                        "label": "db_port",
+                        "type": "number"
+                    },
+                    "db_username": {
+                        "default": "system_monitor",
+                        "description": "EMQX username in the PostgreSQL database",
+                        "label": "db_username",
+                        "type": "string"
+                    },
+                    "db_password": {
+                        "default": "system_monitor_password",
+                        "description": "EMQX user password in the PostgreSQL database",
+                        "label": "db_password",
+                        "type": "string"
+                    },
+                    "db_name": {
+                        "default": "postgres",
+                        "description": "PostgreSQL database name",
+                        "label": "db_name",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-redis.standalone": {
+                "required": [
+                    "server",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "redis"
+                        ],
+                        "type": "enum"
+                    },
+                    "cmd": {
+                        "description": "TODO(Rquired description): cmd",
+                        "label": "cmd",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "server": {
+                        "description": "\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe Redis default port 6379 is used if '[:Port]' isn't present",
+                        "label": "server",
+                        "type": "ip_port"
+                    },
+                    "redis_type": {
+                        "default": "single",
+                        "description": "TODO(Rquired description): redis_type",
+                        "label": "redis_type",
+                        "symbols": [
+                            "single"
+                        ],
+                        "type": "enum"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "database": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "number"
+                    },
+                    "auto_reconnect": {
+                        "default": true,
+                        "description": "TODO(Rquired description): auto_reconnect",
+                        "label": "auto_reconnect",
+                        "type": "boolean"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-jwt.public-key": {
+                "required": [
+                    "mechanism"
+                ],
+                "properties": {
+                    "use_jwks": {
+                        "description": "TODO(Rquired description): use_jwks",
+                        "label": "use_jwks",
+                        "symbols": [
+                            false
+                        ],
+                        "type": "enum"
+                    },
+                    "algorithm": {
+                        "description": "TODO(Rquired description): algorithm",
+                        "label": "algorithm",
+                        "symbols": [
+                            "public-key"
+                        ],
+                        "type": "enum"
+                    },
+                    "certificate": {
+                        "description": "TODO(Rquired description): certificate",
+                        "label": "certificate",
+                        "type": "string"
+                    },
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "jwt"
+                        ],
+                        "type": "enum"
+                    },
+                    "verify_claims": {
+                        "default": {},
+                        "description": "TODO(Rquired description): verify_claims",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "verify_claims",
+                        "type": "array"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_static": {
+                "properties": {
+                    "seeds": {
+                        "default": "",
+                        "description": "TODO(Rquired description): seeds",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "seeds",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-redis.sentinel": {
+                "required": [
+                    "servers",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "redis"
+                        ],
+                        "type": "enum"
+                    },
+                    "cmd": {
+                        "description": "TODO(Rquired description): cmd",
+                        "label": "cmd",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "servers": {
+                        "description": "A Node list for Cluster to connect to. The nodes should be split with ',', such as: 'Node[,Node]'<br>\nFor each Node should be:<br>\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe Redis default port 6379 is used if '[:Port]' isn't present",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "servers",
+                        "type": "array"
+                    },
+                    "redis_type": {
+                        "default": "sentinel",
+                        "description": "TODO(Rquired description): redis_type",
+                        "label": "redis_type",
+                        "symbols": [
+                            "sentinel"
+                        ],
+                        "type": "enum"
+                    },
+                    "sentinel": {
+                        "description": "TODO(Rquired description): sentinel",
+                        "label": "sentinel",
+                        "type": "string"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "database": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "number"
+                    },
+                    "auto_reconnect": {
+                        "default": true,
+                        "description": "TODO(Rquired description): auto_reconnect",
+                        "label": "auto_reconnect",
+                        "type": "boolean"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_call": {
+                "properties": {
+                    "retry_interval": {
+                        "default": "1s",
+                        "description": "Time interval to retry after a failed call.",
+                        "label": "retry_interval",
+                        "type": "duration"
+                    },
+                    "max_history": {
+                        "default": 100,
+                        "description": "Retain the maximum number of completed transactions (for queries).",
+                        "label": "max_history",
+                        "maximum": 500,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "cleanup_interval": {
+                        "default": "5m",
+                        "description": "Time interval to clear completed but stale transactions.\nEnsure that the number of completed transactions is less than the max_history.",
+                        "label": "cleanup_interval",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.overload_protection": {
+                "properties": {
+                    "enable": {
+                        "description": "React on system overload or not",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "backoff_delay": {
+                        "description": "Some unimportant tasks could be delayed for execution, here set the delays in ms",
+                        "label": "backoff_delay",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "backoff_gc": {
+                        "description": "Skip forceful GC if necessary",
+                        "label": "backoff_gc",
+                        "type": "boolean"
+                    },
+                    "backoff_hibernation": {
+                        "description": "Skip process hibernation if necessary",
+                        "label": "backoff_hibernation",
+                        "type": "boolean"
+                    },
+                    "backoff_new_conn": {
+                        "description": "Close new incoming connections if necessary",
+                        "label": "backoff_new_conn",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "configuration.cluster": {
+                "properties": {
+                    "name": {
+                        "default": "emqxcl",
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "type": "string"
+                    },
+                    "discovery_strategy": {
+                        "default": "manual",
+                        "description": "TODO(Rquired description): discovery_strategy",
+                        "label": "discovery_strategy",
+                        "symbols": [
+                            "manual",
+                            "static",
+                            "mcast",
+                            "dns",
+                            "etcd",
+                            "k8s"
+                        ],
+                        "type": "enum"
+                    },
+                    "autoclean": {
+                        "default": "5m",
+                        "description": "TODO(Rquired description): autoclean",
+                        "label": "autoclean",
+                        "type": "duration"
+                    },
+                    "autoheal": {
+                        "default": true,
+                        "description": "TODO(Rquired description): autoheal",
+                        "label": "autoheal",
+                        "type": "boolean"
+                    },
+                    "static": {
+                        "description": "TODO(Rquired description): static",
+                        "label": "static",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_static"
+                    },
+                    "mcast": {
+                        "description": "TODO(Rquired description): mcast",
+                        "label": "mcast",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_mcast"
+                    },
+                    "proto_dist": {
+                        "default": "inet_tcp",
+                        "description": "TODO(Rquired description): proto_dist",
+                        "label": "proto_dist",
+                        "symbols": [
+                            "inet_tcp",
+                            "inet6_tcp",
+                            "inet_tls"
+                        ],
+                        "type": "enum"
+                    },
+                    "dns": {
+                        "description": "TODO(Rquired description): dns",
+                        "label": "dns",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_dns"
+                    },
+                    "etcd": {
+                        "description": "TODO(Rquired description): etcd",
+                        "label": "etcd",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_etcd"
+                    },
+                    "k8s": {
+                        "description": "TODO(Rquired description): k8s",
+                        "label": "k8s",
+                        "$ref": "#/components/schemas/emqx_conf_schema.cluster_k8s"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.force_gc": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "count": {
+                        "default": 16000,
+                        "description": "GC the process after this many received messages.",
+                        "label": "count",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "bytes": {
+                        "default": "16MB",
+                        "description": "GC the process after specified number of bytes have passed through.",
+                        "label": "bytes",
+                        "type": "byteSize"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-hash.other_algorithms": {
+                "properties": {
+                    "name": {
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "symbols": [
+                            "plain",
+                            "md5",
+                            "sha",
+                            "sha256",
+                            "sha512"
+                        ],
+                        "type": "enum"
+                    },
+                    "salt_position": {
+                        "default": "prefix",
+                        "description": "TODO(Rquired description): salt_position",
+                        "label": "salt_position",
+                        "symbols": [
+                            "prefix",
+                            "suffix"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "modules.topic_metrics": {
+                "properties": {
+                    "topic": {
+                        "description": "TODO(Rquired description): topic",
+                        "label": "topic",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-http.get": {
+                "required": [
+                    "url",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "method": {
+                        "default": "post",
+                        "description": "TODO(Rquired description): method",
+                        "label": "method",
+                        "symbols": [
+                            "get"
+                        ],
+                        "type": "enum"
+                    },
+                    "headers": {
+                        "default": {
+                            "accept": "application/json",
+                            "cache-control": "no-cache",
+                            "connection": "keep-alive",
+                            "keep-alive": "timeout=30, max=1000"
+                        },
+                        "description": "TODO(Rquired description): headers",
+                        "label": "headers",
+                        "type": "string"
+                    },
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "http"
+                        ],
+                        "type": "enum"
+                    },
+                    "url": {
+                        "description": "TODO(Rquired description): url",
+                        "label": "url",
+                        "type": "string"
+                    },
+                    "body": {
+                        "description": "TODO(Rquired description): body",
+                        "label": "body",
+                        "type": "string"
+                    },
+                    "request_timeout": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): request_timeout",
+                        "label": "request_timeout",
+                        "type": "duration"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "connect_timeout": {
+                        "default": "15s",
+                        "description": "The timeout when connecting to the HTTP server",
+                        "label": "connect_timeout",
+                        "type": "duration"
+                    },
+                    "enable_pipelining": {
+                        "default": true,
+                        "description": "Enable the HTTP pipeline",
+                        "label": "enable_pipelining",
+                        "type": "boolean"
+                    },
+                    "max_retries": {
+                        "default": 5,
+                        "description": "Max retry times if error on sending request",
+                        "label": "max_retries",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "The pool size",
+                        "label": "pool_size",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "request": {
+                        "description": "\nIf the request is provided, the caller can send HTTP requests via\n<code>emqx_resource:query(ResourceId, {send_message, BridgeId, Message})</code>\n",
+                        "label": "request",
+                        "$ref": "#/components/schemas/connector-http.request"
+                    },
+                    "retry_interval": {
+                        "default": "1s",
+                        "description": "Interval before next retry if error on sending request",
+                        "label": "retry_interval",
+                        "type": "duration"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "limiter.client_bucket": {
+                "properties": {
+                    "rate": {
+                        "description": "TODO(Rquired description): rate",
+                        "label": "rate",
+                        "type": "string"
+                    },
+                    "initial": {
+                        "default": "0",
+                        "description": "TODO(Rquired description): initial",
+                        "label": "initial",
+                        "type": "string"
+                    },
+                    "low_water_mark": {
+                        "default": "0",
+                        "description": "If the remaining tokens are lower than this value,\nthe check/consume will succeed, but it will be forced to wait for a short period of time.",
+                        "label": "low_water_mark",
+                        "type": "string"
+                    },
+                    "capacity": {
+                        "description": "The capacity of the token bucket.",
+                        "label": "capacity",
+                        "type": "string"
+                    },
+                    "divisible": {
+                        "default": false,
+                        "description": "Is it possible to split the number of requested tokens?",
+                        "label": "divisible",
+                        "type": "boolean"
+                    },
+                    "max_retry_time": {
+                        "default": "5s",
+                        "description": "The maximum retry time when acquire failed.",
+                        "label": "max_retry_time",
+                        "type": "duration"
+                    },
+                    "failure_strategy": {
+                        "default": "force",
+                        "description": "The strategy when all the retries failed.",
+                        "label": "failure_strategy",
+                        "symbols": [
+                            "force",
+                            "drop",
+                            "throw"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-postgresql.authentication": {
+                "required": [
+                    "database",
+                    "server",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "postgresql"
+                        ],
+                        "type": "enum"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "query": {
+                        "description": "TODO(Rquired description): query",
+                        "label": "query",
+                        "type": "string"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "server": {
+                        "description": "\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe PostgreSQL default port 5432 is used if '[:Port]' isn't present",
+                        "label": "server",
+                        "type": "ip_port"
+                    },
+                    "database": {
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "string"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "username": {
+                        "description": "TODO(Rquired description): username",
+                        "label": "username",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "auto_reconnect": {
+                        "default": true,
+                        "description": "TODO(Rquired description): auto_reconnect",
+                        "label": "auto_reconnect",
+                        "type": "boolean"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.alarm": {
+                "properties": {
+                    "actions": {
+                        "default": [
+                            "log",
+                            "publish"
+                        ],
+                        "description": "The actions triggered when the alarm is activated.<br/>\nCurrently, the following actions are supported: <code>log</code> and <code>publish</code>.\n<code>log</code> is to write the alarm to log (console or file).\n<code>publish</code> is to publish the alarm as an MQTT message to the system topics:\n<code>$SYS/brokers/emqx@xx.xx.xx.x/alarms/activate</code> and\n<code>$SYS/brokers/emqx@xx.xx.xx.x/alarms/deactivate</code>",
+                        "example": [
+                            "log",
+                            "publish"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "actions",
+                        "type": "array"
+                    },
+                    "size_limit": {
+                        "default": 1000,
+                        "description": "The maximum total number of deactivated alarms to keep as history.<br>\nWhen this limit is exceeded, the oldest deactivated alarms are deleted to cap the total number.\n",
+                        "example": 1000,
+                        "label": "size_limit",
+                        "maximum": 3000,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "validity_period": {
+                        "default": "24h",
+                        "description": "Retention time of deactivated alarms. Alarms are not deleted immediately\nwhen deactivated, but after the retention time.\n",
+                        "example": "24h",
+                        "label": "validity_period",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-jwt.jwks": {
+                "required": [
+                    "mechanism"
+                ],
+                "properties": {
+                    "use_jwks": {
+                        "description": "TODO(Rquired description): use_jwks",
+                        "label": "use_jwks",
+                        "symbols": [
+                            true
+                        ],
+                        "type": "enum"
+                    },
+                    "endpoint": {
+                        "description": "TODO(Rquired description): endpoint",
+                        "label": "endpoint",
+                        "type": "string"
+                    },
+                    "refresh_interval": {
+                        "default": 300,
+                        "description": "TODO(Rquired description): refresh_interval",
+                        "label": "refresh_interval",
+                        "type": "number"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-jwt.ssl_disable"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-jwt.ssl_enable"
+                            }
+                        ]
+                    },
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "jwt"
+                        ],
+                        "type": "enum"
+                    },
+                    "verify_claims": {
+                        "default": {},
+                        "description": "TODO(Rquired description): verify_claims",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "verify_claims",
+                        "type": "array"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.sysmon": {
+                "properties": {
+                    "vm": {
+                        "description": "This part of the configuration is responsible for collecting\n BEAM VM events, such as long garbage collection, traffic congestion in the inter-broker\n communication, etc.",
+                        "label": "vm",
+                        "$ref": "#/components/schemas/emqx_schema.sysmon_vm"
+                    },
+                    "os": {
+                        "description": "This part of the configuration is responsible for monitoring\n the host OS health, such as free memory, disk space, CPU load, etc.",
+                        "label": "os",
+                        "$ref": "#/components/schemas/emqx_schema.sysmon_os"
+                    },
+                    "top": {
+                        "description": "This part of the configuration is responsible for monitoring\n the Erlang processes in the VM. This information can be sent to an external\n PostgreSQL database. This feature is inactive unless the PostgreSQL sink is configured.",
+                        "label": "top",
+                        "$ref": "#/components/schemas/emqx_schema.sysmon_top"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-mongodb.standalone": {
+                "required": [
+                    "database",
+                    "server",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "mongodb"
+                        ],
+                        "type": "enum"
+                    },
+                    "collection": {
+                        "description": "TODO(Rquired description): collection",
+                        "label": "collection",
+                        "type": "string"
+                    },
+                    "selector": {
+                        "description": "TODO(Rquired description): selector",
+                        "label": "selector",
+                        "type": "string"
+                    },
+                    "password_hash_field": {
+                        "description": "TODO(Rquired description): password_hash_field",
+                        "label": "password_hash_field",
+                        "type": "string"
+                    },
+                    "salt_field": {
+                        "description": "TODO(Rquired description): salt_field",
+                        "label": "salt_field",
+                        "type": "string"
+                    },
+                    "is_superuser_field": {
+                        "description": "TODO(Rquired description): is_superuser_field",
+                        "label": "is_superuser_field",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "mongo_type": {
+                        "default": "single",
+                        "description": "TODO(Rquired description): mongo_type",
+                        "label": "mongo_type",
+                        "symbols": [
+                            "single"
+                        ],
+                        "type": "enum"
+                    },
+                    "server": {
+                        "description": "\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe MongoDB default port 27017 is used if '[:Port]' isn't present",
+                        "label": "server",
+                        "type": "ip_port"
+                    },
+                    "w_mode": {
+                        "default": "unsafe",
+                        "description": "TODO(Rquired description): w_mode",
+                        "label": "w_mode",
+                        "symbols": [
+                            "unsafe",
+                            "safe"
+                        ],
+                        "type": "enum"
+                    },
+                    "srv_record": {
+                        "default": false,
+                        "description": "TODO(Rquired description): srv_record",
+                        "label": "srv_record",
+                        "type": "boolean"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "username": {
+                        "description": "TODO(Rquired description): username",
+                        "label": "username",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "auth_source": {
+                        "description": "TODO(Rquired description): auth_source",
+                        "label": "auth_source",
+                        "type": "string"
+                    },
+                    "database": {
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "string"
+                    },
+                    "topology": {
+                        "description": "TODO(Rquired description): topology",
+                        "label": "topology",
+                        "$ref": "#/components/schemas/emqx_connector_mongo.topology"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "configuration.log": {
+                "properties": {
+                    "console_handler": {
+                        "description": "TODO(Rquired description): console_handler",
+                        "label": "console_handler",
+                        "$ref": "#/components/schemas/emqx_conf_schema.console_handler"
+                    },
+                    "file_handlers": {
+                        "description": "TODO(Rquired description): file_handlers",
+                        "label": "file_handlers",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_conf_schema.log_file_handler"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "error_logger": {
+                        "default": "silent",
+                        "description": "TODO(Rquired description): error_logger",
+                        "label": "error_logger",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "prometheus.prometheus": {
+                "properties": {
+                    "push_gateway_server": {
+                        "default": "http://127.0.0.1:9091",
+                        "description": "TODO(Rquired description): push_gateway_server",
+                        "label": "push_gateway_server",
+                        "type": "string"
+                    },
+                    "interval": {
+                        "default": "15s",
+                        "description": "TODO(Rquired description): interval",
+                        "label": "interval",
+                        "type": "duration"
+                    },
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-hash.bcrypt": {
+                "properties": {
+                    "name": {
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "symbols": [
+                            "bcrypt"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.conn_congestion": {
+                "properties": {
+                    "enable_alarm": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable_alarm",
+                        "label": "enable_alarm",
+                        "type": "boolean"
+                    },
+                    "min_alarm_sustain_duration": {
+                        "default": "1m",
+                        "description": "TODO(Rquired description): min_alarm_sustain_duration",
+                        "label": "min_alarm_sustain_duration",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-jwt.ssl_disable": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "symbols": [
+                            false
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.listener_wss_opts": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "cacertfile": {
+                        "description": "Trusted PEM format CA certificates bundle file.<br>\nThe certificates in this file are used to verify the TLS peer's certificates.\nAppend new certificates to the file if new CAs are to be trusted.\nThere is no need to restart EMQX to have the updated file loaded, because\nthe system regularly checks if file has been updated (and reload).<br>\nNOTE: invalidating (deleting) a certificate from the file will not affect\nalready established connections.\n",
+                        "label": "cacertfile",
+                        "type": "string"
+                    },
+                    "certfile": {
+                        "description": "PEM format certificates chain file.<br>\nThe certificates in this file should be in reversed order of the certificate\nissue chain. That is, the host's certificate should be placed in the beginning\nof the file, followed by the immediate issuer certificate and so on.\nAlthough the root CA certificate is optional, it should be placed at the end of\nthe file if it is to be added.\n",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "PEM format private key file.<br>\n",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "verify": {
+                        "default": "verify_none",
+                        "description": "TODO(Rquired description): verify",
+                        "label": "verify",
+                        "symbols": [
+                            "verify_peer",
+                            "verify_none"
+                        ],
+                        "type": "enum"
+                    },
+                    "reuse_sessions": {
+                        "default": true,
+                        "description": "TODO(Rquired description): reuse_sessions",
+                        "label": "reuse_sessions",
+                        "type": "boolean"
+                    },
+                    "depth": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): depth",
+                        "label": "depth",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "String containing the user's password. Only used if the private\nkey file is password-protected.",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "versions": {
+                        "default": [
+                            "tlsv1.3",
+                            "tlsv1.2",
+                            "tlsv1.1",
+                            "tlsv1"
+                        ],
+                        "description": "All TLS/DTLS versions to be supported.<br>\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIn case PSK cipher suites are intended, make sure to configured\n<code>['tlsv1.2', 'tlsv1.1']</code> here.\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "versions",
+                        "type": "array"
+                    },
+                    "ciphers": {
+                        "default": [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_CHACHA20_POLY1305_SHA256",
+                            "TLS_AES_128_CCM_SHA256",
+                            "TLS_AES_128_CCM_8_SHA256",
+                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                            "ECDHE-RSA-AES256-GCM-SHA384",
+                            "ECDHE-ECDSA-AES256-SHA384",
+                            "ECDHE-RSA-AES256-SHA384",
+                            "ECDH-ECDSA-AES256-GCM-SHA384",
+                            "ECDH-RSA-AES256-GCM-SHA384",
+                            "ECDH-ECDSA-AES256-SHA384",
+                            "ECDH-RSA-AES256-SHA384",
+                            "DHE-DSS-AES256-GCM-SHA384",
+                            "DHE-DSS-AES256-SHA256",
+                            "AES256-GCM-SHA384",
+                            "AES256-SHA256",
+                            "ECDHE-ECDSA-AES128-GCM-SHA256",
+                            "ECDHE-RSA-AES128-GCM-SHA256",
+                            "ECDHE-ECDSA-AES128-SHA256",
+                            "ECDHE-RSA-AES128-SHA256",
+                            "ECDH-ECDSA-AES128-GCM-SHA256",
+                            "ECDH-RSA-AES128-GCM-SHA256",
+                            "ECDH-ECDSA-AES128-SHA256",
+                            "ECDH-RSA-AES128-SHA256",
+                            "DHE-DSS-AES128-GCM-SHA256",
+                            "DHE-DSS-AES128-SHA256",
+                            "AES128-GCM-SHA256",
+                            "AES128-SHA256",
+                            "ECDHE-ECDSA-AES256-SHA",
+                            "ECDHE-RSA-AES256-SHA",
+                            "DHE-DSS-AES256-SHA",
+                            "ECDH-ECDSA-AES256-SHA",
+                            "ECDH-RSA-AES256-SHA",
+                            "ECDHE-ECDSA-AES128-SHA",
+                            "ECDHE-RSA-AES128-SHA",
+                            "DHE-DSS-AES128-SHA",
+                            "ECDH-ECDSA-AES128-SHA",
+                            "ECDH-RSA-AES128-SHA",
+                            "RSA-PSK-AES256-GCM-SHA384",
+                            "RSA-PSK-AES256-CBC-SHA384",
+                            "RSA-PSK-AES128-GCM-SHA256",
+                            "RSA-PSK-AES128-CBC-SHA256",
+                            "RSA-PSK-AES256-CBC-SHA",
+                            "RSA-PSK-AES128-CBC-SHA"
+                        ],
+                        "description": "This config holds TLS cipher suite names separated by comma,\nor as an array of strings. e.g.\n<code>\"TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256\"</code> or\n<code>[\"TLS_AES_256_GCM_SHA384\",\"TLS_AES_128_GCM_SHA256\"]</code>.\n<br>\nCiphers (and their ordering) define the way in which the\nclient and server encrypts information over the network connection.\nSelecting a good cipher suite is critical for the\napplication's data security, confidentiality and performance.\n\nThe names should be in OpenSSL string format (not RFC format).\nAll default values and examples provided by EMQX config\ndocumentation are all in OpenSSL format.<br>\n\nNOTE: Certain cipher suites are only compatible with\nspecific TLS <code>versions</code> ('tlsv1.1', 'tlsv1.2' or 'tlsv1.3')\nincompatible cipher suites will be silently dropped.\nFor instance, if only 'tlsv1.3' is given in the <code>versions</code>,\nconfiguring cipher suites for other versions will have no effect.\n<br>\n\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIf PSK cipher suites are intended, 'tlsv1.3' should be disabled from <code>versions</code>.<br>\nPSK cipher suites: <code>\"RSA-PSK-AES256-GCM-SHA384,RSA-PSK-AES256-CBC-SHA384,\nRSA-PSK-AES128-GCM-SHA256,RSA-PSK-AES128-CBC-SHA256,\nRSA-PSK-AES256-CBC-SHA,RSA-PSK-AES128-CBC-SHA,\nRSA-PSK-DES-CBC3-SHA,RSA-PSK-RC4-SHA\"</code><br>\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "ciphers",
+                        "type": "array"
+                    },
+                    "user_lookup_fun": {
+                        "default": "emqx_tls_psk:lookup",
+                        "description": "TODO(Rquired description): user_lookup_fun",
+                        "label": "user_lookup_fun",
+                        "type": "string"
+                    },
+                    "secure_renegotiate": {
+                        "default": true,
+                        "description": "\nSSL parameter renegotiation is a feature that allows a client and a server\nto renegotiate the parameters of the SSL connection on the fly.\nRFC 5746 defines a more secure way of doing this. By enabling secure renegotiation,\nyou drop support for the insecure renegotiation, prone to MitM attacks.\n",
+                        "label": "secure_renegotiate",
+                        "type": "boolean"
+                    },
+                    "dhfile": {
+                        "description": "Path to a file containing PEM-encoded Diffie Hellman parameters\nto be used by the server if a cipher suite using Diffie Hellman\nkey exchange is negotiated. If not specified, default parameters\nare used.<br>\nNOTE: The <code>dhfile</code> option is not supported by TLS 1.3.",
+                        "label": "dhfile",
+                        "type": "string"
+                    },
+                    "fail_if_no_peer_cert": {
+                        "default": false,
+                        "description": "\nUsed together with {verify, verify_peer} by an TLS/DTLS server.\nIf set to true, the server fails if the client does not have a\ncertificate to send, that is, sends an empty certificate.\nIf set to false, it fails only if the client sends an invalid\ncertificate (an empty certificate is considered valid).\n",
+                        "label": "fail_if_no_peer_cert",
+                        "type": "boolean"
+                    },
+                    "honor_cipher_order": {
+                        "default": true,
+                        "description": "TODO(Rquired description): honor_cipher_order",
+                        "label": "honor_cipher_order",
+                        "type": "boolean"
+                    },
+                    "client_renegotiation": {
+                        "default": true,
+                        "description": "\nIn protocols that support client-initiated renegotiation,\nthe cost of resources of such an operation is higher for the server than the client.\nThis can act as a vector for denial of service attacks.\nThe SSL application already takes measures to counter-act such attempts,\nbut client-initiated renegotiation can be strictly disabled by setting this option to false.\nThe default value is true. Note that disabling renegotiation can result in\nlong-lived connections becoming unusable due to limits on\nthe number of messages the underlying cipher suite can encipher.\n",
+                        "label": "client_renegotiation",
+                        "type": "boolean"
+                    },
+                    "handshake_timeout": {
+                        "default": "15s",
+                        "description": "Maximum time duration allowed for the handshake to complete",
+                        "label": "handshake_timeout",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "modules.telemetry": {
+                "properties": {
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt_tcp_listener": {
+                "required": [
+                    "bind"
+                ],
+                "properties": {
+                    "tcp": {
+                        "description": "TCP listener options",
+                        "label": "tcp",
+                        "$ref": "#/components/schemas/emqx_schema.tcp_opts"
+                    },
+                    "bind": {
+                        "description": "TODO(Rquired description): bind",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "ip_port"
+                            }
+                        ]
+                    },
+                    "acceptors": {
+                        "default": 16,
+                        "description": "TODO(Rquired description): acceptors",
+                        "label": "acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "mountpoint": {
+                        "default": "",
+                        "description": "TODO(Rquired description): mountpoint",
+                        "label": "mountpoint",
+                        "type": "string"
+                    },
+                    "zone": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "limiter": {
+                        "default": {},
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "properties": {
+                            "$ratelimit bucket's name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "access_rules": {
+                        "description": "TODO(Rquired description): access_rules",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "access_rules",
+                        "type": "array"
+                    },
+                    "proxy_protocol": {
+                        "default": false,
+                        "description": "TODO(Rquired description): proxy_protocol",
+                        "label": "proxy_protocol",
+                        "type": "boolean"
+                    },
+                    "proxy_protocol_timeout": {
+                        "description": "TODO(Rquired description): proxy_protocol_timeout",
+                        "label": "proxy_protocol_timeout",
+                        "type": "duration"
+                    },
+                    "authentication": {
+                        "description": "Per-listener authentication override\nAuthentication can be one single authenticator instance or a chain of authenticators as an array.\nWhen authenticating a login (username, client ID, etc.) the authenticators are checked\nin the configured order.<br>\n",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/authn-scram-builtin_db.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.jwks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.public-key"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.hmac-based"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.post"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.get"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.sentinel"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.sharded-cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.replica-set"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-postgresql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mysql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-builtin_db.authentication"
+                                }
+                            ]
+                        },
+                        "label": "authentication",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.broker": {
+                "properties": {
+                    "sys_msg_interval": {
+                        "default": "1m",
+                        "description": "TODO(Rquired description): sys_msg_interval",
+                        "label": "sys_msg_interval",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "sys_heartbeat_interval": {
+                        "default": "30s",
+                        "description": "TODO(Rquired description): sys_heartbeat_interval",
+                        "label": "sys_heartbeat_interval",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "enable_session_registry": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable_session_registry",
+                        "label": "enable_session_registry",
+                        "type": "boolean"
+                    },
+                    "session_locking_strategy": {
+                        "default": "quorum",
+                        "description": "TODO(Rquired description): session_locking_strategy",
+                        "label": "session_locking_strategy",
+                        "symbols": [
+                            "local",
+                            "leader",
+                            "quorum",
+                            "all"
+                        ],
+                        "type": "enum"
+                    },
+                    "shared_subscription_strategy": {
+                        "default": "round_robin",
+                        "description": "TODO(Rquired description): shared_subscription_strategy",
+                        "label": "shared_subscription_strategy",
+                        "symbols": [
+                            "random",
+                            "round_robin",
+                            "sticky",
+                            "hash_topic",
+                            "hash_clientid"
+                        ],
+                        "type": "enum"
+                    },
+                    "shared_dispatch_ack_enabled": {
+                        "default": false,
+                        "description": "TODO(Rquired description): shared_dispatch_ack_enabled",
+                        "label": "shared_dispatch_ack_enabled",
+                        "type": "boolean"
+                    },
+                    "route_batch_clean": {
+                        "default": true,
+                        "description": "TODO(Rquired description): route_batch_clean",
+                        "label": "route_batch_clean",
+                        "type": "boolean"
+                    },
+                    "perf": {
+                        "description": "Broker performance tuning parameters",
+                        "label": "perf",
+                        "$ref": "#/components/schemas/emqx_schema.broker_perf"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.cluster_mcast": {
+                "properties": {
+                    "addr": {
+                        "default": "239.192.0.1",
+                        "description": "TODO(Rquired description): addr",
+                        "label": "addr",
+                        "type": "string"
+                    },
+                    "ports": {
+                        "default": [
+                            4369,
+                            4370
+                        ],
+                        "description": "TODO(Rquired description): ports",
+                        "items": {
+                            "type": "number"
+                        },
+                        "label": "ports",
+                        "type": "array"
+                    },
+                    "iface": {
+                        "default": "0.0.0.0",
+                        "description": "TODO(Rquired description): iface",
+                        "label": "iface",
+                        "type": "string"
+                    },
+                    "ttl": {
+                        "default": 255,
+                        "description": "TODO(Rquired description): ttl",
+                        "label": "ttl",
+                        "maximum": 255,
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "loop": {
+                        "default": true,
+                        "description": "TODO(Rquired description): loop",
+                        "label": "loop",
+                        "type": "boolean"
+                    },
+                    "sndbuf": {
+                        "default": "16KB",
+                        "description": "TODO(Rquired description): sndbuf",
+                        "label": "sndbuf",
+                        "type": "byteSize"
+                    },
+                    "recbuf": {
+                        "default": "16KB",
+                        "description": "TODO(Rquired description): recbuf",
+                        "label": "recbuf",
+                        "type": "byteSize"
+                    },
+                    "buffer": {
+                        "default": "32KB",
+                        "description": "TODO(Rquired description): buffer",
+                        "label": "buffer",
+                        "type": "byteSize"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.mqtt": {
+                "properties": {
+                    "idle_timeout": {
+                        "description": "Close TCP connections from the clients that have not sent MQTT CONNECT\nmessage within this interval.",
+                        "label": "idle_timeout",
+                        "oneOf": [
+                            {
+                                "type": "duration"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "max_packet_size": {
+                        "description": "Maximum MQTT packet size allowed.",
+                        "label": "max_packet_size",
+                        "type": "byteSize"
+                    },
+                    "max_clientid_len": {
+                        "description": "Maximum allowed length of MQTT clientId.",
+                        "label": "max_clientid_len",
+                        "maximum": 65535,
+                        "minimum": 23,
+                        "type": "number"
+                    },
+                    "max_topic_levels": {
+                        "description": "Maximum topic levels allowed.",
+                        "label": "max_topic_levels",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "max_qos_allowed": {
+                        "description": "Maximum QoS allowed.",
+                        "label": "max_qos_allowed",
+                        "symbols": [
+                            0,
+                            1,
+                            2
+                        ],
+                        "type": "enum"
+                    },
+                    "max_topic_alias": {
+                        "description": "Maximum Topic Alias, 0 means no topic alias supported.",
+                        "label": "max_topic_alias",
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "retain_available": {
+                        "description": "Support MQTT retained messages.",
+                        "label": "retain_available",
+                        "type": "boolean"
+                    },
+                    "wildcard_subscription": {
+                        "description": "Support MQTT Wildcard Subscriptions.",
+                        "label": "wildcard_subscription",
+                        "type": "boolean"
+                    },
+                    "shared_subscription": {
+                        "description": "Support MQTT Shared Subscriptions.",
+                        "label": "shared_subscription",
+                        "type": "boolean"
+                    },
+                    "ignore_loop_deliver": {
+                        "description": "Ignore loop delivery of messages for MQTT v3.1.1.",
+                        "label": "ignore_loop_deliver",
+                        "type": "boolean"
+                    },
+                    "strict_mode": {
+                        "description": "Parse the MQTT frame in strict mode.",
+                        "label": "strict_mode",
+                        "type": "boolean"
+                    },
+                    "response_information": {
+                        "description": "Specify the response information returned to the client\nThis feature is disabled if is set to \"\".",
+                        "label": "response_information",
+                        "type": "string"
+                    },
+                    "server_keepalive": {
+                        "description": "'Server Keep Alive' of MQTT 5.0.\nIf the server returns a 'Server Keep Alive' in the CONNACK packet,\nthe client MUST use that value instead of the value it sent as the 'Keep Alive'.",
+                        "label": "server_keepalive",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "keepalive_backoff": {
+                        "description": "The backoff for MQTT keepalive timeout. The broker will close the connection\nafter idling for 'Keepalive * backoff * 2'.",
+                        "label": "keepalive_backoff",
+                        "type": "number"
+                    },
+                    "max_subscriptions": {
+                        "description": "Maximum number of subscriptions allowed.",
+                        "label": "max_subscriptions",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "upgrade_qos": {
+                        "description": "Force upgrade of QoS level according to subscription.",
+                        "label": "upgrade_qos",
+                        "type": "boolean"
+                    },
+                    "max_inflight": {
+                        "description": "Maximum size of the Inflight Window storing QoS1/2 messages delivered but un-acked.",
+                        "label": "max_inflight",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "retry_interval": {
+                        "description": "Retry interval for QoS1/2 message delivering.",
+                        "label": "retry_interval",
+                        "type": "duration"
+                    },
+                    "max_awaiting_rel": {
+                        "description": "Maximum QoS2 packets (Client -> Broker) awaiting PUBREL.",
+                        "label": "max_awaiting_rel",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "await_rel_timeout": {
+                        "description": "The QoS2 messages (Client -> Broker) will be dropped if awaiting PUBREL timeout.",
+                        "label": "await_rel_timeout",
+                        "type": "duration"
+                    },
+                    "session_expiry_interval": {
+                        "description": "Default session expiry interval for MQTT V3.1.1 connections.",
+                        "label": "session_expiry_interval",
+                        "type": "duration"
+                    },
+                    "max_mqueue_len": {
+                        "description": "Maximum queue length. Enqueued messages when persistent client disconnected,\nor inflight window is full.",
+                        "label": "max_mqueue_len",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "minimum": 0,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "mqueue_priorities": {
+                        "description": "Topic priorities.<br>\nThere's no priority table by default, hence all messages are treated equal.<br>\nPriority number [1-255]<br>\n\n**NOTE**: Comma and equal signs are not allowed for priority topic names.<br>\n**NOTE**: Messages for topics not in the priority table are treated as\neither highest or lowest priority depending on the configured value for\n<code>mqtt.mqueue_default_priority</code>.\n<br><br>\n**Examples**:\nTo configure <code>\"topic/1\" > \"topic/2\"</code>:<br/>\n<code>mqueue_priorities: {\"topic/1\": 10, \"topic/2\": 8}</code>",
+                        "label": "mqueue_priorities",
+                        "oneOf": [
+                            {
+                                "symbols": [
+                                    "disabled"
+                                ],
+                                "type": "enum"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "mqueue_default_priority": {
+                        "description": "Default to the highest priority for topics not matching priority table.",
+                        "label": "mqueue_default_priority",
+                        "symbols": [
+                            "highest",
+                            "lowest"
+                        ],
+                        "type": "enum"
+                    },
+                    "mqueue_store_qos0": {
+                        "description": "Support enqueue QoS0 messages.",
+                        "label": "mqueue_store_qos0",
+                        "type": "boolean"
+                    },
+                    "use_username_as_clientid": {
+                        "description": "Replace client ID with the username.",
+                        "label": "use_username_as_clientid",
+                        "type": "boolean"
+                    },
+                    "peer_cert_as_username": {
+                        "description": "Use the CN, DN or CRT field from the client certificate as a username.\nOnly works for the TLS connection.",
+                        "label": "peer_cert_as_username",
+                        "symbols": [
+                            "disabled",
+                            "cn",
+                            "dn",
+                            "crt",
+                            "pem",
+                            "md5"
+                        ],
+                        "type": "enum"
+                    },
+                    "peer_cert_as_clientid": {
+                        "description": "Use the CN, DN or CRT field from the client certificate as a clientid.\nOnly works for the TLS connection.",
+                        "label": "peer_cert_as_clientid",
+                        "symbols": [
+                            "disabled",
+                            "cn",
+                            "dn",
+                            "crt",
+                            "pem",
+                            "md5"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-scram-builtin_db.authentication": {
+                "required": [
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "scram"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "built-in-database"
+                        ],
+                        "type": "enum"
+                    },
+                    "algorithm": {
+                        "default": "sha256",
+                        "description": "TODO(Rquired description): algorithm",
+                        "label": "algorithm",
+                        "symbols": [
+                            "sha256",
+                            "sha512"
+                        ],
+                        "type": "enum"
+                    },
+                    "iteration_count": {
+                        "default": 4096,
+                        "description": "TODO(Rquired description): iteration_count",
+                        "label": "iteration_count",
+                        "minimum": 1,
+                        "type": "number"
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.conn_congestion": {
+                "properties": {
+                    "enable_alarm": {
+                        "description": "TODO(Rquired description): enable_alarm",
+                        "label": "enable_alarm",
+                        "type": "boolean"
+                    },
+                    "min_alarm_sustain_duration": {
+                        "description": "TODO(Rquired description): min_alarm_sustain_duration",
+                        "label": "min_alarm_sustain_duration",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "limiter.limiter": {
+                "properties": {
+                    "bytes_in": {
+                        "description": "TODO(Rquired description): bytes_in",
+                        "label": "bytes_in",
+                        "$ref": "#/components/schemas/limiter.limiter_opts"
+                    },
+                    "message_in": {
+                        "description": "TODO(Rquired description): message_in",
+                        "label": "message_in",
+                        "$ref": "#/components/schemas/limiter.limiter_opts"
+                    },
+                    "connection": {
+                        "description": "TODO(Rquired description): connection",
+                        "label": "connection",
+                        "$ref": "#/components/schemas/limiter.limiter_opts"
+                    },
+                    "message_routing": {
+                        "description": "TODO(Rquired description): message_routing",
+                        "label": "message_routing",
+                        "$ref": "#/components/schemas/limiter.limiter_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "dashboard.https": {
+                "required": [
+                    "bind",
+                    "protocol"
+                ],
+                "properties": {
+                    "protocol": {
+                        "default": "http",
+                        "description": "HTTP/HTTPS protocol.",
+                        "label": "protocol",
+                        "symbols": [
+                            "http",
+                            "https"
+                        ],
+                        "type": "enum"
+                    },
+                    "bind": {
+                        "default": 18083,
+                        "description": "Port without IP(18083) or port with specified IP(127.0.0.1:18083).",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "ip_port"
+                            },
+                            {
+                                "minimum": 1,
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "num_acceptors": {
+                        "default": 4,
+                        "description": "Socket acceptor pool for TCP protocols.",
+                        "label": "num_acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": 512,
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "type": "number"
+                    },
+                    "backlog": {
+                        "default": 1024,
+                        "description": "Defines the maximum length that the queue of pending connections can grow to.",
+                        "label": "backlog",
+                        "type": "number"
+                    },
+                    "send_timeout": {
+                        "default": "5s",
+                        "description": "TODO(Rquired description): send_timeout",
+                        "label": "send_timeout",
+                        "type": "duration"
+                    },
+                    "inet6": {
+                        "default": false,
+                        "description": "TODO(Rquired description): inet6",
+                        "label": "inet6",
+                        "type": "boolean"
+                    },
+                    "ipv6_v6only": {
+                        "default": false,
+                        "description": "TODO(Rquired description): ipv6_v6only",
+                        "label": "ipv6_v6only",
+                        "type": "boolean"
+                    },
+                    "enable": {
+                        "default": false,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "cacertfile": {
+                        "description": "Trusted PEM format CA certificates bundle file.<br>\nThe certificates in this file are used to verify the TLS peer's certificates.\nAppend new certificates to the file if new CAs are to be trusted.\nThere is no need to restart EMQX to have the updated file loaded, because\nthe system regularly checks if file has been updated (and reload).<br>\nNOTE: invalidating (deleting) a certificate from the file will not affect\nalready established connections.\n",
+                        "label": "cacertfile",
+                        "type": "string"
+                    },
+                    "certfile": {
+                        "description": "PEM format certificates chain file.<br>\nThe certificates in this file should be in reversed order of the certificate\nissue chain. That is, the host's certificate should be placed in the beginning\nof the file, followed by the immediate issuer certificate and so on.\nAlthough the root CA certificate is optional, it should be placed at the end of\nthe file if it is to be added.\n",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "PEM format private key file.<br>\n",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "verify": {
+                        "default": "verify_none",
+                        "description": "TODO(Rquired description): verify",
+                        "label": "verify",
+                        "symbols": [
+                            "verify_peer",
+                            "verify_none"
+                        ],
+                        "type": "enum"
+                    },
+                    "reuse_sessions": {
+                        "default": true,
+                        "description": "TODO(Rquired description): reuse_sessions",
+                        "label": "reuse_sessions",
+                        "type": "boolean"
+                    },
+                    "depth": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): depth",
+                        "label": "depth",
+                        "type": "number"
+                    },
+                    "password": {
+                        "description": "String containing the user's password. Only used if the private\nkey file is password-protected.",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "versions": {
+                        "default": [
+                            "tlsv1.3",
+                            "tlsv1.2",
+                            "tlsv1.1",
+                            "tlsv1"
+                        ],
+                        "description": "All TLS/DTLS versions to be supported.<br>\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIn case PSK cipher suites are intended, make sure to configured\n<code>['tlsv1.2', 'tlsv1.1']</code> here.\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "versions",
+                        "type": "array"
+                    },
+                    "ciphers": {
+                        "default": [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_CHACHA20_POLY1305_SHA256",
+                            "TLS_AES_128_CCM_SHA256",
+                            "TLS_AES_128_CCM_8_SHA256",
+                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                            "ECDHE-RSA-AES256-GCM-SHA384",
+                            "ECDHE-ECDSA-AES256-SHA384",
+                            "ECDHE-RSA-AES256-SHA384",
+                            "ECDH-ECDSA-AES256-GCM-SHA384",
+                            "ECDH-RSA-AES256-GCM-SHA384",
+                            "ECDH-ECDSA-AES256-SHA384",
+                            "ECDH-RSA-AES256-SHA384",
+                            "DHE-DSS-AES256-GCM-SHA384",
+                            "DHE-DSS-AES256-SHA256",
+                            "AES256-GCM-SHA384",
+                            "AES256-SHA256",
+                            "ECDHE-ECDSA-AES128-GCM-SHA256",
+                            "ECDHE-RSA-AES128-GCM-SHA256",
+                            "ECDHE-ECDSA-AES128-SHA256",
+                            "ECDHE-RSA-AES128-SHA256",
+                            "ECDH-ECDSA-AES128-GCM-SHA256",
+                            "ECDH-RSA-AES128-GCM-SHA256",
+                            "ECDH-ECDSA-AES128-SHA256",
+                            "ECDH-RSA-AES128-SHA256",
+                            "DHE-DSS-AES128-GCM-SHA256",
+                            "DHE-DSS-AES128-SHA256",
+                            "AES128-GCM-SHA256",
+                            "AES128-SHA256",
+                            "ECDHE-ECDSA-AES256-SHA",
+                            "ECDHE-RSA-AES256-SHA",
+                            "DHE-DSS-AES256-SHA",
+                            "ECDH-ECDSA-AES256-SHA",
+                            "ECDH-RSA-AES256-SHA",
+                            "ECDHE-ECDSA-AES128-SHA",
+                            "ECDHE-RSA-AES128-SHA",
+                            "DHE-DSS-AES128-SHA",
+                            "ECDH-ECDSA-AES128-SHA",
+                            "ECDH-RSA-AES128-SHA",
+                            "RSA-PSK-AES256-GCM-SHA384",
+                            "RSA-PSK-AES256-CBC-SHA384",
+                            "RSA-PSK-AES128-GCM-SHA256",
+                            "RSA-PSK-AES128-CBC-SHA256",
+                            "RSA-PSK-AES256-CBC-SHA",
+                            "RSA-PSK-AES128-CBC-SHA"
+                        ],
+                        "description": "This config holds TLS cipher suite names separated by comma,\nor as an array of strings. e.g.\n<code>\"TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256\"</code> or\n<code>[\"TLS_AES_256_GCM_SHA384\",\"TLS_AES_128_GCM_SHA256\"]</code>.\n<br>\nCiphers (and their ordering) define the way in which the\nclient and server encrypts information over the network connection.\nSelecting a good cipher suite is critical for the\napplication's data security, confidentiality and performance.\n\nThe names should be in OpenSSL string format (not RFC format).\nAll default values and examples provided by EMQX config\ndocumentation are all in OpenSSL format.<br>\n\nNOTE: Certain cipher suites are only compatible with\nspecific TLS <code>versions</code> ('tlsv1.1', 'tlsv1.2' or 'tlsv1.3')\nincompatible cipher suites will be silently dropped.\nFor instance, if only 'tlsv1.3' is given in the <code>versions</code>,\nconfiguring cipher suites for other versions will have no effect.\n<br>\n\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIf PSK cipher suites are intended, 'tlsv1.3' should be disabled from <code>versions</code>.<br>\nPSK cipher suites: <code>\"RSA-PSK-AES256-GCM-SHA384,RSA-PSK-AES256-CBC-SHA384,\nRSA-PSK-AES128-GCM-SHA256,RSA-PSK-AES128-CBC-SHA256,\nRSA-PSK-AES256-CBC-SHA,RSA-PSK-AES128-CBC-SHA,\nRSA-PSK-DES-CBC3-SHA,RSA-PSK-RC4-SHA\"</code><br>\n",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "ciphers",
+                        "type": "array"
+                    },
+                    "user_lookup_fun": {
+                        "default": "emqx_tls_psk:lookup",
+                        "description": "TODO(Rquired description): user_lookup_fun",
+                        "label": "user_lookup_fun",
+                        "type": "string"
+                    },
+                    "secure_renegotiate": {
+                        "default": true,
+                        "description": "\nSSL parameter renegotiation is a feature that allows a client and a server\nto renegotiate the parameters of the SSL connection on the fly.\nRFC 5746 defines a more secure way of doing this. By enabling secure renegotiation,\nyou drop support for the insecure renegotiation, prone to MitM attacks.\n",
+                        "label": "secure_renegotiate",
+                        "type": "boolean"
+                    },
+                    "dhfile": {
+                        "description": "Path to a file containing PEM-encoded Diffie Hellman parameters\nto be used by the server if a cipher suite using Diffie Hellman\nkey exchange is negotiated. If not specified, default parameters\nare used.<br>\nNOTE: The <code>dhfile</code> option is not supported by TLS 1.3.",
+                        "label": "dhfile",
+                        "type": "string"
+                    },
+                    "honor_cipher_order": {
+                        "default": true,
+                        "description": "TODO(Rquired description): honor_cipher_order",
+                        "label": "honor_cipher_order",
+                        "type": "boolean"
+                    },
+                    "client_renegotiation": {
+                        "default": true,
+                        "description": "\nIn protocols that support client-initiated renegotiation,\nthe cost of resources of such an operation is higher for the server than the client.\nThis can act as a vector for denial of service attacks.\nThe SSL application already takes measures to counter-act such attempts,\nbut client-initiated renegotiation can be strictly disabled by setting this option to false.\nThe default value is true. Note that disabling renegotiation can result in\nlong-lived connections becoming unusable due to limits on\nthe number of messages the underlying cipher suite can encipher.\n",
+                        "label": "client_renegotiation",
+                        "type": "boolean"
+                    },
+                    "handshake_timeout": {
+                        "default": "15s",
+                        "description": "Maximum time duration allowed for the handshake to complete",
+                        "label": "handshake_timeout",
+                        "type": "duration"
+                    }
+                },
+                "type": "object"
+            },
+            "modules.event_message": {
+                "properties": {
+                    "client_connected": {
+                        "default": false,
+                        "description": "Enable/disable client_connected event messages",
+                        "label": "client_connected",
+                        "type": "boolean"
+                    },
+                    "client_disconnected": {
+                        "default": false,
+                        "description": "Enable/disable client_disconnected event messages",
+                        "label": "client_disconnected",
+                        "type": "boolean"
+                    },
+                    "client_subscribed": {
+                        "default": false,
+                        "description": "Enable/disable client_subscribed event messages",
+                        "label": "client_subscribed",
+                        "type": "boolean"
+                    },
+                    "client_unsubscribed": {
+                        "default": false,
+                        "description": "Enable/disable client_unsubscribed event messages",
+                        "label": "client_unsubscribed",
+                        "type": "boolean"
+                    },
+                    "message_delivered": {
+                        "default": false,
+                        "description": "Enable/disable message_delivered event messages",
+                        "label": "message_delivered",
+                        "type": "boolean"
+                    },
+                    "message_acked": {
+                        "default": false,
+                        "description": "Enable/disable message_acked event messages",
+                        "label": "message_acked",
+                        "type": "boolean"
+                    },
+                    "message_dropped": {
+                        "default": false,
+                        "description": "Enable/disable message_dropped event messages",
+                        "label": "message_dropped",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "limiter.limiter_opts": {
+                "properties": {
+                    "global": {
+                        "description": "TODO(Rquired description): global",
+                        "label": "global",
+                        "$ref": "#/components/schemas/limiter.rate_burst"
+                    },
+                    "zone": {
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "properties": {
+                            "$zone name": {
+                                "$ref": "#/components/schemas/limiter.rate_burst"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "bucket": {
+                        "description": "Token bucket",
+                        "label": "bucket",
+                        "properties": {
+                            "$bucket_id": {
+                                "$ref": "#/components/schemas/limiter.bucket"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_conf_schema.log_rotation": {
+                "properties": {
+                    "enable": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "count": {
+                        "default": 10,
+                        "description": "TODO(Rquired description): count",
+                        "label": "count",
+                        "maximum": 2048,
+                        "minimum": 1,
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-builtin_db.authentication": {
+                "required": [
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "built-in-database"
+                        ],
+                        "type": "enum"
+                    },
+                    "user_id_type": {
+                        "default": "username",
+                        "description": "TODO(Rquired description): user_id_type",
+                        "label": "user_id_type",
+                        "symbols": [
+                            "clientid",
+                            "username"
+                        ],
+                        "type": "enum"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt_rw"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-jwt.ssl_enable": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "symbols": [
+                            true
+                        ],
+                        "type": "enum"
+                    },
+                    "cacertfile": {
+                        "description": "TODO(Rquired description): cacertfile",
+                        "label": "cacertfile",
+                        "type": "string"
+                    },
+                    "certfile": {
+                        "description": "TODO(Rquired description): certfile",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "TODO(Rquired description): keyfile",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "verify": {
+                        "default": "verify_none",
+                        "description": "TODO(Rquired description): verify",
+                        "label": "verify",
+                        "symbols": [
+                            "verify_peer",
+                            "verify_none"
+                        ],
+                        "type": "enum"
+                    },
+                    "server_name_indication": {
+                        "description": "TODO(Rquired description): server_name_indication",
+                        "label": "server_name_indication",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.broker_perf": {
+                "properties": {
+                    "route_lock_type": {
+                        "default": "key",
+                        "description": "TODO(Rquired description): route_lock_type",
+                        "label": "route_lock_type",
+                        "symbols": [
+                            "key",
+                            "tab",
+                            "global"
+                        ],
+                        "type": "enum"
+                    },
+                    "trie_compaction": {
+                        "default": true,
+                        "description": "TODO(Rquired description): trie_compaction",
+                        "label": "trie_compaction",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "auto_subscribe.topic": {
+                "properties": {
+                    "topic": {
+                        "description": "TODO(Rquired description): topic",
+                        "example": "/clientid/${clientid}/username/${username}/host/${host}/port/${port}",
+                        "label": "topic",
+                        "type": "string"
+                    },
+                    "qos": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): qos",
+                        "label": "qos",
+                        "symbols": [
+                            0,
+                            1,
+                            2
+                        ],
+                        "type": "enum"
+                    },
+                    "rh": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): rh",
+                        "label": "rh",
+                        "maximum": 2,
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "rap": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): rap",
+                        "label": "rap",
+                        "maximum": 1,
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "nl": {
+                        "default": 0,
+                        "description": "TODO(Rquired description): nl",
+                        "label": "nl",
+                        "maximum": 1,
+                        "minimum": 0,
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt_quic_listener": {
+                "required": [
+                    "bind"
+                ],
+                "properties": {
+                    "enabled": {
+                        "default": true,
+                        "description": "TODO(Rquired description): enabled",
+                        "label": "enabled",
+                        "type": "boolean"
+                    },
+                    "certfile": {
+                        "description": "TODO(Rquired description): certfile",
+                        "label": "certfile",
+                        "type": "string"
+                    },
+                    "keyfile": {
+                        "description": "TODO(Rquired description): keyfile",
+                        "label": "keyfile",
+                        "type": "string"
+                    },
+                    "ciphers": {
+                        "default": [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_CHACHA20_POLY1305_SHA256"
+                        ],
+                        "description": "This config holds TLS cipher suite names separated by comma,\nor as an array of strings. e.g.\n<code>\"TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256\"</code> or\n<code>[\"TLS_AES_256_GCM_SHA384\",\"TLS_AES_128_GCM_SHA256\"]</code>.\n<br>\nCiphers (and their ordering) define the way in which the\nclient and server encrypts information over the network connection.\nSelecting a good cipher suite is critical for the\napplication's data security, confidentiality and performance.\n\nThe names should be in OpenSSL string format (not RFC format).\nAll default values and examples provided by EMQX config\ndocumentation are all in OpenSSL format.<br>\n\nNOTE: Certain cipher suites are only compatible with\nspecific TLS <code>versions</code> ('tlsv1.1', 'tlsv1.2' or 'tlsv1.3')\nincompatible cipher suites will be silently dropped.\nFor instance, if only 'tlsv1.3' is given in the <code>versions</code>,\nconfiguring cipher suites for other versions will have no effect.\n<br>\n\nNOTE: PSK ciphers are suppressed by 'tlsv1.3' version config<br>\nIf PSK cipher suites are intended, 'tlsv1.3' should be disabled from <code>versions</code>.<br>\nPSK cipher suites: <code>\"RSA-PSK-AES256-GCM-SHA384,RSA-PSK-AES256-CBC-SHA384,\nRSA-PSK-AES128-GCM-SHA256,RSA-PSK-AES128-CBC-SHA256,\nRSA-PSK-AES256-CBC-SHA,RSA-PSK-AES128-CBC-SHA,\nRSA-PSK-DES-CBC3-SHA,RSA-PSK-RC4-SHA\"</code><br>\nNOTE: QUIC listener supports only 'tlsv1.3' ciphers<br>",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "ciphers",
+                        "type": "array"
+                    },
+                    "idle_timeout": {
+                        "default": "15s",
+                        "description": "TODO(Rquired description): idle_timeout",
+                        "label": "idle_timeout",
+                        "type": "duration"
+                    },
+                    "bind": {
+                        "description": "TODO(Rquired description): bind",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "ip_port"
+                            }
+                        ]
+                    },
+                    "acceptors": {
+                        "default": 16,
+                        "description": "TODO(Rquired description): acceptors",
+                        "label": "acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "mountpoint": {
+                        "default": "",
+                        "description": "TODO(Rquired description): mountpoint",
+                        "label": "mountpoint",
+                        "type": "string"
+                    },
+                    "zone": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "limiter": {
+                        "default": {},
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "properties": {
+                            "$ratelimit bucket's name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.listeners": {
+                "properties": {
+                    "tcp": {
+                        "description": "TCP listeners",
+                        "label": "tcp",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.mqtt_tcp_listener"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "ssl": {
+                        "description": "SSL listeners",
+                        "label": "ssl",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.mqtt_ssl_listener"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "ws": {
+                        "description": "HTTP websocket listeners",
+                        "label": "ws",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.mqtt_ws_listener"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "wss": {
+                        "description": "HTTPS websocket listeners",
+                        "label": "wss",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.mqtt_wss_listener"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "quic": {
+                        "description": "QUIC listeners",
+                        "label": "quic",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.mqtt_quic_listener"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-hash.pbkdf2": {
+                "properties": {
+                    "name": {
+                        "description": "TODO(Rquired description): name",
+                        "label": "name",
+                        "symbols": [
+                            "pbkdf2"
+                        ],
+                        "type": "enum"
+                    },
+                    "mac_fun": {
+                        "description": "TODO(Rquired description): mac_fun",
+                        "label": "mac_fun",
+                        "symbols": [
+                            "md4",
+                            "md5",
+                            "ripemd160",
+                            "sha",
+                            "sha224",
+                            "sha256",
+                            "sha384",
+                            "sha512"
+                        ],
+                        "type": "enum"
+                    },
+                    "iterations": {
+                        "description": "TODO(Rquired description): iterations",
+                        "label": "iterations",
+                        "type": "number"
+                    },
+                    "dk_length": {
+                        "description": "TODO(Rquired description): dk_length",
+                        "label": "dk_length",
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "authn-mongodb.sharded-cluster": {
+                "required": [
+                    "database",
+                    "servers",
+                    "backend",
+                    "mechanism"
+                ],
+                "properties": {
+                    "mechanism": {
+                        "description": "TODO(Rquired description): mechanism",
+                        "label": "mechanism",
+                        "symbols": [
+                            "password-based"
+                        ],
+                        "type": "enum"
+                    },
+                    "backend": {
+                        "description": "TODO(Rquired description): backend",
+                        "label": "backend",
+                        "symbols": [
+                            "mongodb"
+                        ],
+                        "type": "enum"
+                    },
+                    "collection": {
+                        "description": "TODO(Rquired description): collection",
+                        "label": "collection",
+                        "type": "string"
+                    },
+                    "selector": {
+                        "description": "TODO(Rquired description): selector",
+                        "label": "selector",
+                        "type": "string"
+                    },
+                    "password_hash_field": {
+                        "description": "TODO(Rquired description): password_hash_field",
+                        "label": "password_hash_field",
+                        "type": "string"
+                    },
+                    "salt_field": {
+                        "description": "TODO(Rquired description): salt_field",
+                        "label": "salt_field",
+                        "type": "string"
+                    },
+                    "is_superuser_field": {
+                        "description": "TODO(Rquired description): is_superuser_field",
+                        "label": "is_superuser_field",
+                        "type": "string"
+                    },
+                    "password_hash_algorithm": {
+                        "default": {
+                            "name": "sha256",
+                            "salt_position": "prefix"
+                        },
+                        "description": "TODO(Rquired description): password_hash_algorithm",
+                        "label": "password_hash_algorithm",
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/authn-hash.other_algorithms"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.pbkdf2"
+                            },
+                            {
+                                "$ref": "#/components/schemas/authn-hash.bcrypt"
+                            }
+                        ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "description": "Set to <code>false</code> to disable this auth provider",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "mongo_type": {
+                        "default": "sharded",
+                        "description": "TODO(Rquired description): mongo_type",
+                        "label": "mongo_type",
+                        "symbols": [
+                            "sharded"
+                        ],
+                        "type": "enum"
+                    },
+                    "servers": {
+                        "description": "A Node list for Cluster to connect to. The nodes should be split with ',', such as: 'Node[,Node]'<br>\nFor each Node should be:<br>\nThe IPv4 or IPv6 address or host name to connect to.<br>\nA host entry has the following form: 'Host[:Port]'<br>\nThe MongoDB default port 27017 is used if '[:Port]' isn't present",
+                        "label": "servers",
+                        "type": "string"
+                    },
+                    "w_mode": {
+                        "default": "unsafe",
+                        "description": "TODO(Rquired description): w_mode",
+                        "label": "w_mode",
+                        "symbols": [
+                            "unsafe",
+                            "safe"
+                        ],
+                        "type": "enum"
+                    },
+                    "srv_record": {
+                        "default": false,
+                        "description": "TODO(Rquired description): srv_record",
+                        "label": "srv_record",
+                        "type": "boolean"
+                    },
+                    "pool_size": {
+                        "default": 8,
+                        "description": "TODO(Rquired description): pool_size",
+                        "label": "pool_size",
+                        "type": "number"
+                    },
+                    "username": {
+                        "description": "TODO(Rquired description): username",
+                        "label": "username",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "TODO(Rquired description): password",
+                        "label": "password",
+                        "type": "string"
+                    },
+                    "auth_source": {
+                        "description": "TODO(Rquired description): auth_source",
+                        "label": "auth_source",
+                        "type": "string"
+                    },
+                    "database": {
+                        "description": "TODO(Rquired description): database",
+                        "label": "database",
+                        "type": "string"
+                    },
+                    "topology": {
+                        "description": "TODO(Rquired description): topology",
+                        "label": "topology",
+                        "$ref": "#/components/schemas/emqx_connector_mongo.topology"
+                    },
+                    "ssl": {
+                        "default": {
+                            "enable": false
+                        },
+                        "description": "TODO(Rquired description): ssl",
+                        "label": "ssl",
+                        "$ref": "#/components/schemas/emqx_schema.ssl_client_opts"
+                    }
+                },
+                "type": "object"
+            },
+            "limiter.bucket_aggregated": {
+                "properties": {
+                    "rate": {
+                        "description": "TODO(Rquired description): rate",
+                        "label": "rate",
+                        "type": "string"
+                    },
+                    "initial": {
+                        "default": "0",
+                        "description": "TODO(Rquired description): initial",
+                        "label": "initial",
+                        "type": "string"
+                    },
+                    "capacity": {
+                        "description": "TODO(Rquired description): capacity",
+                        "label": "capacity",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "dashboard.dashboard": {
+                "required": [
+                    "default_password",
+                    "default_username"
+                ],
+                "properties": {
+                    "listeners": {
+                        "description": "HTTP(s) listeners are identified by their protocol type and are\nused to serve dashboard UI and restful HTTP API.<br>\nListeners must have a unique combination of port number and IP address.<br>\nFor example, an HTTP listener can listen on all configured IP addresses\non a given port for a machine by specifying the IP address 0.0.0.0.<br>\nAlternatively, the HTTP listener can specify a unique IP address for each listener,\nbut use the same port.\n",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/dashboard.https"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/dashboard.http"
+                                }
+                            ]
+                        },
+                        "label": "listeners",
+                        "type": "array"
+                    },
+                    "default_username": {
+                        "default": "admin",
+                        "description": "TODO(Rquired description): default_username",
+                        "label": "default_username",
+                        "type": "string"
+                    },
+                    "default_password": {
+                        "default": "public",
+                        "description": "\nThe initial default password for dashboard 'admin' user.\nFor safety, it should be changed as soon as possible.",
+                        "label": "default_password",
+                        "type": "string"
+                    },
+                    "sample_interval": {
+                        "default": "10s",
+                        "description": "TODO(Rquired description): sample_interval",
+                        "label": "sample_interval",
+                        "type": "duration"
+                    },
+                    "token_expired_time": {
+                        "default": "30m",
+                        "description": "TODO(Rquired description): token_expired_time",
+                        "label": "token_expired_time",
+                        "type": "duration"
+                    },
+                    "cors": {
+                        "default": false,
+                        "description": "Support Cross-Origin Resource Sharing (CORS).\nAllows a server to indicate any origins (domain, scheme, or port) other than\nits own from which a browser should permit loading resources.",
+                        "label": "cors",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "emqx_schema.mqtt_ws_listener": {
+                "required": [
+                    "bind"
+                ],
+                "properties": {
+                    "tcp": {
+                        "description": "TODO(Rquired description): tcp",
+                        "label": "tcp",
+                        "$ref": "#/components/schemas/emqx_schema.tcp_opts"
+                    },
+                    "websocket": {
+                        "description": "TODO(Rquired description): websocket",
+                        "label": "websocket",
+                        "$ref": "#/components/schemas/emqx_schema.ws_opts"
+                    },
+                    "bind": {
+                        "description": "TODO(Rquired description): bind",
+                        "label": "bind",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "ip_port"
+                            }
+                        ]
+                    },
+                    "acceptors": {
+                        "default": 16,
+                        "description": "TODO(Rquired description): acceptors",
+                        "label": "acceptors",
+                        "type": "number"
+                    },
+                    "max_connections": {
+                        "default": "infinity",
+                        "description": "TODO(Rquired description): max_connections",
+                        "label": "max_connections",
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "symbols": [
+                                    "infinity"
+                                ],
+                                "type": "enum"
+                            }
+                        ]
+                    },
+                    "mountpoint": {
+                        "default": "",
+                        "description": "TODO(Rquired description): mountpoint",
+                        "label": "mountpoint",
+                        "type": "string"
+                    },
+                    "zone": {
+                        "default": "default",
+                        "description": "TODO(Rquired description): zone",
+                        "label": "zone",
+                        "type": "string"
+                    },
+                    "limiter": {
+                        "default": {},
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "properties": {
+                            "$ratelimit bucket's name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "access_rules": {
+                        "description": "TODO(Rquired description): access_rules",
+                        "items": {
+                            "type": "string"
+                        },
+                        "label": "access_rules",
+                        "type": "array"
+                    },
+                    "proxy_protocol": {
+                        "default": false,
+                        "description": "TODO(Rquired description): proxy_protocol",
+                        "label": "proxy_protocol",
+                        "type": "boolean"
+                    },
+                    "proxy_protocol_timeout": {
+                        "description": "TODO(Rquired description): proxy_protocol_timeout",
+                        "label": "proxy_protocol_timeout",
+                        "type": "duration"
+                    },
+                    "authentication": {
+                        "description": "Per-listener authentication override\nAuthentication can be one single authenticator instance or a chain of authenticators as an array.\nWhen authenticating a login (username, client ID, etc.) the authenticators are checked\nin the configured order.<br>\n",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/authn-scram-builtin_db.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.jwks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.public-key"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-jwt.hmac-based"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.post"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-http.get"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.sentinel"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-redis.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.sharded-cluster"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.replica-set"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mongodb.standalone"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-postgresql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-mysql.authentication"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/authn-builtin_db.authentication"
+                                }
+                            ]
+                        },
+                        "label": "authentication",
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "zone.force_shutdown": {
+                "properties": {
+                    "enable": {
+                        "description": "TODO(Rquired description): enable",
+                        "label": "enable",
+                        "type": "boolean"
+                    },
+                    "max_message_queue_len": {
+                        "description": "TODO(Rquired description): max_message_queue_len",
+                        "label": "max_message_queue_len",
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "max_heap_size": {
+                        "description": "TODO(Rquired description): max_heap_size",
+                        "label": "max_heap_size",
+                        "type": "byteSize"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "EMQX Hot Conf Schema",
+        "version": "0.1.0"
+    },
+    "paths": {
+        "/configs": {
+            "get": {
+                "properties": {
+                    "listeners": {
+                        "description": "MQTT listeners identified by their protocol type and assigned names",
+                        "label": "listeners",
+                        "$ref": "#/components/schemas/emqx_schema.listeners"
+                    },
+                    "zones": {
+                        "description": "A zone is a set of configs grouped by the zone <code>name</code>.<br>\nFor flexible configuration mapping, the <code>name</code>\ncan be set to a listener's <code>zone</code> config.<br>\nNOTE: A built-in zone named <code>default</code> is auto created\nand can not be deleted.",
+                        "label": "zones",
+                        "properties": {
+                            "$name": {
+                                "$ref": "#/components/schemas/emqx_schema.zone"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "mqtt": {
+                        "description": "Global MQTT configuration.<br>\nThe configs here work as default values which can be overridden\nin <code>zone</code> configs",
+                        "label": "mqtt",
+                        "$ref": "#/components/schemas/emqx_schema.mqtt"
+                    },
+                    "node": {
+                        "description": "Node name, cookie, config & data directories and the Erlang virtual machine (BEAM) boot parameters.",
+                        "label": "node",
+                        "$ref": "#/components/schemas/configuration.node"
+                    },
+                    "cluster": {
+                        "description": "EMQX nodes can form a cluster to scale up the total capacity.<br>Here holds the configs to instruct how individual nodes can discover each other.",
+                        "label": "cluster",
+                        "$ref": "#/components/schemas/configuration.cluster"
+                    },
+                    "log": {
+                        "description": "Configure logging backends (to console or to file), and logging level for each logger backend.",
+                        "label": "log",
+                        "$ref": "#/components/schemas/configuration.log"
+                    },
+                    "broker": {
+                        "description": "TODO(Rquired description): broker",
+                        "label": "broker",
+                        "$ref": "#/components/schemas/emqx_schema.broker"
+                    },
+                    "rate_limit": {
+                        "description": "TODO(Rquired description): rate_limit",
+                        "label": "rate_limit",
+                        "$ref": "#/components/schemas/emqx_schema.rate_limit"
+                    },
+                    "force_shutdown": {
+                        "description": "TODO(Rquired description): force_shutdown",
+                        "label": "force_shutdown",
+                        "$ref": "#/components/schemas/emqx_schema.force_shutdown"
+                    },
+                    "overload_protection": {
+                        "description": "TODO(Rquired description): overload_protection",
+                        "label": "overload_protection",
+                        "$ref": "#/components/schemas/emqx_schema.overload_protection"
+                    },
+                    "force_gc": {
+                        "description": "Force the MQTT connection process garbage collection after\nthis number of messages or bytes have passed through.",
+                        "label": "force_gc",
+                        "$ref": "#/components/schemas/emqx_schema.force_gc"
+                    },
+                    "conn_congestion": {
+                        "description": "TODO(Rquired description): conn_congestion",
+                        "label": "conn_congestion",
+                        "$ref": "#/components/schemas/emqx_schema.conn_congestion"
+                    },
+                    "stats": {
+                        "description": "TODO(Rquired description): stats",
+                        "label": "stats",
+                        "$ref": "#/components/schemas/emqx_schema.stats"
+                    },
+                    "sysmon": {
+                        "description": "TODO(Rquired description): sysmon",
+                        "label": "sysmon",
+                        "$ref": "#/components/schemas/emqx_schema.sysmon"
+                    },
+                    "alarm": {
+                        "description": "TODO(Rquired description): alarm",
+                        "label": "alarm",
+                        "$ref": "#/components/schemas/emqx_schema.alarm"
+                    },
+                    "flapping_detect": {
+                        "description": "TODO(Rquired description): flapping_detect",
+                        "label": "flapping_detect",
+                        "$ref": "#/components/schemas/emqx_schema.flapping_detect"
+                    },
+                    "persistent_session_store": {
+                        "description": "TODO(Rquired description): persistent_session_store",
+                        "label": "persistent_session_store",
+                        "$ref": "#/components/schemas/emqx_schema.persistent_session_store"
+                    },
+                    "trace": {
+                        "description": "\nReal-time filtering logs for the ClientID or Topic or IP for debugging.\n",
+                        "label": "trace",
+                        "$ref": "#/components/schemas/emqx_schema.trace"
+                    },
+                    "retainer": {
+                        "description": "TODO(Rquired description): retainer",
+                        "label": "retainer",
+                        "$ref": "#/components/schemas/retainer.retainer"
+                    },
+                    "statsd": {
+                        "description": "TODO(Rquired description): statsd",
+                        "label": "statsd",
+                        "$ref": "#/components/schemas/statsd.statsd"
+                    },
+                    "auto_subscribe": {
+                        "description": "TODO(Rquired description): auto_subscribe",
+                        "label": "auto_subscribe",
+                        "$ref": "#/components/schemas/auto_subscribe.auto_subscribe"
+                    },
+                    "delayed": {
+                        "description": "TODO(Rquired description): delayed",
+                        "label": "delayed",
+                        "$ref": "#/components/schemas/modules.delayed"
+                    },
+                    "telemetry": {
+                        "description": "TODO(Rquired description): telemetry",
+                        "label": "telemetry",
+                        "$ref": "#/components/schemas/modules.telemetry"
+                    },
+                    "event_message": {
+                        "description": "TODO(Rquired description): event_message",
+                        "label": "event_message",
+                        "$ref": "#/components/schemas/modules.event_message"
+                    },
+                    "rewrite": {
+                        "description": "TODO(Rquired description): rewrite",
+                        "items": {
+                            "$ref": "#/components/schemas/modules.rewrite"
+                        },
+                        "label": "rewrite",
+                        "type": "array"
+                    },
+                    "topic_metrics": {
+                        "description": "TODO(Rquired description): topic_metrics",
+                        "items": {
+                            "$ref": "#/components/schemas/modules.topic_metrics"
+                        },
+                        "label": "topic_metrics",
+                        "type": "array"
+                    },
+                    "dashboard": {
+                        "description": "TODO(Rquired description): dashboard",
+                        "label": "dashboard",
+                        "$ref": "#/components/schemas/dashboard.dashboard"
+                    },
+                    "prometheus": {
+                        "description": "TODO(Rquired description): prometheus",
+                        "label": "prometheus",
+                        "$ref": "#/components/schemas/prometheus.prometheus"
+                    },
+                    "limiter": {
+                        "description": "TODO(Rquired description): limiter",
+                        "label": "limiter",
+                        "$ref": "#/components/schemas/limiter.limiter"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "/configs/alarm": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.alarm"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.alarm"
+            }
+        },
+        "/configs/auto_subscribe": {
+            "get": {
+                "$ref": "#/components/schemas/auto_subscribe.auto_subscribe"
+            },
+            "put": {
+                "$ref": "#/components/schemas/auto_subscribe.auto_subscribe"
+            }
+        },
+        "/configs/broker": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.broker"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.broker"
+            }
+        },
+        "/configs/cluster": {
+            "get": {
+                "$ref": "#/components/schemas/configuration.cluster"
+            },
+            "put": {
+                "$ref": "#/components/schemas/configuration.cluster"
+            }
+        },
+        "/configs/conn_congestion": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.conn_congestion"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.conn_congestion"
+            }
+        },
+        "/configs/dashboard": {
+            "get": {
+                "$ref": "#/components/schemas/dashboard.dashboard"
+            },
+            "put": {
+                "$ref": "#/components/schemas/dashboard.dashboard"
+            }
+        },
+        "/configs/delayed": {
+            "get": {
+                "$ref": "#/components/schemas/modules.delayed"
+            },
+            "put": {
+                "$ref": "#/components/schemas/modules.delayed"
+            }
+        },
+        "/configs/event_message": {
+            "get": {
+                "$ref": "#/components/schemas/modules.event_message"
+            },
+            "put": {
+                "$ref": "#/components/schemas/modules.event_message"
+            }
+        },
+        "/configs/flapping_detect": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.flapping_detect"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.flapping_detect"
+            }
+        },
+        "/configs/force_gc": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.force_gc"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.force_gc"
+            }
+        },
+        "/configs/force_shutdown": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.force_shutdown"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.force_shutdown"
+            }
+        },
+        "/configs/limiter": {
+            "get": {
+                "$ref": "#/components/schemas/limiter.limiter"
+            },
+            "put": {
+                "$ref": "#/components/schemas/limiter.limiter"
+            }
+        },
+        "/configs/listeners": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.listeners"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.listeners"
+            }
+        },
+        "/configs/log": {
+            "get": {
+                "$ref": "#/components/schemas/configuration.log"
+            },
+            "put": {
+                "$ref": "#/components/schemas/configuration.log"
+            }
+        },
+        "/configs/mqtt": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.mqtt"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.mqtt"
+            }
+        },
+        "/configs/node": {
+            "get": {
+                "$ref": "#/components/schemas/configuration.node"
+            },
+            "put": {
+                "$ref": "#/components/schemas/configuration.node"
+            }
+        },
+        "/configs/overload_protection": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.overload_protection"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.overload_protection"
+            }
+        },
+        "/configs/persistent_session_store": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.persistent_session_store"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.persistent_session_store"
+            }
+        },
+        "/configs/prometheus": {
+            "get": {
+                "$ref": "#/components/schemas/prometheus.prometheus"
+            },
+            "put": {
+                "$ref": "#/components/schemas/prometheus.prometheus"
+            }
+        },
+        "/configs/rate_limit": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.rate_limit"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.rate_limit"
+            }
+        },
+        "/configs/retainer": {
+            "get": {
+                "$ref": "#/components/schemas/retainer.retainer"
+            },
+            "put": {
+                "$ref": "#/components/schemas/retainer.retainer"
+            }
+        },
+        "/configs/rewrite": {
+            "get": {
+                "items": {
+                    "$ref": "#/components/schemas/modules.rewrite"
+                },
+                "type": "array"
+            },
+            "put": {
+                "items": {
+                    "$ref": "#/components/schemas/modules.rewrite"
+                },
+                "type": "array"
+            }
+        },
+        "/configs/stats": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.stats"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.stats"
+            }
+        },
+        "/configs/statsd": {
+            "get": {
+                "$ref": "#/components/schemas/statsd.statsd"
+            },
+            "put": {
+                "$ref": "#/components/schemas/statsd.statsd"
+            }
+        },
+        "/configs/sysmon": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.sysmon"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.sysmon"
+            }
+        },
+        "/configs/telemetry": {
+            "get": {
+                "$ref": "#/components/schemas/modules.telemetry"
+            },
+            "put": {
+                "$ref": "#/components/schemas/modules.telemetry"
+            }
+        },
+        "/configs/topic_metrics": {
+            "get": {
+                "items": {
+                    "$ref": "#/components/schemas/modules.topic_metrics"
+                },
+                "type": "array"
+            },
+            "put": {
+                "items": {
+                    "$ref": "#/components/schemas/modules.topic_metrics"
+                },
+                "type": "array"
+            }
+        },
+        "/configs/trace": {
+            "get": {
+                "$ref": "#/components/schemas/emqx_schema.trace"
+            },
+            "put": {
+                "$ref": "#/components/schemas/emqx_schema.trace"
+            }
+        },
+        "/configs/zones": {
+            "get": {
+                "properties": {
+                    "$name": {
+                        "$ref": "#/components/schemas/emqx_schema.zone"
+                    }
+                },
+                "type": "object"
+            },
+            "put": {
+                "properties": {
+                    "$name": {
+                        "$ref": "#/components/schemas/emqx_schema.zone"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "/configs_reset/:rootname": {}
+    }
+}

--- a/src/components/SchemaForm.vue
+++ b/src/components/SchemaForm.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="schema-form">{{ components }}</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import useSchemaForm from '@/hooks/Config/useSchemaForm'
+
+export default defineComponent({
+  name: 'Cluster',
+  props: {
+    path: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { components } = useSchemaForm(props.path)
+    return {
+      components,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/hooks/Config/useSchemaForm.ts
+++ b/src/hooks/Config/useSchemaForm.ts
@@ -1,0 +1,92 @@
+import { inject, ref, Ref, watch } from 'vue'
+import _ from 'lodash'
+
+type InjectSchema = Ref<any> | undefined
+
+interface Properties {
+  [key: string]: {
+    $ref?: string
+    description: string
+    label: string
+    default: any
+    symbols?: string[]
+    type: string
+    parent?: string
+    properties?: Properties
+  }
+}
+
+interface Component {
+  type: string
+  properties: Properties
+}
+
+interface Components {
+  schemas: {
+    [key: string]: {
+      type: string
+      properties: Properties
+      required?: string[]
+    }
+  }
+}
+
+interface Schema {
+  components: Components
+  paths: {
+    [key: string]: {
+      get: {
+        $ref: string
+      }
+      put: {
+        $ref: string
+      }
+    }
+  }
+}
+
+export default function useSchemaForm(path: string): {
+  schema: InjectSchema
+  components: Ref
+} {
+  const schema: InjectSchema = inject('schema')
+  const components = ref<Properties>({})
+  watch(
+    () => schema?.value,
+    (val) => {
+      handleInjectChanged(val)
+    },
+  )
+  const filter = (ref: string) => ref.replace('#/', '').split('/')
+  // https://www.lodashjs.com/docs/lodash.get
+  const getComponentByRef = (data: Schema, ref: string): Component => _.get(data, filter(ref), {})
+  const getComponents = (data: Schema) => {
+    const transComponents = (component: Component) => {
+      const res: Properties = {}
+      const { properties, type } = component
+      if (type === 'object' && properties) {
+        Object.keys(properties).forEach((key) => {
+          const property = properties[key]
+          const { $ref } = property
+          if ($ref) {
+            const component = getComponentByRef(data, $ref)
+            property.properties = transComponents(component)
+          }
+          res[key] = property
+        })
+      }
+      return res
+    }
+    const { $ref } = data.paths[path].get
+    const component = getComponentByRef(data, $ref)
+    const components = transComponents(component)
+    return components
+  }
+  const handleInjectChanged = (data: Schema) => {
+    components.value = getComponents(data)
+  }
+  return {
+    schema,
+    components,
+  }
+}

--- a/src/i18n/BasicConfig.js
+++ b/src/i18n/BasicConfig.js
@@ -1,0 +1,6 @@
+export default {
+  cluster: {
+    zh: '集群',
+    en: 'Cluster',
+  },
+}

--- a/src/i18n/components.js
+++ b/src/i18n/components.js
@@ -179,6 +179,10 @@ export default {
     zh: '配置',
     en: 'Configuration',
   },
+  'basic-config': {
+    zh: '基础配置',
+    en: 'Basic Config',
+  },
   advanced: {
     zh: 'MQTT高级特性',
     en: 'MQTT Advanced Feat.',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,6 +17,7 @@ import ClientDetails from '@/views/Clients/ClientDetails.vue'
 import Topics from '@/views/Topics/Topics.vue'
 import Subscriptions from '@/views/Subscriptions/Subscriptions.vue'
 import Advanced from '@/views/Config/Advanced/Advanced.vue'
+import BasicConfig from '@/views/Config/BasicConfig/BasicConfig.vue'
 import Users from '@/views/General/Users.vue'
 import Blacklist from '@/views/General/Blacklist.vue'
 import Gateway from '@/views/Gateway/Gateway.vue'
@@ -428,6 +429,21 @@ export const routes: Array<RouteRecordRaw> = [
             component: ConnectorCreate,
           },
         ],
+      },
+    ],
+  },
+  {
+    path: '/basic-config',
+    component: Layout,
+    meta: {
+      hideKey: 'basic-config',
+      authRequired: true,
+    },
+    children: [
+      {
+        path: '',
+        name: 'basic-config',
+        component: BasicConfig,
       },
     ],
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,9 +11,6 @@ export default createStore({
     edition: localStorage.getItem('edition'),
   },
   actions: {
-    UPDATE_MODULE({ commit }, selectedModule) {
-      commit('UPDATE_MODULE', selectedModule)
-    },
     SET_ALERT_COUNT({ commit }, count = 0) {
       commit('SET_ALERT_COUNT', count)
     },
@@ -31,10 +28,6 @@ export default createStore({
     },
   },
   mutations: {
-    UPDATE_MODULE(state, selectedModule) {
-      localStorage.setItem('selectedModule', JSON.stringify(selectedModule))
-      state.selectedModule = selectedModule
-    },
     SET_ALERT_COUNT(state, count) {
       state.alertCount = count
     },

--- a/src/views/Base/LeftBar.vue
+++ b/src/views/Base/LeftBar.vue
@@ -138,6 +138,10 @@ export default {
 
     let config = [
       {
+        title: 'basic-config',
+        path: '/basic-config',
+      },
+      {
         title: 'advanced',
         path: '/advanced',
       },

--- a/src/views/Config/BasicConfig/BasicConfig.vue
+++ b/src/views/Config/BasicConfig/BasicConfig.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="basic-config">
+    <SubTabMenu
+      v-slot="{ pane }"
+      :panes="panes"
+      i18nKeyword="BasicConfig"
+      @tab-click="handleClickTab"
+    >
+      <component :is="pane" class="item-page" :ref="(el) => setPaneRef(el, pane)"></component>
+    </SubTabMenu>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, provide, ref } from 'vue'
+import axios from 'axios'
+import SubTabMenu from '@/components/SubTabMenu.vue'
+import useSubTabMenu from '@/hooks/useSubTabMenu'
+import Cluster from './components/Cluster.vue'
+
+export default defineComponent({
+  name: 'BasicConfig',
+  components: {
+    SubTabMenu,
+    Cluster,
+  },
+  setup() {
+    const panes = ref(['cluster'])
+    const { handleClickTab, setPaneRef } = useSubTabMenu(panes.value)
+    const schemaRequest = axios.create({
+      baseURL: '',
+    })
+    const schema = ref({})
+    provide('schema', schema)
+    const loadSchemaConfig = async () => {
+      const res = await schemaRequest.get('static/schema.json')
+      if (res.data) {
+        schema.value = res.data
+      }
+    }
+    loadSchemaConfig()
+    return {
+      panes,
+      schema,
+      handleClickTab,
+      setPaneRef,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/Config/BasicConfig/components/Cluster.vue
+++ b/src/views/Config/BasicConfig/components/Cluster.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="no-tab-wrapper cluster">
+    <schema-form path="/configs/cluster"></schema-form>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import SchemaForm from '@/components/SchemaForm.vue'
+
+export default defineComponent({
+  name: 'Cluster',
+  components: {
+    SchemaForm,
+  },
+  setup() {
+    const loadData = () => {}
+    const reloading = () => {
+      loadData()
+    }
+    return {
+      reloading,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
@Kinplemelon Note:

1. scheam.json is the default config schema form render file, the emqx build will replace it with the new file.
2. Currently in this PR it's just a matter of building the schema.json content into a data format that works well on the front end and printing it to the page

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/21299158/156145737-66525f0c-90d7-4271-8729-5c681ba3a21f.png">