### PR TITLE
fix(layout): correct footer height and border color

### DIFF
--- a/src/views/Base/Layout.vue
+++ b/src/views/Base/Layout.vue
@@ -218,9 +218,9 @@ bindKeyupListener()
     box-sizing: border-box;
     bottom: 0;
     width: calc(var(--menu-normal-width) - 1px);
-    height: var(--left-menu-footer-height);
+    height: calc(var(--left-menu-footer-height) + 16px);
     background-color: var(--color-bg);
-    border-top: 1px solid #ffffff24;
+    border-top: 1px solid var(--color-border-card);
     transition: all 0.3s;
     &.is-collapse {
       width: calc(var(--menu-collapse-width) - 1px);
@@ -231,7 +231,6 @@ bindKeyupListener()
       justify-content: space-between;
       height: 100%;
       padding: 0 16px;
-      padding-bottom: 29px;
       .iconfont {
         flex-shrink: 0;
         width: 32px;


### PR DESCRIPTION
**Summary**

- The sidebar footer used hardcoded border-top that only worked on the dark theme
- Adjusted footer height and removed a redundant padding

<img width="1236" height="267" alt="pr" src="https://github.com/user-attachments/assets/0a6356a2-9c58-447c-b7a2-06deccb9e67e" />
