### PR TITLE
refactor(bridge): remove `enable_batch`

### DIFF
--- a/src/hooks/Rule/bridge/useResourceOpt.ts
+++ b/src/hooks/Rule/bridge/useResourceOpt.ts
@@ -24,7 +24,6 @@ export default (): {
     if (config.batch) {
       formData = {
         ...formData,
-        enable_batch: false,
         batch_size: 100,
         batch_time: '10ms',
       }

--- a/src/types/rule.d.ts
+++ b/src/types/rule.d.ts
@@ -62,7 +62,6 @@ export interface ResourceOpt {
 
   max_queue_bytes: string
 
-  enable_batch?: boolean
   batch_size?: number
   batch_time?: string
 }


### PR DESCRIPTION
Modify the return value of the method, which has no effect on the two data bridges of the open source version