### PR TITLE
chore: remove root `request_timeout` from GCP PubSub bridge (e5.0)

### DIFF
--- a/src/hooks/Rule/bridge/useSchemaBridgePropsLayout.ts
+++ b/src/hooks/Rule/bridge/useSchemaBridgePropsLayout.ts
@@ -82,7 +82,7 @@ export default (
       ),
     },
     [BridgeType.GCP]: {
-      ...createOrderObj(['pubsub_topic', 'request_timeout', 'pool_size', 'pipelining'], 1),
+      ...createOrderObj(['pubsub_topic', 'pool_size', 'pipelining'], 1),
     },
     [BridgeType.MongoDB]: {
       ...createOrderObj(

--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeHttpConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeHttpConfig.vue
@@ -172,7 +172,7 @@ export default defineComponent({
         pool_size: 4,
         enable_pipelining: 100,
         connect_timeout: '5s',
-        request_timeout: '5s',
+        request_timeout: '15s',
         resource_opts: createDefaultResourceOptsForm({ inflight: true }),
         ssl: createSSLForm(),
       } as HTTPBridge)


### PR DESCRIPTION
`resource_opts` already have such option, and keeping both could lead to inconsistent behavior.

Related PR: https://github.com/emqx/emqx/pull/10051