### PR TITLE
fix(scopes): handle legacy unset dashboard scopes

### DIFF
--- a/src/common/scopes.ts
+++ b/src/common/scopes.ts
@@ -1,0 +1,19 @@
+import type { DashboardScopes, LegacyUnsetScopes } from '@/types/systemModule'
+
+export const LEGACY_UNSET_SCOPES = 'unset'
+
+export const isLegacyUnsetScopes = (scopes: unknown): scopes is LegacyUnsetScopes =>
+  scopes === LEGACY_UNSET_SCOPES
+
+export const normalizeScopes = (scopes: DashboardScopes): string[] | undefined =>
+  Array.isArray(scopes) ? scopes : undefined
+
+export const hasSelectedScopes = (scopes: DashboardScopes): scopes is string[] =>
+  Array.isArray(scopes) && scopes.length > 0
+
+export const sanitizeScopesForSubmit = <T extends { scopes?: DashboardScopes }>(data: T): T => {
+  if (!Array.isArray(data.scopes) || data.scopes.length === 0) {
+    delete data.scopes
+  }
+  return data
+}

--- a/src/i18n/APIKey.ts
+++ b/src/i18n/APIKey.ts
@@ -68,12 +68,16 @@ export default {
     en: 'Scopes',
   },
   scopesPlaceholder: {
-    zh: '默认拥有全部范围权限',
-    en: 'Defaults to all scope permissions',
+    zh: '未选择时按角色默认权限授权',
+    en: 'When empty, fall back to the role default',
   },
   allScopes: {
     zh: '全部',
     en: 'All',
+  },
+  legacyScopesTip: {
+    zh: '该 API 密钥的权限范围未设置，请编辑并保存权限范围。',
+    en: 'This API key has no scopes set. Edit and save its scopes.',
   },
   scopeLabel_connections: {
     zh: '连接',

--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -63,6 +63,10 @@ export default {
     zh: '仅管理员可持有此权限范围',
     en: 'Only administrators may hold this scope',
   },
+  legacyScopesTip: {
+    zh: '该 API 密钥的权限范围未设置，请编辑并保存权限范围。',
+    en: 'This API key has no scopes set. Edit and save its scopes.',
+  },
   source: {
     zh: '来源',
     en: 'Source',

--- a/src/types/systemModule.d.ts
+++ b/src/types/systemModule.d.ts
@@ -1,6 +1,10 @@
 import { ExhookFailedAction, ExhookStatus } from './enum'
 import { SSL } from './common'
 
+export type LegacyUnsetScopes = 'unset'
+
+export type DashboardScopes = string[] | LegacyUnsetScopes | null | undefined
+
 export interface APIKeyScope {
   name: string
   desc: string
@@ -23,7 +27,7 @@ export interface APIKeyFormWhenCreating {
   enable: boolean
   api_key?: string
   role: string
-  scopes?: string[]
+  scopes?: DashboardScopes
 }
 
 export interface APIKey extends APIKeyFormWhenCreating {
@@ -100,14 +104,14 @@ export interface User {
   description: string
   username: string
   role?: string
-  scopes?: string[]
+  scopes?: DashboardScopes
 }
 
 export interface UserItem {
   description: string
   username: string
   role?: string
-  scopes?: string[]
+  scopes?: DashboardScopes
   backend?: string
 }
 

--- a/src/views/General/APIKey.vue
+++ b/src/views/General/APIKey.vue
@@ -25,8 +25,14 @@
       </el-table-column>
       <el-table-column prop="scopes" :label="tl('scopes')">
         <template #default="{ row }">
-          <span v-if="row.role === UserRole.Publisher">-</span>
-          <span v-else-if="!row.scopes?.length">{{ tl('allScopes') }}</span>
+          <template v-if="isLegacyUnsetScopes(row.scopes)">
+            <span>{{ tl('allScopes') }}</span>
+            <el-tooltip :content="tl('legacyScopesTip')" placement="top">
+              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
+            </el-tooltip>
+          </template>
+          <span v-else-if="row.role === UserRole.Publisher">-</span>
+          <span v-else-if="!hasSelectedScopes(row.scopes)">{{ tl('allScopes') }}</span>
           <template v-else>
             <el-tag
               v-for="scope in row.scopes"
@@ -75,6 +81,8 @@ import APIKeyDialog, { OperationType } from './components/APIKeyDialog.vue'
 import { deleteAPIKey, loadAPIKeyList, updateAPIKey } from '@/api/systemModule'
 import dayjs from 'dayjs'
 import { UserRole } from '@/types/enum'
+import { hasSelectedScopes, isLegacyUnsetScopes } from '@/common/scopes'
+import { Warning } from '@element-plus/icons-vue'
 
 const { t, te } = useI18n()
 const tl = function (key: string, collection = 'APIKey') {
@@ -164,6 +172,12 @@ getList()
   .key-name {
     cursor: pointer;
     color: var(--el-color-primary);
+  }
+  .legacy-scopes-icon {
+    margin-left: 4px;
+    color: var(--el-color-warning);
+    cursor: help;
+    vertical-align: -2px;
   }
 }
 </style>

--- a/src/views/General/Users.vue
+++ b/src/views/General/Users.vue
@@ -20,7 +20,13 @@
       </el-table-column>
       <el-table-column :label="tl('userScopes')" :min-width="220">
         <template #default="{ row }">
-          <template v-if="row.scopes && row.scopes.length">
+          <template v-if="isLegacyUnsetScopes(row.scopes)">
+            <span>{{ t('APIKey.allScopes') }}</span>
+            <el-tooltip :content="tl('legacyScopesTip')" placement="top">
+              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
+            </el-tooltip>
+          </template>
+          <template v-else-if="hasSelectedScopes(row.scopes)">
             <el-tag
               v-for="scope in row.scopes"
               :key="scope"
@@ -126,7 +132,17 @@
             </el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="accessType !== 'chPass'" :label="tl('userScopes')" prop="scopes">
+        <el-form-item v-if="accessType !== 'chPass'" prop="scopes">
+          <template #label>
+            <span>{{ tl('userScopes') }}</span>
+            <el-tooltip
+              v-if="record.scopesNeedUpdate"
+              :content="tl('legacyScopesTip')"
+              placement="top"
+            >
+              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
+            </el-tooltip>
+          </template>
           <el-select
             v-model="record.scopes"
             multiple
@@ -193,8 +209,15 @@
 <script setup>
 import { changePassword, createUser, destroyUser, loadUser, updateUser } from '@/api/function.ts'
 import { getLoginUserScopes } from '@/api/systemModule.ts'
+import {
+  hasSelectedScopes,
+  isLegacyUnsetScopes,
+  normalizeScopes,
+  sanitizeScopesForSubmit,
+} from '@/common/scopes'
 import { UserRole } from '@/types/enum.ts'
 import UserMFASettingDialog from './components/UserMFASettingDialog.vue'
+import { Warning } from '@element-plus/icons-vue'
 
 const SOURCE_LOCAL = 'local'
 
@@ -355,7 +378,8 @@ const showDialog = (type = 'create', item = {}) => {
 
   if (type === 'edit') {
     record.value = Object.assign({}, item, {
-      scopes: Array.isArray(item.scopes) ? [...item.scopes] : [],
+      scopes: normalizeScopes(item.scopes) ?? [],
+      scopesNeedUpdate: isLegacyUnsetScopes(item.scopes),
     })
   } else if (type === 'chPass') {
     record.value = {
@@ -391,8 +415,8 @@ const getBackend = (backend) => (backend === SOURCE_LOCAL ? undefined : backend)
 //
 // The backend distinguishes three states for the `scopes` field:
 //   - field absent / undefined → fall back to the user's role default
-//     (administrator gets implicit full access; viewer gets implicit
-//     empty — only the role's own privileges apply).
+//     (administrator, viewer, and SSO users all get the default scope list
+//     that belongs to their role).
 //   - explicit []              → reject every mapped path (rarely the
 //     intended meaning of "leave it empty" in the UI).
 //   - explicit [..names..]     → only those scopes are granted.
@@ -403,10 +427,7 @@ const getBackend = (backend) => (backend === SOURCE_LOCAL ? undefined : backend)
 // applies the role default.
 const buildUserPayload = (rec, fields) => {
   const payload = pick(rec, fields)
-  if (Array.isArray(payload.scopes) && payload.scopes.length === 0) {
-    delete payload.scopes
-  }
-  return payload
+  return sanitizeScopesForSubmit(payload)
 }
 
 const save = async () => {
@@ -476,6 +497,12 @@ onBeforeMount(async () => {
 .users {
   .el-tag {
     margin-right: 4px;
+  }
+  .legacy-scopes-icon {
+    margin-left: 4px;
+    color: var(--el-color-warning);
+    cursor: help;
+    vertical-align: -2px;
   }
   .mfa-label {
     text-wrap: nowrap;

--- a/src/views/General/components/APIKeyDialog.vue
+++ b/src/views/General/components/APIKeyDialog.vue
@@ -82,7 +82,17 @@
           </el-form-item>
         </el-col>
         <el-col :span="24" v-if="!isPublisherRole">
-          <el-form-item :label="tl('scopes')" prop="scopes">
+          <el-form-item prop="scopes">
+            <template #label>
+              <span>{{ tl('scopes') }}</span>
+              <el-tooltip
+                v-if="formData.scopesNeedUpdate"
+                :content="tl('legacyScopesTip')"
+                placement="top"
+              >
+                <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
+              </el-tooltip>
+            </template>
             <el-select
               v-model="formData.scopes"
               multiple
@@ -145,9 +155,16 @@ import {
   APIKeyScope,
 } from '@/types/systemModule'
 import { createAPIKey, updateAPIKey, getAPIKeyScopes } from '@/api/systemModule'
+import { isLegacyUnsetScopes, normalizeScopes, sanitizeScopesForSubmit } from '@/common/scopes'
 import APIKeyResultDialog from './APIKeyResultDialog.vue'
+import { Warning } from '@element-plus/icons-vue'
 
 export type OperationType = 'create' | 'view' | 'edit'
+type APIKeyFormData = Omit<APIKeyFormWhenCreating, 'scopes'> &
+  Partial<Omit<APIKey, 'scopes'>> & {
+    scopes?: string[]
+    scopesNeedUpdate?: boolean
+  }
 
 const props = defineProps({
   modelValue: {
@@ -183,7 +200,7 @@ const createRawFormData = () => ({
 })
 
 const formCom = ref()
-const formData: Ref<APIKeyFormWhenCreating | APIKey> = ref(createRawFormData())
+const formData: Ref<APIKeyFormData> = ref(createRawFormData())
 const availableScopes: Ref<APIKeyScope[]> = ref([])
 const { createLetterStartRule } = useFormRules()
 const rules = {
@@ -227,7 +244,12 @@ watch(showDialog, async (val) => {
       availableScopes.value = scopes
     })
     if (props.operationType !== 'create') {
-      formData.value = { ...(props.APIKeyData as APIKey) }
+      const data = props.APIKeyData as APIKey
+      formData.value = {
+        ...data,
+        scopes: normalizeScopes(data.scopes),
+        scopesNeedUpdate: isLegacyUnsetScopes(data.scopes),
+      }
       if (props.operationType === 'view') {
         await nextTick()
       }
@@ -264,11 +286,13 @@ const getScopeDesc = (name: string): string => {
 const todayStartTime = new Date().setHours(0, 0, 0, 0)
 const isItEarlierThanToday = (date: Date) => date.getTime() < todayStartTime
 
-const handleDataForSubmitting = (formData: APIKeyFormWhenCreating) => {
+const handleDataForSubmitting = (formData: APIKeyFormData) => {
   const ret = { ...formData }
+  delete ret.scopesNeedUpdate
   if (ret.role === UserRole.Publisher) {
     ret.scopes = undefined
   }
+  sanitizeScopesForSubmit(ret)
   // The interface convention is that when the api key is never expired,
   // do not submit expired_at
   if (!ret.expired_at) {
@@ -336,5 +360,11 @@ const submit = async () => {
   margin-left: 8px;
   font-size: 12px;
   font-weight: normal;
+}
+.legacy-scopes-icon {
+  margin-left: 4px;
+  color: var(--el-color-warning);
+  cursor: help;
+  vertical-align: -2px;
 }
 </style>


### PR DESCRIPTION
Normalize dashboard user and API key scopes when the backend returns the legacy "unset" sentinel. Display unset scopes as the default "All" state with a warning tooltip, and avoid submitting unset or empty scope lists back to the API so the backend can apply role defaults.

Also update scope response types and clarify the API key scope placeholder copy.