### PR TITLE
style: refine tabs and menu styling with consistent borders

### DIFF
--- a/src/style/common.scss
+++ b/src/style/common.scss
@@ -447,10 +447,6 @@ input:disabled {
     background-color: var(--color-bg-details);
     padding: 0 24px;
     margin-bottom: 24px;
-    border-bottom: 1px solid var(--color-border-primary);
-    .el-tabs__item.is-active {
-      border-bottom: 1px solid var(--color-border-card);
-    }
   }
   .app-wrapper {
     padding-top: 0px;
@@ -463,9 +459,6 @@ input:disabled {
   .el-tabs.detail-tabs {
     .el-tabs__header {
       margin-bottom: 24px;
-      .el-tabs__item.is-active {
-        border-bottom: 1px solid var(--color-bg-content);
-      }
     }
   }
 }

--- a/src/style/normalize.scss
+++ b/src/style/normalize.scss
@@ -93,7 +93,7 @@
 /* Menu */
 .el-menu {
   $menu-item-padding: 0;
-  $menu-icon-size: 21px;
+  $menu-icon-size: 20px;
   @mixin menu-item-hover {
     color: var(--color-menu-text-active);
     background-color: var(--color-bg-table-hd);
@@ -139,7 +139,7 @@
       }
       .el-sub-menu__icon-arrow {
         top: 52%;
-        right: 8px;
+        right: 3px;
       }
     }
     .el-menu-item {
@@ -170,9 +170,9 @@
     opacity: 0.8;
   }
   &.el-menu--popup {
-    min-width: initial;
     background-color: var(--color-bg);
     .el-menu-item {
+      margin: 6px 0;
       color: var(--color-menu-text-normal);
       &.is-active,
       &:hover {
@@ -186,16 +186,21 @@
   &.el-menu--horizontal {
     height: auto;
     background-color: transparent;
-    border-bottom: 1px solid var(--color-border-card);
+    border-bottom: 3px solid var(--color-bg-table-hd);
     margin-bottom: 32px;
     height: auto;
     & > .el-menu-item {
-      height: 36px;
+      height: 40px;
       padding: 0px 12px;
       margin-right: 16px;
+      position: relative;
+      top: 3px;
       &:hover {
         background-color: var(--color-hover);
         color: var(--color-primary);
+      }
+      &.is-active {
+        border-bottom: 3px solid var(--color-primary);
       }
     }
   }
@@ -361,11 +366,14 @@
   .el-tabs__content {
     overflow: visible;
   }
+  .el-tabs__active-bar {
+    height: 3px;
+  }
 }
 .el-tabs.el-tabs--top:not(.el-tabs--card) {
   & .is-top .el-tabs__nav-wrap::after {
-    height: 1px;
-    background-color: var(--color-border-primary);
+    height: 3px;
+    background-color: var(--color-bg-table-hd);
   }
 }
 .el-tabs.el-tabs--left:not(.el-tabs--card) {
@@ -393,13 +401,9 @@
 /* Tabs Card */
 .el-tabs--card {
   & > .el-tabs__header {
-    border-bottom: 1px solid var(--color-border-card);
     margin-bottom: 0px;
     .el-tabs__nav {
       border: none;
-    }
-    .el-tabs__item.is-active {
-      border-bottom: 1px solid var(--color-bg-content);
     }
     .el-tabs__item,
     .is-focus {
@@ -1045,4 +1049,7 @@
 .el-breadcrumb__inner.is-link,
 .el-breadcrumb__inner a {
   font-weight: normal;
+}
+.el-breadcrumb__separator {
+  margin: 0 16px;
 }

--- a/src/views/Config/Monitoring/components/HelpDrawer.vue
+++ b/src/views/Config/Monitoring/components/HelpDrawer.vue
@@ -315,9 +315,6 @@ const downloadGrafaTemplate = () => {
   }
   .el-tabs .el-tabs__header {
     margin-bottom: 24px;
-    .el-tabs__item.is-active {
-      border-bottom: 1px solid var(--color-bg-content);
-    }
   }
 }
 </style>

--- a/src/views/Diagnose/WebSocket.vue
+++ b/src/views/Diagnose/WebSocket.vue
@@ -153,9 +153,6 @@ addNewTab()
 .el-tabs {
   :deep(.el-tabs__header) {
     margin-bottom: 24px;
-    .el-tabs__item.is-active {
-      border-bottom: 1px solid var(--color-bg-main);
-    }
   }
   & :deep(.el-badge__content.is-dot) {
     top: 7px;

--- a/src/views/RuleEngine/Source/SourceDetail.vue
+++ b/src/views/RuleEngine/Source/SourceDetail.vue
@@ -116,7 +116,7 @@
 <script lang="ts" setup>
 import { BridgeDirection } from '@/types/enum'
 import { Source } from '@/types/rule'
-import { Delete, Share } from '@element-plus/icons-vue'
+import { Share } from '@element-plus/icons-vue'
 import BridgeItemOverview from '../Bridge/Components/BridgeItemOverview.vue'
 import DeleteBridgeSecondConfirm from '../Bridge/Components/DeleteBridgeSecondConfirm.vue'
 import TargetItemStatus from '../components/TargetItemStatus.vue'


### PR DESCRIPTION
- Replace 1px borders with 3px active indicators for tabs and menus
- Remove redundant tab border overrides across components
- Adjust menu spacing and submenu positioning
- Add zero timeout to left bar menu transitions
- Update breadcrumb separator spacing
- Remove unused Delete icon import