### PR TITLE
refactor(i18n): simplify overview tab label to avoid repetition

### DIFF
--- a/src/i18n/components.ts
+++ b/src/i18n/components.ts
@@ -429,8 +429,8 @@ export default {
     en: 'Create Rule',
   },
   overview: {
-    zh: '集群概览',
-    en: 'Cluster Overview',
+    zh: '概览',
+    en: 'Overview',
   },
   'connector-create': {
     zh: '创建连接器',


### PR DESCRIPTION
Change the overview tab label from "Cluster Overview" to "Overview" to prevent redundancy in the UI where "Cluster Overview" appeared three times (breadcrumb twice and tab once).