### PR TITLE
feat(clients & subs): some key fields are displayed with spaces reserved

### DIFF
--- a/src/common/auth.ts
+++ b/src/common/auth.ts
@@ -7,26 +7,16 @@ import { UserInfo } from '@/types/common'
  * key for set/get local storage
  */
 const USER_INFO_KEY = 'uK'
-const ENCRYPTION_KEY = 'eK'
+const ENCRYPTION_KEY = 'YWSCVU8Z55N9N1G1'
 
 const getUserInfoKey = () => {
   return localStorage.getItem(USER_INFO_KEY)
 }
 
 const setUserInfoKey = () => {
-  const uk = createRandomString(8)
+  const uk = createRandomString(4)
   localStorage.setItem(USER_INFO_KEY, uk)
   return uk
-}
-
-const getEncryptionKey = () => {
-  return localStorage.getItem(ENCRYPTION_KEY)
-}
-
-const setEncryptionKey = () => {
-  const ek = createRandomString(10)
-  localStorage.setItem(ENCRYPTION_KEY, ek)
-  return ek
 }
 
 const encryptSafely = (str: string, key: string) => {
@@ -55,22 +45,20 @@ const decryptSafely = (str: string, key: string) => {
  */
 export const setUser = (user: UserInfo): void => {
   const uk = setUserInfoKey()
-  const ek = setEncryptionKey()
-  const userInfo = encryptSafely(stringifyObjSafely(user), ek)
+  const userInfo = encryptSafely(stringifyObjSafely(user), ENCRYPTION_KEY)
   localStorage.setItem(uk, userInfo as string)
 }
 
 export const getUser = (): undefined | UserInfo => {
   const uk = getUserInfoKey()
-  const ek = getEncryptionKey()
-  if (!uk || !ek) {
+  if (!uk) {
     return
   }
   const user = localStorage.getItem(uk)
   if (!user) {
     return
   }
-  const userInfoStr = decryptSafely(user, ek) as string
+  const userInfoStr = decryptSafely(user, ENCRYPTION_KEY) as string
   const userInfo = parseJSONSafely(userInfoStr) as UserInfo
   return userInfo
 }
@@ -82,5 +70,4 @@ export const removeUser = (): void => {
   }
   localStorage.removeItem(uk)
   localStorage.removeItem(USER_INFO_KEY)
-  localStorage.removeItem(ENCRYPTION_KEY)
 }

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -7,7 +7,6 @@ import { Properties, Property } from '@/types/schemaForm'
 import { Setting } from '@element-plus/icons-vue'
 import _ from 'lodash'
 import { computed, defineComponent, onMounted, PropType, ref, watch, watchEffect } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import ArrayEditor from './ArrayEditor.vue'
 import InputWithUnit from './InputWithUnit.vue'
@@ -17,6 +16,7 @@ import useSSL from '@/hooks/useSSL'
 import InfoTooltip from '@/components/InfoTooltip.vue'
 import Monaco from '@/components/Monaco.vue'
 import { createRandomString, escapeCode, transLink } from '@/common/tools'
+import useI18nTl from '@/hooks/useI18nTl'
 
 interface FormItemMeta {
   col: number
@@ -124,7 +124,7 @@ const SchemaForm = defineComponent({
 
     const formCom = ref()
 
-    const { t } = useI18n()
+    const { t, tl } = useI18nTl('BasicConfig')
 
     // Record<string(type), Array<string>>
     const customGroups: Record<string, Array<string>> = {
@@ -145,18 +145,18 @@ const SchemaForm = defineComponent({
       Object.keys(properties).forEach((key) => {
         const prop = properties[key]
         if (prop.properties) {
-          _groups.push(prop.label)
+          _groups.push(key)
         } else {
           hasBasicInfo = true
         }
       })
       if (hasBasicInfo) {
-        _groups = [t('BasicConfig.basic'), ..._groups]
+        _groups = [tl('basic'), ..._groups]
       }
       return _groups
     })
 
-    const currentGroup = ref(groups.value[0] || t('BasicConfig.basic'))
+    const currentGroup = ref(groups.value[0] || tl('basic'))
 
     watch(
       () => props.form,
@@ -180,7 +180,7 @@ const SchemaForm = defineComponent({
     })
 
     const initCurrentGroup = () => {
-      currentGroup.value = groups.value[0] || t('BasicConfig.basic')
+      currentGroup.value = groups.value[0] || tl('basic')
     }
 
     const validate = () => {
@@ -474,7 +474,7 @@ const SchemaForm = defineComponent({
           {property.readOnly ? (
             <el-tooltip
               popper-class="read-only-tooltip"
-              content={t('BasicConfig.readOnlyTip')}
+              content={tl('readOnlyTip')}
               placement="right"
               effect="dark"
             >
@@ -527,7 +527,7 @@ const SchemaForm = defineComponent({
       const groupTabs = groups.value.map((group: string) => (
         // There is no content inside the tab pane, and the renderSchemaForm function
         // is retriggered after the tab switch to change the content
-        <el-tab-pane label={group} name={group} />
+        <el-tab-pane label={tl(group)} name={group} />
       ))
       let tabs: JSX.Element | null = (
         <el-tabs type="card" v-model={currentGroup.value} class="group-tabs">
@@ -619,7 +619,7 @@ const SchemaForm = defineComponent({
       for (const key in properties) {
         const propItem = properties[key]
         if (propItem.properties) {
-          if (currentGroup.value === propItem.label) {
+          if (currentGroup.value === propItem.path) {
             // for hot configuration
             _properties = propItem?.properties
             break

--- a/src/i18n/BasicConfig.js
+++ b/src/i18n/BasicConfig.js
@@ -159,4 +159,21 @@ export default {
     zh: '代理协议超时',
     en: 'Proxy Protocol Timeout',
   },
+  /* Tab Name */
+  vm: {
+    zh: '虚拟机',
+    en: 'Erlang VM',
+  },
+  os: {
+    zh: '操作系统',
+    en: 'OS',
+  },
+  console_handler: {
+    zh: '控制台',
+    en: 'Console',
+  },
+  file_handlers: {
+    zh: '文件',
+    en: 'File',
+  },
 }

--- a/src/style/common.scss
+++ b/src/style/common.scss
@@ -682,3 +682,7 @@ input:disabled {
     }
   }
 }
+
+.keep-spaces {
+  white-space: pre-wrap;
+}

--- a/src/views/Clients/ClientDetails.vue
+++ b/src/views/Clients/ClientDetails.vue
@@ -68,7 +68,7 @@
                   <span>{{ record.ip_address + ':' + record.port }}</span>
                 </span>
                 <span v-else>
-                  <span>{{ record[item] }}</span>
+                  <span class="keep-spaces">{{ record[item] }}</span>
                 </span>
               </el-descriptions-item>
             </el-descriptions>
@@ -129,7 +129,11 @@
         </div>
       </div>
       <el-table class="subs" :data="subscriptions" v-loading.lock="subsLockTable" key="topic">
-        <el-table-column prop="topic" show-overflow-tooltip :label="$t('Base.topic')" />
+        <el-table-column prop="topic" show-overflow-tooltip :label="$t('Base.topic')">
+          <template #default="{ row }">
+            <span class="keep-spaces">{{ row.topic }}</span>
+          </template>
+        </el-table-column>
         <el-table-column prop="qos" min-width="110px" label="QoS" />
         <template v-if="isMQTTVersion5">
           <el-table-column prop="nl" :label="tl('noLocal')">

--- a/src/views/Clients/Clients.vue
+++ b/src/views/Clients/Clients.vue
@@ -92,14 +92,17 @@
               name: 'connection-detail',
               params: { clientId: row.clientid },
             }"
-            class="table-data-without-break"
+            class="table-data-without-break keep-spaces"
+            >{{ row.clientid }}</router-link
           >
-            {{ row.clientid }}
-          </router-link>
         </template>
       </el-table-column>
 
-      <el-table-column prop="username" min-width="120" :label="$t('Clients.username')" />
+      <el-table-column prop="username" min-width="120" :label="$t('Clients.username')">
+        <template #default="{ row }">
+          <span class="keep-spaces">{{ row.username }}</span>
+        </template>
+      </el-table-column>
       <el-table-column
         prop="connected"
         :min-width="store.state.lang === 'en' ? 140 : 90"

--- a/src/views/Config/Monitoring/AlarmSettings.vue
+++ b/src/views/Config/Monitoring/AlarmSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="alarm-settings">
+  <div class="alarm-settings app-wrapper">
     <el-card class="config-card">
       <schema-form
         :according-to="{ path: '/configs/sysmon' }"

--- a/src/views/Subscriptions/Subscriptions.vue
+++ b/src/views/Subscriptions/Subscriptions.vue
@@ -75,12 +75,12 @@
     <el-table :data="tableData" v-loading.lock="lockTable">
       <el-table-column prop="clientid" :label="$t('Clients.clientId')" show-overflow-tooltip>
         <template #default="{ row }">
-          <p class="table-data-without-break">{{ row.clientid }}</p>
+          <p class="table-data-without-break keep-spaces">{{ row.clientid }}</p>
         </template>
       </el-table-column>
       <el-table-column prop="topic" :label="$t('Subs.topic')" show-overflow-tooltip>
         <template #default="{ row }">
-          <p class="table-data-without-break">{{ row.topic }}</p>
+          <p class="table-data-without-break keep-spaces">{{ row.topic }}</p>
         </template>
       </el-table-column>
       <el-table-column prop="qos" label="QoS" />

--- a/src/views/Topics/Topics.vue
+++ b/src/views/Topics/Topics.vue
@@ -24,7 +24,7 @@
     <el-table :data="tableData" v-loading.lock="lockTable">
       <el-table-column prop="topic" :label="$t('Topics.topic')" show-overflow-tooltip>
         <template #default="{ row }">
-          <p class="table-data-without-break">{{ row.topic }}</p>
+          <p class="table-data-without-break keep-spaces">{{ row.topic }}</p>
         </template>
       </el-table-column>
       <el-table-column prop="node" :label="$t('Clients.node')" />


### PR DESCRIPTION
The client id is still not visible to clients with spaces, but at least it is now possible to click into the details pageÎ

https://user-images.githubusercontent.com/26165221/195291096-474a1382-ef4d-4ca7-bd8a-8f21d5001234.mov

