### PR TITLE
feat(cluster-link): support dispatch_strategy in resource_opts

### DIFF
--- a/src/views/Config/ClusterLinking/ClusterLinkingCreate.vue
+++ b/src/views/Config/ClusterLinking/ClusterLinkingCreate.vue
@@ -47,10 +47,11 @@ const generateRawRecord = (): ClusterLinkingData => ({
   resource_opts: {
     start_timeout: '5s',
     worker_pool_size: 16,
+    dispatch_strategy: 'per_clientid',
+    request_ttl: '45s',
     health_check_interval: '15s',
     max_buffer_bytes: '256MB',
     inflight_window: 100,
-    request_ttl: '45s',
   },
 })
 

--- a/src/views/Config/ClusterLinking/components/ClusterLinkingForm.vue
+++ b/src/views/Config/ClusterLinking/components/ClusterLinkingForm.vue
@@ -163,6 +163,21 @@
             </el-form-item>
           </el-col>
           <el-col :span="12">
+            <el-form-item
+              :label="getLabel('dispatch_strategy')"
+              prop="resource_opts.dispatch_strategy"
+            >
+              <el-select v-model="record.resource_opts.dispatch_strategy">
+                <el-option
+                  v-for="item in ['per_clientid', 'random']"
+                  :key="item"
+                  :value="item"
+                  :label="$t(`SchemaSymbolLabel.${item}`)"
+                />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
             <el-form-item :label="getLabel('request_ttl')" prop="resource_opts.request_ttl">
               <Oneof
                 v-model="record.resource_opts.request_ttl"


### PR DESCRIPTION
Adapt to emqx/emqx#17237 which adds `dispatch_strategy` to cluster link `resource_opts` (values: `per_clientid` / `random`, default `per_clientid`) to control forwarding pool worker dispatch.

- Add `dispatch_strategy` select in ClusterLinkingForm, placed between `worker_pool_size` and `request_ttl` to match the order defined in `actionResourceOptFields` and `BridgeResourceOpt.vue`.
- Default `dispatch_strategy` to `per_clientid` in ClusterLinkingCreate, consistent with the backend default.
- Reuse existing i18n keys (`BridgeSchema.common.dispatch_strategy.label` and `SchemaSymbolLabel.per_clientid` / `random`).