### PR TITLE
fix(ci): authenticate schema checks

### DIFF
--- a/.github/workflows/build_emqx_for_test.yaml
+++ b/.github/workflows/build_emqx_for_test.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: emqx/emqx
-          ref: release-62
+          ref: release-63
 
       - name: build and export to Docker
         id: build

--- a/.github/workflows/check_audit_dict.yaml
+++ b/.github/workflows/check_audit_dict.yaml
@@ -8,7 +8,7 @@ on:
         type: string
 
 env:
-  IS_CI: "true"
+  IS_CI: 'true'
   EMQX_NAME: ${{ inputs.emqx-name }}
 
 jobs:
@@ -20,33 +20,104 @@ jobs:
         with:
           name: ${{ env.EMQX_NAME }}-docker
           path: /tmp
+
       - name: load docker image
+        shell: bash
         run: |
+          set -euo pipefail
           EMQX_IMAGE_TAG=$(docker load < /tmp/${EMQX_NAME}-docker.tar.gz 2>/dev/null | sed 's/Loaded image: //g')
-          echo "EMQX_IMAGE_TAG=$EMQX_IMAGE_TAG" >> $GITHUB_ENV
-      - name: run docker
-        run: |
-          CID=$(docker run -d --rm -P $EMQX_IMAGE_TAG)
-          HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
-          echo "HTTP_PORT=$HTTP_PORT" >> $GITHUB_ENV
-          echo "CID=$CID" >> $GITHUB_ENV
-          echo "HOST_URL=http://localhost:$HTTP_PORT" >> $GITHUB_ENV
+          echo "EMQX_IMAGE_TAG=$EMQX_IMAGE_TAG" >> "$GITHUB_ENV"
 
       - name: checkout dashboard code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: install dep
+      - name: run EMQX
+        shell: bash
         run: |
-          yarn
+          set -euo pipefail
+
+          EMQX_ADMIN_PASSWORD=$(openssl rand -hex 24)
+          echo "::add-mask::$EMQX_ADMIN_PASSWORD"
+
+          CID=$(docker run -d --rm -P \
+            -e EMQX_DASHBOARD__DEFAULT_PASSWORD="$EMQX_ADMIN_PASSWORD" \
+            "$EMQX_IMAGE_TAG")
+          echo "CID=$CID" >> "$GITHUB_ENV"
+
+          HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' "$CID")
+          HOST_URL="http://localhost:$HTTP_PORT"
+
+          echo "HOST_URL=$HOST_URL" >> "$GITHUB_ENV"
+          echo "EMQX_ADMIN_PASSWORD=$EMQX_ADMIN_PASSWORD" >> "$GITHUB_ENV"
+
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent "$HOST_URL/status" > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          docker logs "$CID"
+          exit 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17'
+          cache: pnpm
+
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: download authenticated Swagger schema
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LOGIN_BODY=$(jq -nc \
+            --arg username admin \
+            --arg password "$EMQX_ADMIN_PASSWORD" \
+            '{username: $username, password: $password}')
+          TOKEN=''
+          for attempt in $(seq 1 30); do
+            if TOKEN=$(curl --fail-with-body --silent --show-error \
+              -X POST "$HOST_URL/api/v5/login" \
+              -H 'Content-Type: application/json' \
+              --data "$LOGIN_BODY" | jq -er '.token'); then
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$TOKEN" ]; then
+            echo "Failed to log in to EMQX."
+            docker logs "$CID"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $TOKEN" \
+            "$HOST_URL/api-docs/swagger.json" \
+            -o swagger.json
+
+          jq -e '
+            .openapi and
+            ((.paths | type) == "object") and
+            ((.paths | length) > 2) and
+            ((.components.schemas | type) == "object")
+          ' swagger.json > /dev/null
 
       - name: run script that checks the audit dict
-        run: |
-          node ./scripts/checkAuditDict.cjs
+        run: SWAGGER_FILE=./swagger.json node ./scripts/checkAuditDict.cjs
 
-      - name: check for script errors
-        if: ${{ failure() }}
-        run: exit 1
-
-      - name: stop docker
+      - name: stop EMQX
+        if: always()
         run: |
-          docker stop ${CID}
+          if [ -n "${CID:-}" ]; then
+            docker stop "$CID" || true
+          fi

--- a/.github/workflows/check_newest_schema.yaml
+++ b/.github/workflows/check_newest_schema.yaml
@@ -20,51 +20,126 @@ jobs:
         with:
           name: ${{ env.EMQX_NAME }}-docker
           path: /tmp
+
       - name: load docker image
+        shell: bash
         run: |
+          set -euo pipefail
           EMQX_IMAGE_TAG=$(docker load < /tmp/${EMQX_NAME}-docker.tar.gz 2>/dev/null | sed 's/Loaded image: //g')
-          echo "EMQX_IMAGE_TAG=$EMQX_IMAGE_TAG" >> $GITHUB_ENV
-      - name: run docker
-        run: |
-          CID=$(docker run -d --rm -P $EMQX_IMAGE_TAG)
-          HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
-          echo "HTTP_PORT=$HTTP_PORT" >> $GITHUB_ENV
-          echo "CID=$CID" >> $GITHUB_ENV
-          echo "HOST_URL=http://localhost:$HTTP_PORT" >> $GITHUB_ENV
+          echo "EMQX_IMAGE_TAG=$EMQX_IMAGE_TAG" >> "$GITHUB_ENV"
 
       - name: checkout dashboard code
-        uses: actions/checkout@v3
-           
+        uses: actions/checkout@v4
+
+      - name: run EMQX
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          EMQX_ADMIN_PASSWORD=$(openssl rand -hex 24)
+          echo "::add-mask::$EMQX_ADMIN_PASSWORD"
+
+          CID=$(docker run -d --rm -P \
+            -e EMQX_DASHBOARD__DEFAULT_PASSWORD="$EMQX_ADMIN_PASSWORD" \
+            "$EMQX_IMAGE_TAG")
+          echo "CID=$CID" >> "$GITHUB_ENV"
+
+          HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' "$CID")
+          HOST_URL="http://localhost:$HTTP_PORT"
+
+          echo "HOST_URL=$HOST_URL" >> "$GITHUB_ENV"
+          echo "EMQX_ADMIN_PASSWORD=$EMQX_ADMIN_PASSWORD" >> "$GITHUB_ENV"
+
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent "$HOST_URL/status" > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          docker logs "$CID"
+          exit 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.17'
+          cache: pnpm
 
-      - name: run script that checks schemas
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: download authenticated Swagger schema
+        shell: bash
         run: |
-          npm install -g pnpm
-          pnpm install
-          pnpm orval
+          set -euo pipefail
+
+          LOGIN_BODY=$(jq -nc \
+            --arg username admin \
+            --arg password "$EMQX_ADMIN_PASSWORD" \
+            '{username: $username, password: $password}')
+          TOKEN=''
+          for attempt in $(seq 1 30); do
+            if TOKEN=$(curl --fail-with-body --silent --show-error \
+              -X POST "$HOST_URL/api/v5/login" \
+              -H 'Content-Type: application/json' \
+              --data "$LOGIN_BODY" | jq -er '.token'); then
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$TOKEN" ]; then
+            echo "Failed to log in to EMQX."
+            docker logs "$CID"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $TOKEN" \
+            "$HOST_URL/api-docs/swagger.json" \
+            -o swagger.json
+
+          jq -e '
+            .openapi and
+            ((.paths | type) == "object") and
+            ((.paths | length) > 2) and
+            ((.components.schemas | type) == "object")
+          ' swagger.json > /dev/null
+
+      - name: generate schemas
+        run: pnpm orval:local
 
       - name: check for changes
+        id: schema_diff
+        shell: bash
         run: |
-          git_diff=$(git diff)
-          if [ -n "$git_diff" ]; then
-            git diff src/types/schemas
+          set -euo pipefail
+          changes=$(git status --porcelain --untracked-files=all -- src/types/schemas)
+          if [ -n "$changes" ]; then
+            echo "$changes"
+            git diff -- src/types/schemas
             echo "Detected differences in the repository. Uploading mismatched schemas."
             exit 1
-          else
-            echo "No differences detected."
           fi
+          echo "No differences detected."
 
       - name: upload schemas
-        if: failure()
+        if: failure() && steps.schema_diff.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: newest-schemas
           path: ./src/types/schemas/*.ts
           retention-days: 3
 
-      - name: stop docker
+      - name: stop EMQX
+        if: always()
         run: |
-          docker stop ${CID}
+          if [ -n "${CID:-}" ]; then
+            docker stop "$CID" || true
+          fi

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  '@parcel/watcher': set this to true or false
-  esbuild: set this to true or false
-  vue-demi: set this to true or false
+  '@parcel/watcher': true
+  esbuild: true
+  vue-demi: true

--- a/scripts/checkAuditDict.cjs
+++ b/scripts/checkAuditDict.cjs
@@ -1,6 +1,8 @@
 const rawDict = require('../src/views/General/resource_dict.json')
+const { readFile } = require('node:fs/promises')
 const axios = require('axios')
 const baseURL = process.env.HOST_URL || 'http://mac:18084'
+const swaggerFile = process.env.SWAGGER_FILE
 
 const WILDCARD_MARKER = '[...]'
 
@@ -46,8 +48,16 @@ const replacePlaceholder = (path) =>
   path.replace(reg, ($0, $1) => {
     return `:${$1}`
   })
+const loadSwagger = async () => {
+  if (swaggerFile) {
+    return JSON.parse(await readFile(swaggerFile, 'utf8'))
+  }
+
+  const { data } = await axios.get(`${baseURL}/api-docs/swagger.json`)
+  return data
+}
 const check = async () => {
-  const { data: swaggerJSON } = await axios.get(`${baseURL}/api-docs/swagger.json`)
+  const swaggerJSON = await loadSwagger()
   const { paths } = swaggerJSON
   Object.entries(paths).forEach(([rawPathItem, requestMap]) => {
     const pathItem = replacePlaceholder(rawPathItem)

--- a/scripts/transformer/filterTagsSchema.js
+++ b/scripts/transformer/filterTagsSchema.js
@@ -1,7 +1,26 @@
-const { isObject, get, set, isArray, isPlainObject } = require('lodash')
+import lodash from 'lodash'
+
+const { isObject, get, set, isArray, isPlainObject } = lodash
 
 const paramRefReg = /^#\/components\/parameters\//
 const schemaRefReg = /^#\/components\/schemas\//
+
+const compareStrings = (a, b) => {
+  if (a === b) {
+    return 0
+  }
+  return a < b ? -1 : 1
+}
+
+const getSortKey = (value) => {
+  if (isPlainObject(value)) {
+    return `2:object:${JSON.stringify(value)}`
+  }
+  if (isArray(value)) {
+    return `1:array:${JSON.stringify(value)}`
+  }
+  return `0:${typeof value}:${String(value)}`
+}
 
 const removeAllDesc = (swaggerJSON) => {
   const walk = (target) => {
@@ -126,7 +145,7 @@ const getAllRefsByRefArr = (swaggerJSON, refArr) => {
 }
 
 const keepTargetParam = (swaggerJSON, refs) => {
-  const sortedRefs = refs.sort((a, b) => a.localeCompare(b))
+  const sortedRefs = refs.sort(compareStrings)
   const params = sortedRefs.reduce((obj, ref) => {
     const path = getPathByRef(ref)
     const key = path[path.length - 1]
@@ -138,7 +157,7 @@ const keepTargetParam = (swaggerJSON, refs) => {
 }
 
 const keepTargetSchema = (swaggerJSON, refs) => {
-  const sortedRefs = refs.sort((a, b) => a.localeCompare(b))
+  const sortedRefs = refs.sort(compareStrings)
   const schemas = sortedRefs.reduce((obj, ref) => {
     const path = getPathByRef(ref)
     const key = path[path.length - 1]
@@ -164,7 +183,7 @@ const handleActionJSON = (swaggerJSON) => {
   ]
   const enums = get(swaggerJSON, path)
   if (enums) {
-    set(swaggerJSON, path, enums.sort())
+    set(swaggerJSON, path, enums.sort(compareStrings))
   }
   return swaggerJSON
 }
@@ -184,13 +203,13 @@ const handleSourceJSON = (swaggerJSON) => {
   ]
   const enums = get(swaggerJSON, path)
   if (enums) {
-    set(swaggerJSON, path, enums.sort())
+    set(swaggerJSON, path, enums.sort(compareStrings))
   }
   return swaggerJSON
 }
 
 const sortMetricsKey = (metrics) => {
-  const sortedMetrics = Object.keys(metrics).sort((a, b) => a.localeCompare(b))
+  const sortedMetrics = Object.keys(metrics).sort(compareStrings)
   const sortedMetricsObj = sortedMetrics.reduce((obj, key) => {
     obj[key] = metrics[key]
     return obj
@@ -222,21 +241,7 @@ const sortObj = (rawObj) => {
         rawObj[index] = item
       }
     })
-    return rawObj.sort((a, b) => {
-      if (isPlainObject(a)) {
-        return 2
-      }
-      if (isPlainObject(b)) {
-        return -2
-      }
-      if (isArray(a)) {
-        return 1
-      }
-      if (isArray(b)) {
-        return -1
-      }
-      return a.toString().localeCompare(b.toString())
-    })
+    return rawObj.sort((a, b) => compareStrings(getSortKey(a), getSortKey(b)))
   }
   Object.entries(rawObj).forEach(([key, value]) => {
     if (isPlainObject(value) || isArray(value)) {
@@ -245,9 +250,7 @@ const sortObj = (rawObj) => {
       rawObj[key] = value
     }
   })
-  const sortedKeys = Object.keys(rawObj).sort((pK, nK) => {
-    return pK.localeCompare(nK.toString())
-  })
+  const sortedKeys = Object.keys(rawObj).sort(compareStrings)
   const sortedObj = sortedKeys.reduce((obj, key) => {
     obj[key] = rawObj[key]
     return obj
@@ -260,9 +263,9 @@ const sortOneofRefs = (oneofRefs) => {
     const aValue = a.$ref || (a.enum && a.enum[0])
     const bValue = b.$ref || (b.enum && b.enum[0])
     if (aValue && bValue) {
-      return aValue.localeCompare(bValue)
+      return compareStrings(String(aValue), String(bValue))
     }
-    return 0
+    return compareStrings(getSortKey(a), getSortKey(b))
   })
   return sortedRefs
 }

--- a/src/types/schemas/a2ARegistry.schemas.ts
+++ b/src/types/schemas/a2ARegistry.schemas.ts
@@ -25,11 +25,11 @@ export type GetA2aCardsList404 = {
 }
 
 export type GetA2aCardsListParams = {
-  only_global?: boolean
-  ns?: string
+  agent_id?: string
   org_id?: string
   unit_id?: string
-  agent_id?: string
+  ns?: string
+  only_global?: boolean
 }
 
 export type PostA2aCardsCardOrgIdUnitIdAgentId503Code =

--- a/src/types/schemas/actions.schemas.ts
+++ b/src/types/schemas/actions.schemas.ts
@@ -54,6 +54,133 @@ export type PostNodesNodeActionsIdOperationParams = {
   ns?: string
 }
 
+export type GetActionsSummaryParams = {
+  ns?: string
+  only_global?: boolean
+}
+
+export type PostActionsProbe400Code =
+  (typeof PostActionsProbe400Code)[keyof typeof PostActionsProbe400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostActionsProbe400Code = {
+  TEST_FAILED: 'TEST_FAILED',
+} as const
+
+export type PostActionsProbe400 = {
+  code?: PostActionsProbe400Code
+  message?: string
+}
+
+export type PostActionsProbeBody =
+  | ActionAlloydbPostBridgeV2
+  | ActionAwsTimestreamPostBridgeV2
+  | ActionAzureBlobStoragePostBridgeV2
+  | ActionBigqueryPostBridgeV2
+  | ActionBigtablePostBridgeV2
+  | ActionCockroachdbPostBridgeV2
+  | ActionCouchbasePostBridgeV2
+  | ActionDiskLogPostBridgeV2
+  | ActionDorisPostBridgeV2
+  | ActionEmqxTablesPostBridgeV2
+  | ActionQuasardbPostBridgeV2
+  | ActionRedshiftPostBridgeV2
+  | ActionS3tablesPostBridgeV2
+  | ActionSnowflakeAggregatedPostBridgeV2
+  | ActionSnowflakeStreamingPostBridgeV2
+  | ActionSourceAzureEventGridPostBridgeV2
+  | BridgeAzureEventHubPostBridgeV2
+  | BridgeCassaPostBridgeV2
+  | BridgeClickhousePostBridgeV2
+  | BridgeDatalayersPostBridgeV2
+  | BridgeDynamoPostBridgeV2
+  | BridgeElasticsearchPostBridgeV2
+  | BridgeGreptimedbPostBridgeV2
+  | BridgeHttpPostBridgeV2
+  | BridgeInfluxdbPostBridgeV2
+  | BridgeIotdbPostBridgeV2
+  | BridgeKafkaPostBridgeV2
+  | BridgeKinesisPostBridgeV2
+  | BridgeMatrixPostBridgeV2
+  | BridgeMongodbPostBridgeV2
+  | BridgeMqttPublisherPostBridgeV2
+  | BridgeMysqlPostBridgeV2
+  | BridgeOpentsPostBridgeV2
+  | BridgeOraclePostBridgeV2
+  | BridgePgsqlPostBridgeV2
+  | BridgeRabbitmqPostBridgeV2
+  | BridgeS3PostBridgeV2
+  | BridgeSqlserverPostBridgeV2
+  | BridgeTablestorePostBridgeV2
+  | BridgeTdenginePostBridgeV2
+  | BridgeTimescalePostBridgeV2
+  | ConfluentPostBridgeV2
+  | GcpPubsubProducerPostBridgeV2
+  | PulsarPostBridgeV2
+  | RedisPostBridgeV2
+  | RocketmqPostBridgeV2
+  | SyskeeperPostBridgeV2
+
+export type PostActionsProbeParams = {
+  ns?: string
+}
+
+export type PostActionsIdOperation503Code =
+  (typeof PostActionsIdOperation503Code)[keyof typeof PostActionsIdOperation503Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostActionsIdOperation503Code = {
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+} as const
+
+export type PostActionsIdOperation503 = {
+  code?: PostActionsIdOperation503Code
+  message?: string
+}
+
+export type PostActionsIdOperation501Code =
+  (typeof PostActionsIdOperation501Code)[keyof typeof PostActionsIdOperation501Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostActionsIdOperation501Code = {
+  NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
+} as const
+
+export type PostActionsIdOperation501 = {
+  code?: PostActionsIdOperation501Code
+  message?: string
+}
+
+export type PostActionsIdOperation404Code =
+  (typeof PostActionsIdOperation404Code)[keyof typeof PostActionsIdOperation404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostActionsIdOperation404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostActionsIdOperation404 = {
+  code?: PostActionsIdOperation404Code
+  message?: string
+}
+
+export type PostActionsIdOperation400Code =
+  (typeof PostActionsIdOperation400Code)[keyof typeof PostActionsIdOperation400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostActionsIdOperation400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PostActionsIdOperation400 = {
+  code?: PostActionsIdOperation400Code
+  message?: string
+}
+
+export type PostActionsIdOperationParams = {
+  ns?: string
+}
+
 export type PutActionsIdMetricsReset404Code =
   (typeof PutActionsIdMetricsReset404Code)[keyof typeof PutActionsIdMetricsReset404Code]
 
@@ -120,62 +247,6 @@ export type PutActionsIdEnableEnable404 = {
 }
 
 export type PutActionsIdEnableEnableParams = {
-  ns?: string
-}
-
-export type PostActionsIdOperation503Code =
-  (typeof PostActionsIdOperation503Code)[keyof typeof PostActionsIdOperation503Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostActionsIdOperation503Code = {
-  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
-} as const
-
-export type PostActionsIdOperation503 = {
-  code?: PostActionsIdOperation503Code
-  message?: string
-}
-
-export type PostActionsIdOperation501Code =
-  (typeof PostActionsIdOperation501Code)[keyof typeof PostActionsIdOperation501Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostActionsIdOperation501Code = {
-  NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
-} as const
-
-export type PostActionsIdOperation501 = {
-  code?: PostActionsIdOperation501Code
-  message?: string
-}
-
-export type PostActionsIdOperation404Code =
-  (typeof PostActionsIdOperation404Code)[keyof typeof PostActionsIdOperation404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostActionsIdOperation404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PostActionsIdOperation404 = {
-  code?: PostActionsIdOperation404Code
-  message?: string
-}
-
-export type PostActionsIdOperation400Code =
-  (typeof PostActionsIdOperation400Code)[keyof typeof PostActionsIdOperation400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostActionsIdOperation400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PostActionsIdOperation400 = {
-  code?: PostActionsIdOperation400Code
-  message?: string
-}
-
-export type PostActionsIdOperationParams = {
   ns?: string
 }
 
@@ -427,77 +498,6 @@ export type DeleteActionsIdParams = {
   ns?: string
 }
 
-export type GetActionsSummaryParams = {
-  ns?: string
-  only_global?: boolean
-}
-
-export type PostActionsProbe400Code =
-  (typeof PostActionsProbe400Code)[keyof typeof PostActionsProbe400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostActionsProbe400Code = {
-  TEST_FAILED: 'TEST_FAILED',
-} as const
-
-export type PostActionsProbe400 = {
-  code?: PostActionsProbe400Code
-  message?: string
-}
-
-export type PostActionsProbeBody =
-  | ActionAlloydbPostBridgeV2
-  | ActionAwsTimestreamPostBridgeV2
-  | ActionAzureBlobStoragePostBridgeV2
-  | ActionBigqueryPostBridgeV2
-  | ActionBigtablePostBridgeV2
-  | ActionCockroachdbPostBridgeV2
-  | ActionCouchbasePostBridgeV2
-  | ActionDiskLogPostBridgeV2
-  | ActionDorisPostBridgeV2
-  | ActionEmqxTablesPostBridgeV2
-  | ActionQuasardbPostBridgeV2
-  | ActionRedshiftPostBridgeV2
-  | ActionS3tablesPostBridgeV2
-  | ActionSnowflakeAggregatedPostBridgeV2
-  | ActionSnowflakeStreamingPostBridgeV2
-  | ActionSourceAzureEventGridPostBridgeV2
-  | BridgeAzureEventHubPostBridgeV2
-  | BridgeCassaPostBridgeV2
-  | BridgeClickhousePostBridgeV2
-  | BridgeDatalayersPostBridgeV2
-  | BridgeDynamoPostBridgeV2
-  | BridgeElasticsearchPostBridgeV2
-  | BridgeGreptimedbPostBridgeV2
-  | BridgeHttpPostBridgeV2
-  | BridgeInfluxdbPostBridgeV2
-  | BridgeIotdbPostBridgeV2
-  | BridgeKafkaPostBridgeV2
-  | BridgeKinesisPostBridgeV2
-  | BridgeMatrixPostBridgeV2
-  | BridgeMongodbPostBridgeV2
-  | BridgeMqttPublisherPostBridgeV2
-  | BridgeMysqlPostBridgeV2
-  | BridgeOpentsPostBridgeV2
-  | BridgeOraclePostBridgeV2
-  | BridgePgsqlPostBridgeV2
-  | BridgeRabbitmqPostBridgeV2
-  | BridgeS3PostBridgeV2
-  | BridgeSqlserverPostBridgeV2
-  | BridgeTablestorePostBridgeV2
-  | BridgeTdenginePostBridgeV2
-  | BridgeTimescalePostBridgeV2
-  | ConfluentPostBridgeV2
-  | GcpPubsubProducerPostBridgeV2
-  | PulsarPostBridgeV2
-  | RedisPostBridgeV2
-  | RocketmqPostBridgeV2
-  | SyskeeperPostBridgeV2
-
-export type PostActionsProbeParams = {
-  ns?: string
-}
-
 export type PostActions400Code = (typeof PostActions400Code)[keyof typeof PostActions400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -613,53 +613,53 @@ export type PostActionsParams = {
 }
 
 export type GetActions200Item =
-  | ActionEmqxTablesGetBridgeV2
-  | ActionDiskLogGetBridgeV2
-  | BridgeOpentsGetBridgeV2
-  | BridgeAzureEventHubGetBridgeV2
-  | BridgeMatrixGetBridgeV2
-  | ActionDorisGetBridgeV2
-  | ConfluentGetBridgeV2
-  | BridgeMysqlGetBridgeV2
-  | ActionQuasardbGetBridgeV2
-  | BridgeKafkaGetBridgeV2
-  | BridgePgsqlGetBridgeV2
-  | BridgeKinesisGetBridgeV2
-  | ActionCockroachdbGetBridgeV2
-  | PulsarGetBridgeV2
-  | BridgeDatalayersGetBridgeV2
   | ActionAlloydbGetBridgeV2
-  | BridgeTablestoreGetBridgeV2
-  | BridgeMongodbGetBridgeV2
-  | GcpPubsubProducerGetBridgeV2
-  | ActionSnowflakeAggregatedGetBridgeV2
-  | BridgeHttpGetBridgeV2
-  | ActionSourceAzureEventGridGetBridgeV2
-  | SyskeeperGetBridgeV2
-  | BridgeCassaGetBridgeV2
-  | BridgeRabbitmqGetBridgeV2
-  | ActionRedshiftGetBridgeV2
-  | ActionAzureBlobStorageGetBridgeV2
-  | RedisGetBridgeV2
   | ActionAwsTimestreamGetBridgeV2
-  | BridgeInfluxdbGetBridgeV2
-  | ActionBigtableGetBridgeV2
-  | BridgeClickhouseGetBridgeV2
-  | ActionS3tablesGetBridgeV2
-  | BridgeS3GetBridgeV2
-  | BridgeGreptimedbGetBridgeV2
+  | ActionAzureBlobStorageGetBridgeV2
   | ActionBigqueryGetBridgeV2
-  | BridgeMqttPublisherGetBridgeV2
+  | ActionBigtableGetBridgeV2
+  | ActionCockroachdbGetBridgeV2
   | ActionCouchbaseGetBridgeV2
-  | BridgeTimescaleGetBridgeV2
-  | BridgeDynamoGetBridgeV2
+  | ActionDiskLogGetBridgeV2
+  | ActionDorisGetBridgeV2
+  | ActionEmqxTablesGetBridgeV2
+  | ActionQuasardbGetBridgeV2
+  | ActionRedshiftGetBridgeV2
+  | ActionS3tablesGetBridgeV2
+  | ActionSnowflakeAggregatedGetBridgeV2
   | ActionSnowflakeStreamingGetBridgeV2
-  | BridgeIotdbGetBridgeV2
-  | RocketmqGetBridgeV2
-  | BridgeTdengineGetBridgeV2
-  | BridgeSqlserverGetBridgeV2
-  | BridgeOracleGetBridgeV2
+  | ActionSourceAzureEventGridGetBridgeV2
+  | BridgeAzureEventHubGetBridgeV2
+  | BridgeCassaGetBridgeV2
+  | BridgeClickhouseGetBridgeV2
+  | BridgeDatalayersGetBridgeV2
+  | BridgeDynamoGetBridgeV2
   | BridgeElasticsearchGetBridgeV2
+  | BridgeGreptimedbGetBridgeV2
+  | BridgeHttpGetBridgeV2
+  | BridgeInfluxdbGetBridgeV2
+  | BridgeIotdbGetBridgeV2
+  | BridgeKafkaGetBridgeV2
+  | BridgeKinesisGetBridgeV2
+  | BridgeMatrixGetBridgeV2
+  | BridgeMongodbGetBridgeV2
+  | BridgeMqttPublisherGetBridgeV2
+  | BridgeMysqlGetBridgeV2
+  | BridgeOpentsGetBridgeV2
+  | BridgeOracleGetBridgeV2
+  | BridgePgsqlGetBridgeV2
+  | BridgeRabbitmqGetBridgeV2
+  | BridgeS3GetBridgeV2
+  | BridgeSqlserverGetBridgeV2
+  | BridgeTablestoreGetBridgeV2
+  | BridgeTdengineGetBridgeV2
+  | BridgeTimescaleGetBridgeV2
+  | ConfluentGetBridgeV2
+  | GcpPubsubProducerGetBridgeV2
+  | PulsarGetBridgeV2
+  | RedisGetBridgeV2
+  | RocketmqGetBridgeV2
+  | SyskeeperGetBridgeV2
 
 export type GetActionsParams = {
   ns?: string
@@ -721,8 +721,8 @@ export const GetActionTypes200Item = {
 } as const
 
 export type SyskeeperPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface SyskeeperPutBridgeV2 {
   connector: string
@@ -743,8 +743,8 @@ export const SyskeeperPostBridgeV2Type = {
 } as const
 
 export type SyskeeperPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface SyskeeperParameters {
   /**
@@ -788,8 +788,8 @@ export const SyskeeperGetBridgeV2Status = {
 } as const
 
 export type SyskeeperGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type SyskeeperCreationOptsRequestTtl = 'infinity' | string
 
@@ -816,7 +816,7 @@ export const SyskeeperCreationOptsDispatchStrategy = {
 /**
  * @deprecated
  */
-export type SyskeeperCreationOptsAutoRestartInterval = string | 'infinity'
+export type SyskeeperCreationOptsAutoRestartInterval = 'infinity' | string
 
 export interface SyskeeperCreationOpts {
   /** @deprecated */
@@ -867,11 +867,11 @@ export interface RuleEngineRepublishMqttProperties {
   'Response-Topic'?: string
 }
 
-export type RuleEngineRepublishArgsRetain = string | boolean
+export type RuleEngineRepublishArgsRetain = boolean | string
 
-export type RuleEngineRepublishArgsQos = string | number
+export type RuleEngineRepublishArgsQos = number | string
 
-export type RuleEngineRepublishArgsDirectDispatch = string | boolean
+export type RuleEngineRepublishArgsDirectDispatch = boolean | string
 
 export interface RuleEngineRepublishArgs {
   direct_dispatch?: RuleEngineRepublishArgsDirectDispatch
@@ -884,8 +884,8 @@ export interface RuleEngineRepublishArgs {
 }
 
 export type RocketmqPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RocketmqPutBridgeV2 {
   connector: string
@@ -906,8 +906,8 @@ export const RocketmqPostBridgeV2Type = {
 } as const
 
 export type RocketmqPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RocketmqPostBridgeV2 {
   connector: string
@@ -941,8 +941,8 @@ export const RocketmqGetBridgeV2Status = {
 } as const
 
 export type RocketmqGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RocketmqGetBridgeV2 {
   connector: string
@@ -1001,7 +1001,7 @@ export interface RocketmqActionResourceOpts {
   worker_pool_size?: number
 }
 
-export type RocketmqActionParametersStrategy = string | 'key_dispatch' | 'roundrobin'
+export type RocketmqActionParametersStrategy = 'key_dispatch' | 'roundrobin' | string
 
 export interface RocketmqActionParameters {
   key?: string
@@ -1015,8 +1015,8 @@ export interface RocketmqActionParameters {
 }
 
 export type RedisPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RedisPutBridgeV2 {
   connector: string
@@ -1037,8 +1037,8 @@ export const RedisPostBridgeV2Type = {
 } as const
 
 export type RedisPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RedisPostBridgeV2 {
   connector: string
@@ -1071,8 +1071,8 @@ export const RedisGetBridgeV2Status = {
 } as const
 
 export type RedisGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface RedisGetBridgeV2 {
   connector: string
@@ -1132,8 +1132,8 @@ export interface RedisActionResourceOpts {
 }
 
 export type PulsarPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface PulsarPutBridgeV2 {
   connector: string
@@ -1159,8 +1159,8 @@ export const PulsarPostBridgeV2Type = {
 } as const
 
 export type PulsarPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface PulsarPostBridgeV2 {
   connector: string
@@ -1194,8 +1194,8 @@ export const PulsarGetBridgeV2Status = {
 } as const
 
 export type PulsarGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface PulsarGetBridgeV2 {
   connector: string
@@ -1257,7 +1257,7 @@ export const PulsarActionParametersStrategy = {
   roundrobin: 'roundrobin',
 } as const
 
-export type PulsarActionParametersRetentionPeriod = string | 'infinity'
+export type PulsarActionParametersRetentionPeriod = 'infinity' | string
 
 export type PulsarActionParametersCompression =
   (typeof PulsarActionParametersCompression)[keyof typeof PulsarActionParametersCompression]
@@ -1286,8 +1286,8 @@ export interface PulsarActionParameters {
 }
 
 export type GcpPubsubProducerPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type GcpPubsubProducerPostBridgeV2Type =
   (typeof GcpPubsubProducerPostBridgeV2Type)[keyof typeof GcpPubsubProducerPostBridgeV2Type]
@@ -1298,8 +1298,8 @@ export const GcpPubsubProducerPostBridgeV2Type = {
 } as const
 
 export type GcpPubsubProducerPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type GcpPubsubProducerGetBridgeV2Type =
   (typeof GcpPubsubProducerGetBridgeV2Type)[keyof typeof GcpPubsubProducerGetBridgeV2Type]
@@ -1321,8 +1321,8 @@ export const GcpPubsubProducerGetBridgeV2Status = {
 } as const
 
 export type GcpPubsubProducerGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type GcpPubsubProducerActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -1445,8 +1445,8 @@ export const ConnectorAggregatorContainerParquetType = {
 } as const
 
 export type ConnectorAggregatorContainerParquetSchema =
-  | ConnectorAggregatorParquetSchemaAvroRef
   | ConnectorAggregatorParquetSchemaAvroInline
+  | ConnectorAggregatorParquetSchemaAvroRef
 
 export type ConnectorAggregatorContainerParquetDefaultCompression =
   (typeof ConnectorAggregatorContainerParquetDefaultCompression)[keyof typeof ConnectorAggregatorContainerParquetDefaultCompression]
@@ -1491,8 +1491,8 @@ export interface ConnectorAggregatorContainerCsv {
 }
 
 export type ConfluentPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ConfluentPutBridgeV2 {
   connector: string
@@ -1523,7 +1523,7 @@ export const ConfluentProducerKafkaOptsQueryMode = {
   sync: 'sync',
 } as const
 
-export type ConfluentProducerKafkaOptsPartitionsLimit = number | 'all_partitions'
+export type ConfluentProducerKafkaOptsPartitionsLimit = 'all_partitions' | number
 
 export type ConfluentProducerKafkaOptsPartitionStrategy =
   (typeof ConfluentProducerKafkaOptsPartitionStrategy)[keyof typeof ConfluentProducerKafkaOptsPartitionStrategy]
@@ -1583,8 +1583,8 @@ export const ConfluentPostBridgeV2Type = {
 } as const
 
 export type ConfluentPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ConfluentPostBridgeV2 {
   connector: string
@@ -1623,8 +1623,8 @@ export const ConfluentGetBridgeV2Status = {
 } as const
 
 export type ConfluentGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ConfluentGetBridgeV2 {
   connector: string
@@ -1642,8 +1642,8 @@ export interface ConfluentGetBridgeV2 {
 }
 
 export type BridgeTimescalePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTimescalePutBridgeV2 {
   connector: string
@@ -1664,8 +1664,8 @@ export const BridgeTimescalePostBridgeV2Type = {
 } as const
 
 export type BridgeTimescalePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTimescalePostBridgeV2 {
   connector: string
@@ -1680,8 +1680,8 @@ export interface BridgeTimescalePostBridgeV2 {
 }
 
 export type BridgeTimescaleGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTimescaleGetBridgeV2 {
   connector: string
@@ -1694,8 +1694,8 @@ export interface BridgeTimescaleGetBridgeV2 {
 }
 
 export type BridgeTdenginePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeTdenginePostBridgeV2Type =
   (typeof BridgeTdenginePostBridgeV2Type)[keyof typeof BridgeTdenginePostBridgeV2Type]
@@ -1706,8 +1706,8 @@ export const BridgeTdenginePostBridgeV2Type = {
 } as const
 
 export type BridgeTdenginePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeTdengineGetBridgeV2Type =
   (typeof BridgeTdengineGetBridgeV2Type)[keyof typeof BridgeTdengineGetBridgeV2Type]
@@ -1729,8 +1729,8 @@ export const BridgeTdengineGetBridgeV2Status = {
 } as const
 
 export type BridgeTdengineGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTdengineGetBridgeV2 {
   connector: string
@@ -1817,11 +1817,11 @@ export interface BridgeTdenginePostBridgeV2 {
   type: BridgeTdenginePostBridgeV2Type
 }
 
-export type BridgeTablestoreTablestoreFieldsValue = string | number | boolean
+export type BridgeTablestoreTablestoreFieldsValue = boolean | number | string
 
-export type BridgeTablestoreTablestoreFieldsIsint = string | boolean
+export type BridgeTablestoreTablestoreFieldsIsint = boolean | string
 
-export type BridgeTablestoreTablestoreFieldsIsbinary = string | boolean
+export type BridgeTablestoreTablestoreFieldsIsbinary = boolean | string
 
 export interface BridgeTablestoreTablestoreFields {
   column: string
@@ -1831,8 +1831,8 @@ export interface BridgeTablestoreTablestoreFields {
 }
 
 export type BridgeTablestorePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTablestorePutBridgeV2 {
   connector: string
@@ -1853,8 +1853,8 @@ export const BridgeTablestorePostBridgeV2Type = {
 } as const
 
 export type BridgeTablestorePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTablestorePostBridgeV2 {
   connector: string
@@ -1888,8 +1888,8 @@ export const BridgeTablestoreGetBridgeV2Status = {
 } as const
 
 export type BridgeTablestoreGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeTablestoreGetBridgeV2 {
   connector: string
@@ -1948,7 +1948,7 @@ export interface BridgeTablestoreActionResourceOpts {
   worker_pool_size?: number
 }
 
-export type BridgeTablestoreActionParametersTimestamp = string | number
+export type BridgeTablestoreActionParametersTimestamp = number | string
 
 export type BridgeTablestoreActionParametersTags = { [key: string]: unknown }
 
@@ -1981,8 +1981,8 @@ export interface BridgeTablestoreActionParameters {
 }
 
 export type BridgeSqlserverPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeSqlserverPutBridgeV2 {
   connector: string
@@ -2003,8 +2003,8 @@ export const BridgeSqlserverPostBridgeV2Type = {
 } as const
 
 export type BridgeSqlserverPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeSqlserverPostBridgeV2 {
   connector: string
@@ -2038,8 +2038,8 @@ export const BridgeSqlserverGetBridgeV2Status = {
 } as const
 
 export type BridgeSqlserverGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeSqlserverGetBridgeV2 {
   connector: string
@@ -2194,9 +2194,9 @@ export const BridgeS3S3AggregatedUploadParametersMode = {
 export type BridgeS3S3AggregatedUploadParametersHeaders = { [key: string]: unknown }
 
 export type BridgeS3S3AggregatedUploadParametersContainer =
-  | ConnectorAggregatorContainerParquet
-  | ConnectorAggregatorContainerJsonLines
   | ConnectorAggregatorContainerCsv
+  | ConnectorAggregatorContainerJsonLines
+  | ConnectorAggregatorContainerParquet
 
 export type BridgeS3S3AggregatedUploadParametersAcl =
   (typeof BridgeS3S3AggregatedUploadParametersAcl)[keyof typeof BridgeS3S3AggregatedUploadParametersAcl]
@@ -2224,12 +2224,12 @@ export interface BridgeS3S3AggregatedUploadParameters {
 }
 
 export type BridgeS3PutBridgeV2Parameters =
-  | BridgeS3S3DirectUploadParameters
   | BridgeS3S3AggregatedUploadParameters
+  | BridgeS3S3DirectUploadParameters
 
 export type BridgeS3PutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeS3PutBridgeV2 {
   connector: string
@@ -2250,12 +2250,12 @@ export const BridgeS3PostBridgeV2Type = {
 } as const
 
 export type BridgeS3PostBridgeV2Parameters =
-  | BridgeS3S3DirectUploadParameters
   | BridgeS3S3AggregatedUploadParameters
+  | BridgeS3S3DirectUploadParameters
 
 export type BridgeS3PostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeS3PostBridgeV2 {
   connector: string
@@ -2289,12 +2289,12 @@ export const BridgeS3GetBridgeV2Status = {
 } as const
 
 export type BridgeS3GetBridgeV2Parameters =
-  | BridgeS3S3DirectUploadParameters
   | BridgeS3S3AggregatedUploadParameters
+  | BridgeS3S3DirectUploadParameters
 
 export type BridgeS3GetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeS3GetBridgeV2 {
   connector: string
@@ -2316,8 +2316,8 @@ export interface BridgeRedisActionParameters {
 }
 
 export type BridgeRabbitmqPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeRabbitmqPutBridgeV2 {
   connector: string
@@ -2361,8 +2361,8 @@ export const BridgeRabbitmqPostBridgeV2Type = {
 } as const
 
 export type BridgeRabbitmqPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeRabbitmqPostBridgeV2 {
   connector: string
@@ -2401,8 +2401,8 @@ export const BridgeRabbitmqGetBridgeV2Status = {
 } as const
 
 export type BridgeRabbitmqGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeRabbitmqGetBridgeV2 {
   connector: string
@@ -2499,8 +2499,8 @@ export interface BridgePulsarProducerBuffer {
 }
 
 export type BridgePgsqlPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgePgsqlPutBridgeV2 {
   connector: string
@@ -2521,12 +2521,12 @@ export const BridgePgsqlPostBridgeV2Type = {
 } as const
 
 export type BridgePgsqlPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgePgsqlGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgePgsqlActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -2597,8 +2597,8 @@ export interface BridgePgsqlGetBridgeV2 {
 }
 
 export type BridgeOraclePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOraclePutBridgeV2 {
   connector: string
@@ -2619,8 +2619,8 @@ export const BridgeOraclePostBridgeV2Type = {
 } as const
 
 export type BridgeOraclePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOraclePostBridgeV2 {
   connector: string
@@ -2654,8 +2654,8 @@ export const BridgeOracleGetBridgeV2Status = {
 } as const
 
 export type BridgeOracleGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOracleGetBridgeV2 {
   connector: string
@@ -2719,8 +2719,8 @@ export interface BridgeOracleActionParameters {
 }
 
 export type BridgeOpentsPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOpentsPutBridgeV2 {
   connector: string
@@ -2741,8 +2741,8 @@ export const BridgeOpentsPostBridgeV2Type = {
 } as const
 
 export type BridgeOpentsPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOpentsPostBridgeV2 {
   connector: string
@@ -2776,8 +2776,8 @@ export const BridgeOpentsGetBridgeV2Status = {
 } as const
 
 export type BridgeOpentsGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeOpentsGetBridgeV2 {
   connector: string
@@ -2836,13 +2836,13 @@ export interface BridgeOpentsActionResourceOpts {
   worker_pool_size?: number
 }
 
-export type BridgeOpentsActionParametersDataValue = string | number | number
+export type BridgeOpentsActionParametersDataValue = number | number | string
 
 export type BridgeOpentsActionParametersDataTagsOneOf = { [key: string]: unknown }
 
 export type BridgeOpentsActionParametersDataTags =
-  | string
   | BridgeOpentsActionParametersDataTagsOneOf
+  | string
 
 export interface BridgeOpentsActionParametersData {
   metric: string
@@ -2856,8 +2856,8 @@ export interface BridgeOpentsActionParameters {
 }
 
 export type BridgeMysqlPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMysqlPutBridgeV2 {
   connector: string
@@ -2878,8 +2878,8 @@ export const BridgeMysqlPostBridgeV2Type = {
 } as const
 
 export type BridgeMysqlPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeMysqlGetBridgeV2Type =
   (typeof BridgeMysqlGetBridgeV2Type)[keyof typeof BridgeMysqlGetBridgeV2Type]
@@ -2901,8 +2901,8 @@ export const BridgeMysqlGetBridgeV2Status = {
 } as const
 
 export type BridgeMysqlGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeMysqlActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -2979,8 +2979,8 @@ export interface BridgeMysqlGetBridgeV2 {
 }
 
 export type BridgeMqttPublisherPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeMqttPublisherPostBridgeV2Type =
   (typeof BridgeMqttPublisherPostBridgeV2Type)[keyof typeof BridgeMqttPublisherPostBridgeV2Type]
@@ -2991,8 +2991,8 @@ export const BridgeMqttPublisherPostBridgeV2Type = {
 } as const
 
 export type BridgeMqttPublisherPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeMqttPublisherGetBridgeV2Type =
   (typeof BridgeMqttPublisherGetBridgeV2Type)[keyof typeof BridgeMqttPublisherGetBridgeV2Type]
@@ -3014,8 +3014,8 @@ export const BridgeMqttPublisherGetBridgeV2Status = {
 } as const
 
 export type BridgeMqttPublisherGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMqttPublisherGetBridgeV2 {
   connector: string
@@ -3071,9 +3071,9 @@ export interface BridgeMqttPublisherActionResourceOpts {
   worker_pool_size?: number
 }
 
-export type BridgeMqttPublisherActionParametersRetain = string | boolean
+export type BridgeMqttPublisherActionParametersRetain = boolean | string
 
-export type BridgeMqttPublisherActionParametersQos = string | number
+export type BridgeMqttPublisherActionParametersQos = number | string
 
 export interface BridgeMqttPublisherActionParameters {
   payload?: string
@@ -3105,8 +3105,8 @@ export interface BridgeMqttPublisherPostBridgeV2 {
 }
 
 export type BridgeMongodbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMongodbPutBridgeV2 {
   connector: string
@@ -3127,8 +3127,8 @@ export const BridgeMongodbPostBridgeV2Type = {
 } as const
 
 export type BridgeMongodbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMongodbPostBridgeV2 {
   connector: string
@@ -3162,8 +3162,8 @@ export const BridgeMongodbGetBridgeV2Status = {
 } as const
 
 export type BridgeMongodbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMongodbGetBridgeV2 {
   connector: string
@@ -3225,8 +3225,8 @@ export interface BridgeMongodbActionParameters {
 }
 
 export type BridgeMatrixPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMatrixPutBridgeV2 {
   connector: string
@@ -3247,8 +3247,8 @@ export const BridgeMatrixPostBridgeV2Type = {
 } as const
 
 export type BridgeMatrixPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMatrixPostBridgeV2 {
   connector: string
@@ -3263,8 +3263,8 @@ export interface BridgeMatrixPostBridgeV2 {
 }
 
 export type BridgeMatrixGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeMatrixGetBridgeV2 {
   connector: string
@@ -3277,8 +3277,8 @@ export interface BridgeMatrixGetBridgeV2 {
 }
 
 export type BridgeKinesisPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeKinesisPutBridgeV2 {
   connector: string
@@ -3299,8 +3299,8 @@ export const BridgeKinesisPostBridgeV2Type = {
 } as const
 
 export type BridgeKinesisPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeKinesisGetBridgeV2Type =
   (typeof BridgeKinesisGetBridgeV2Type)[keyof typeof BridgeKinesisGetBridgeV2Type]
@@ -3322,8 +3322,8 @@ export const BridgeKinesisGetBridgeV2Status = {
 } as const
 
 export type BridgeKinesisGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeKinesisActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -3411,8 +3411,8 @@ export interface BridgeKafkaResourceOpts {
 }
 
 export type BridgeKafkaPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeKafkaPutBridgeV2 {
   connector: string
@@ -3443,7 +3443,7 @@ export const BridgeKafkaProducerKafkaOptsQueryMode = {
   sync: 'sync',
 } as const
 
-export type BridgeKafkaProducerKafkaOptsPartitionsLimit = number | 'all_partitions'
+export type BridgeKafkaProducerKafkaOptsPartitionsLimit = 'all_partitions' | number
 
 export type BridgeKafkaProducerKafkaOptsPartitionStrategy =
   (typeof BridgeKafkaProducerKafkaOptsPartitionStrategy)[keyof typeof BridgeKafkaProducerKafkaOptsPartitionStrategy]
@@ -3525,8 +3525,8 @@ export const BridgeKafkaPostBridgeV2Type = {
 } as const
 
 export type BridgeKafkaPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeKafkaPostBridgeV2 {
   connector: string
@@ -3566,8 +3566,8 @@ export const BridgeKafkaGetBridgeV2Status = {
 } as const
 
 export type BridgeKafkaGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeKafkaGetBridgeV2 {
   connector: string
@@ -3589,8 +3589,8 @@ export type BridgeIotdbPutBridgeV2Parameters =
   | BridgeIotdbActionParametersTree
 
 export type BridgeIotdbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeIotdbPutBridgeV2 {
   connector: string
@@ -3611,8 +3611,8 @@ export const BridgeIotdbPostBridgeV2Type = {
 } as const
 
 export type BridgeIotdbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeIotdbPostBridgeV2 {
   connector: string
@@ -3650,8 +3650,8 @@ export type BridgeIotdbGetBridgeV2Parameters =
   | BridgeIotdbActionParametersTree
 
 export type BridgeIotdbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeIotdbGetBridgeV2 {
   connector: string
@@ -3749,11 +3749,11 @@ export type BridgeIotdbPostBridgeV2Parameters =
   | BridgeIotdbActionParametersTree
 
 export type BridgeIotdbActionParametersDataTreeTimestamp =
-  | string
   | 'now'
   | 'now_ms'
   | 'now_ns'
   | 'now_us'
+  | string
 
 export type BridgeIotdbActionParametersDataTreeDataType =
   (typeof BridgeIotdbActionParametersDataTreeDataType)[keyof typeof BridgeIotdbActionParametersDataTreeDataType]
@@ -3776,11 +3776,11 @@ export interface BridgeIotdbActionParametersDataTree {
 }
 
 export type BridgeIotdbActionParametersDataTableTimestamp =
-  | string
   | 'now'
   | 'now_ms'
   | 'now_ns'
   | 'now_us'
+  | string
 
 export type BridgeIotdbActionParametersDataTableDataType =
   (typeof BridgeIotdbActionParametersDataTableDataType)[keyof typeof BridgeIotdbActionParametersDataTableDataType]
@@ -3814,8 +3814,8 @@ export interface BridgeIotdbActionParametersDataTable {
 }
 
 export type BridgeInfluxdbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeInfluxdbPostBridgeV2Type =
   (typeof BridgeInfluxdbPostBridgeV2Type)[keyof typeof BridgeInfluxdbPostBridgeV2Type]
@@ -3826,8 +3826,8 @@ export const BridgeInfluxdbPostBridgeV2Type = {
 } as const
 
 export type BridgeInfluxdbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeInfluxdbGetBridgeV2Type =
   (typeof BridgeInfluxdbGetBridgeV2Type)[keyof typeof BridgeInfluxdbGetBridgeV2Type]
@@ -3849,8 +3849,8 @@ export const BridgeInfluxdbGetBridgeV2Status = {
 } as const
 
 export type BridgeInfluxdbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeInfluxdbGetBridgeV2 {
   connector: string
@@ -3948,8 +3948,8 @@ export interface BridgeInfluxdbPostBridgeV2 {
 }
 
 export type BridgeHttpPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeHttpPostBridgeV2Type =
   (typeof BridgeHttpPostBridgeV2Type)[keyof typeof BridgeHttpPostBridgeV2Type]
@@ -3960,8 +3960,8 @@ export const BridgeHttpPostBridgeV2Type = {
 } as const
 
 export type BridgeHttpPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeHttpParametersOptsMethod =
   (typeof BridgeHttpParametersOptsMethod)[keyof typeof BridgeHttpParametersOptsMethod]
@@ -4027,8 +4027,8 @@ export const BridgeHttpGetBridgeV2Status = {
 } as const
 
 export type BridgeHttpGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeHttpGetBridgeV2 {
   connector: string
@@ -4085,8 +4085,8 @@ export interface BridgeHttpActionResourceOpts {
 }
 
 export type BridgeGreptimedbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeGreptimedbPostBridgeV2Type =
   (typeof BridgeGreptimedbPostBridgeV2Type)[keyof typeof BridgeGreptimedbPostBridgeV2Type]
@@ -4097,8 +4097,8 @@ export const BridgeGreptimedbPostBridgeV2Type = {
 } as const
 
 export type BridgeGreptimedbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeGreptimedbPostBridgeV2 {
   connector: string
@@ -4132,8 +4132,8 @@ export const BridgeGreptimedbGetBridgeV2Status = {
 } as const
 
 export type BridgeGreptimedbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeGreptimedbGetBridgeV2 {
   connector: string
@@ -4224,13 +4224,13 @@ export interface BridgeGcpPubsubKeyValuePair {
 }
 
 export type BridgeElasticsearchPutBridgeV2Parameters =
-  | BridgeElasticsearchActionUpdate
-  | BridgeElasticsearchActionDelete
   | BridgeElasticsearchActionCreate
+  | BridgeElasticsearchActionDelete
+  | BridgeElasticsearchActionUpdate
 
 export type BridgeElasticsearchPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeElasticsearchPutBridgeV2 {
   connector: string
@@ -4251,8 +4251,8 @@ export const BridgeElasticsearchPostBridgeV2Type = {
 } as const
 
 export type BridgeElasticsearchPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeElasticsearchGetBridgeV2Type =
   (typeof BridgeElasticsearchGetBridgeV2Type)[keyof typeof BridgeElasticsearchGetBridgeV2Type]
@@ -4274,8 +4274,8 @@ export const BridgeElasticsearchGetBridgeV2Status = {
 } as const
 
 export type BridgeElasticsearchGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeElasticsearchGetBridgeV2 {
   connector: string
@@ -4313,14 +4313,14 @@ export interface BridgeElasticsearchActionUpdate {
 }
 
 export type BridgeElasticsearchPostBridgeV2Parameters =
-  | BridgeElasticsearchActionUpdate
-  | BridgeElasticsearchActionDelete
   | BridgeElasticsearchActionCreate
+  | BridgeElasticsearchActionDelete
+  | BridgeElasticsearchActionUpdate
 
 export type BridgeElasticsearchGetBridgeV2Parameters =
-  | BridgeElasticsearchActionUpdate
-  | BridgeElasticsearchActionDelete
   | BridgeElasticsearchActionCreate
+  | BridgeElasticsearchActionDelete
+  | BridgeElasticsearchActionUpdate
 
 export type BridgeElasticsearchActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -4411,8 +4411,8 @@ export interface BridgeElasticsearchActionCreate {
 }
 
 export type BridgeDynamoPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDynamoPutBridgeV2 {
   connector: string
@@ -4433,8 +4433,8 @@ export const BridgeDynamoPostBridgeV2Type = {
 } as const
 
 export type BridgeDynamoPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDynamoPostBridgeV2 {
   connector: string
@@ -4468,8 +4468,8 @@ export const BridgeDynamoGetBridgeV2Status = {
 } as const
 
 export type BridgeDynamoGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDynamoGetBridgeV2 {
   connector: string
@@ -4541,8 +4541,8 @@ export type BridgeDatalayersPutBridgeV2Parameters =
   | BridgeDatalayersActionParametersInflux
 
 export type BridgeDatalayersPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDatalayersPutBridgeV2 {
   connector: string
@@ -4567,8 +4567,8 @@ export type BridgeDatalayersPostBridgeV2Parameters =
   | BridgeDatalayersActionParametersInflux
 
 export type BridgeDatalayersPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDatalayersPostBridgeV2 {
   connector: string
@@ -4606,8 +4606,8 @@ export type BridgeDatalayersGetBridgeV2Parameters =
   | BridgeDatalayersActionParametersInflux
 
 export type BridgeDatalayersGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeDatalayersGetBridgeV2 {
   connector: string
@@ -4687,8 +4687,8 @@ export interface BridgeDatalayersActionParametersArrowFlight {
 }
 
 export type BridgeClickhousePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeClickhousePostBridgeV2Type =
   (typeof BridgeClickhousePostBridgeV2Type)[keyof typeof BridgeClickhousePostBridgeV2Type]
@@ -4699,8 +4699,8 @@ export const BridgeClickhousePostBridgeV2Type = {
 } as const
 
 export type BridgeClickhousePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeClickhousePostBridgeV2 {
   connector: string
@@ -4734,8 +4734,8 @@ export const BridgeClickhouseGetBridgeV2Status = {
 } as const
 
 export type BridgeClickhouseGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeClickhouseGetBridgeV2 {
   connector: string
@@ -4811,8 +4811,8 @@ export interface BridgeClickhousePutBridgeV2 {
 }
 
 export type BridgeCassaPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeCassaPutBridgeV2 {
   connector: string
@@ -4833,8 +4833,8 @@ export const BridgeCassaPostBridgeV2Type = {
 } as const
 
 export type BridgeCassaPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeCassaPostBridgeV2 {
   connector: string
@@ -4868,8 +4868,8 @@ export const BridgeCassaGetBridgeV2Status = {
 } as const
 
 export type BridgeCassaGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeCassaGetBridgeV2 {
   connector: string
@@ -4933,8 +4933,8 @@ export interface BridgeCassaActionParameters {
 }
 
 export type BridgeAzureEventHubPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type BridgeAzureEventHubProducerKafkaOptsRequiredAcks =
   (typeof BridgeAzureEventHubProducerKafkaOptsRequiredAcks)[keyof typeof BridgeAzureEventHubProducerKafkaOptsRequiredAcks]
@@ -4954,7 +4954,7 @@ export const BridgeAzureEventHubProducerKafkaOptsQueryMode = {
   sync: 'sync',
 } as const
 
-export type BridgeAzureEventHubProducerKafkaOptsPartitionsLimit = number | 'all_partitions'
+export type BridgeAzureEventHubProducerKafkaOptsPartitionsLimit = 'all_partitions' | number
 
 export type BridgeAzureEventHubProducerKafkaOptsPartitionStrategy =
   (typeof BridgeAzureEventHubProducerKafkaOptsPartitionStrategy)[keyof typeof BridgeAzureEventHubProducerKafkaOptsPartitionStrategy]
@@ -5013,8 +5013,8 @@ export const BridgeAzureEventHubPostBridgeV2Type = {
 } as const
 
 export type BridgeAzureEventHubPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeAzureEventHubPostBridgeV2 {
   connector: string
@@ -5053,8 +5053,8 @@ export const BridgeAzureEventHubGetBridgeV2Status = {
 } as const
 
 export type BridgeAzureEventHubGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface BridgeAzureEventHubGetBridgeV2 {
   connector: string
@@ -5147,53 +5147,53 @@ export interface ActionsAndSourcesFallbackActionRepublish {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ActionsAndSourcesFallbackActionReferenceType = {
-  pulsar: 'pulsar',
-  doris: 'doris',
-  influxdb: 'influxdb',
-  couchbase: 'couchbase',
-  azure_blob_storage: 'azure_blob_storage',
-  matrix: 'matrix',
-  cockroachdb: 'cockroachdb',
-  greptimedb: 'greptimedb',
-  mqtt: 'mqtt',
-  mongodb: 'mongodb',
-  redshift: 'redshift',
-  bigquery: 'bigquery',
-  oracle: 'oracle',
-  s3: 's3',
-  http: 'http',
+  alloydb: 'alloydb',
   aws_timestream: 'aws_timestream',
-  kinesis: 'kinesis',
-  s3tables: 's3tables',
-  syskeeper_forwarder: 'syskeeper_forwarder',
-  rocketmq: 'rocketmq',
-  quasardb: 'quasardb',
-  disk_log: 'disk_log',
-  kafka_producer: 'kafka_producer',
-  datalayers: 'datalayers',
-  snowflake: 'snowflake',
-  gcp_pubsub_producer: 'gcp_pubsub_producer',
-  iotdb: 'iotdb',
-  rabbitmq: 'rabbitmq',
-  clickhouse: 'clickhouse',
+  azure_blob_storage: 'azure_blob_storage',
+  azure_event_grid: 'azure_event_grid',
+  azure_event_hub_producer: 'azure_event_hub_producer',
+  bigquery: 'bigquery',
+  bigtable: 'bigtable',
   cassandra: 'cassandra',
+  clickhouse: 'clickhouse',
+  cockroachdb: 'cockroachdb',
+  confluent_producer: 'confluent_producer',
+  couchbase: 'couchbase',
+  datalayers: 'datalayers',
+  disk_log: 'disk_log',
+  doris: 'doris',
+  dynamo: 'dynamo',
+  elasticsearch: 'elasticsearch',
+  emqx_tables: 'emqx_tables',
+  gcp_pubsub_producer: 'gcp_pubsub_producer',
+  greptimedb: 'greptimedb',
+  http: 'http',
+  influxdb: 'influxdb',
+  iotdb: 'iotdb',
+  kafka_producer: 'kafka_producer',
+  kinesis: 'kinesis',
+  matrix: 'matrix',
+  mongodb: 'mongodb',
+  mqtt: 'mqtt',
   mysql: 'mysql',
   opents: 'opents',
-  confluent_producer: 'confluent_producer',
-  emqx_tables: 'emqx_tables',
-  snowflake_streaming: 'snowflake_streaming',
+  oracle: 'oracle',
   pgsql: 'pgsql',
-  sqlserver: 'sqlserver',
-  timescale: 'timescale',
-  azure_event_grid: 'azure_event_grid',
-  dynamo: 'dynamo',
-  bigtable: 'bigtable',
+  pulsar: 'pulsar',
+  quasardb: 'quasardb',
+  rabbitmq: 'rabbitmq',
   redis: 'redis',
-  elasticsearch: 'elasticsearch',
+  redshift: 'redshift',
+  rocketmq: 'rocketmq',
+  s3: 's3',
+  s3tables: 's3tables',
+  snowflake: 'snowflake',
+  snowflake_streaming: 'snowflake_streaming',
+  sqlserver: 'sqlserver',
+  syskeeper_forwarder: 'syskeeper_forwarder',
   tablestore: 'tablestore',
-  azure_event_hub_producer: 'azure_event_hub_producer',
   tdengine: 'tdengine',
-  alloydb: 'alloydb',
+  timescale: 'timescale',
 } as const
 
 export type ActionsAndSourcesFallbackActionReferenceKind =
@@ -5253,8 +5253,8 @@ export interface ActionsAndSourcesActionResourceOpts {
 }
 
 export type ActionSourceAzureEventGridPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSourceAzureEventGridPutBridgeV2 {
   connector: string
@@ -5275,8 +5275,8 @@ export const ActionSourceAzureEventGridPostBridgeV2Type = {
 } as const
 
 export type ActionSourceAzureEventGridPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSourceAzureEventGridPostBridgeV2 {
   connector: string
@@ -5310,8 +5310,8 @@ export const ActionSourceAzureEventGridGetBridgeV2Status = {
 } as const
 
 export type ActionSourceAzureEventGridGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSourceAzureEventGridGetBridgeV2 {
   connector: string
@@ -5329,8 +5329,8 @@ export interface ActionSourceAzureEventGridGetBridgeV2 {
 }
 
 export type ActionSnowflakeStreamingPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSnowflakeStreamingPutBridgeV2 {
   connector: string
@@ -5351,8 +5351,8 @@ export const ActionSnowflakeStreamingPostBridgeV2Type = {
 } as const
 
 export type ActionSnowflakeStreamingPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSnowflakeStreamingParameters {
   connect_timeout?: string
@@ -5400,8 +5400,8 @@ export const ActionSnowflakeStreamingGetBridgeV2Status = {
 } as const
 
 export type ActionSnowflakeStreamingGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionSnowflakeStreamingActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -5461,8 +5461,8 @@ export interface ActionSnowflakeStreamingGetBridgeV2 {
 }
 
 export type ActionSnowflakeAggregatedPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSnowflakeAggregatedProxyConfig {
   host: string
@@ -5482,8 +5482,8 @@ export const ActionSnowflakeAggregatedPostBridgeV2Type = {
 } as const
 
 export type ActionSnowflakeAggregatedPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSnowflakeAggregatedPostBridgeV2 {
   connector: string
@@ -5517,8 +5517,8 @@ export const ActionSnowflakeAggregatedGetBridgeV2Status = {
 } as const
 
 export type ActionSnowflakeAggregatedGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionSnowflakeAggregatedGetBridgeV2 {
   connector: string
@@ -5633,8 +5633,8 @@ export interface ActionS3tablesS3Upload {
 }
 
 export type ActionS3tablesPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionS3tablesPutBridgeV2 {
   connector: string
@@ -5655,8 +5655,8 @@ export const ActionS3tablesPostBridgeV2Type = {
 } as const
 
 export type ActionS3tablesPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionS3tablesPostBridgeV2 {
   connector: string
@@ -5690,8 +5690,8 @@ export const ActionS3tablesGetBridgeV2Status = {
 } as const
 
 export type ActionS3tablesGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionS3tablesGetBridgeV2 {
   connector: string
@@ -5734,8 +5734,8 @@ export interface ActionS3tablesContainerAvro {
 }
 
 export type ActionS3tablesAggregationContainer =
-  | ActionS3tablesContainerParquet
   | ActionS3tablesContainerAvro
+  | ActionS3tablesContainerParquet
 
 export interface ActionS3tablesAggregation {
   container?: ActionS3tablesAggregationContainer
@@ -5794,8 +5794,8 @@ export interface ActionS3tablesActionParameters {
 }
 
 export type ActionRedshiftPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionRedshiftPutBridgeV2 {
   connector: string
@@ -5816,8 +5816,8 @@ export const ActionRedshiftPostBridgeV2Type = {
 } as const
 
 export type ActionRedshiftPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionRedshiftPostBridgeV2 {
   connector: string
@@ -5851,8 +5851,8 @@ export const ActionRedshiftGetBridgeV2Status = {
 } as const
 
 export type ActionRedshiftGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionRedshiftActionParameters {
   sql?: string
@@ -5874,8 +5874,8 @@ export interface ActionRedshiftGetBridgeV2 {
 }
 
 export type ActionQuasardbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionQuasardbPostBridgeV2Type =
   (typeof ActionQuasardbPostBridgeV2Type)[keyof typeof ActionQuasardbPostBridgeV2Type]
@@ -5886,8 +5886,8 @@ export const ActionQuasardbPostBridgeV2Type = {
 } as const
 
 export type ActionQuasardbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionQuasardbPostBridgeV2 {
   connector: string
@@ -5921,8 +5921,8 @@ export const ActionQuasardbGetBridgeV2Status = {
 } as const
 
 export type ActionQuasardbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionQuasardbGetBridgeV2 {
   connector: string
@@ -5997,8 +5997,8 @@ export interface ActionQuasardbPutBridgeV2 {
 }
 
 export type ActionEmqxTablesPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionEmqxTablesPutBridgeV2 {
   connector: string
@@ -6019,8 +6019,8 @@ export const ActionEmqxTablesPostBridgeV2Type = {
 } as const
 
 export type ActionEmqxTablesPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionEmqxTablesPostBridgeV2 {
   connector: string
@@ -6054,8 +6054,8 @@ export const ActionEmqxTablesGetBridgeV2Status = {
 } as const
 
 export type ActionEmqxTablesGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionEmqxTablesGetBridgeV2 {
   connector: string
@@ -6115,8 +6115,8 @@ export interface ActionEmqxTablesActionResourceOpts {
 }
 
 export type ActionDorisPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionDorisPostBridgeV2Type =
   (typeof ActionDorisPostBridgeV2Type)[keyof typeof ActionDorisPostBridgeV2Type]
@@ -6127,8 +6127,8 @@ export const ActionDorisPostBridgeV2Type = {
 } as const
 
 export type ActionDorisPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionDorisGetBridgeV2Type =
   (typeof ActionDorisGetBridgeV2Type)[keyof typeof ActionDorisGetBridgeV2Type]
@@ -6150,8 +6150,8 @@ export const ActionDorisGetBridgeV2Status = {
 } as const
 
 export type ActionDorisGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionDorisGetBridgeV2 {
   connector: string
@@ -6238,8 +6238,8 @@ export interface ActionDorisPostBridgeV2 {
 }
 
 export type ActionDiskLogPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionDiskLogPutBridgeV2 {
   connector: string
@@ -6260,8 +6260,8 @@ export const ActionDiskLogPostBridgeV2Type = {
 } as const
 
 export type ActionDiskLogPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionDiskLogPostBridgeV2 {
   connector: string
@@ -6295,8 +6295,8 @@ export const ActionDiskLogGetBridgeV2Status = {
 } as const
 
 export type ActionDiskLogGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionDiskLogGetBridgeV2 {
   connector: string
@@ -6370,8 +6370,8 @@ export interface ActionDiskLogActionParameters {
 }
 
 export type ActionCouchbasePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionCouchbasePutBridgeV2 {
   connector: string
@@ -6392,8 +6392,8 @@ export const ActionCouchbasePostBridgeV2Type = {
 } as const
 
 export type ActionCouchbasePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionCouchbaseParameters {
   /** @minimum 0 */
@@ -6421,8 +6421,8 @@ export const ActionCouchbaseGetBridgeV2Status = {
 } as const
 
 export type ActionCouchbaseGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionCouchbaseGetBridgeV2 {
   connector: string
@@ -6491,8 +6491,8 @@ export interface ActionCouchbasePostBridgeV2 {
 }
 
 export type ActionCockroachdbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionCockroachdbPostBridgeV2Type =
   (typeof ActionCockroachdbPostBridgeV2Type)[keyof typeof ActionCockroachdbPostBridgeV2Type]
@@ -6503,8 +6503,8 @@ export const ActionCockroachdbPostBridgeV2Type = {
 } as const
 
 export type ActionCockroachdbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionCockroachdbPostBridgeV2 {
   connector: string
@@ -6538,8 +6538,8 @@ export const ActionCockroachdbGetBridgeV2Status = {
 } as const
 
 export type ActionCockroachdbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionCockroachdbActionParameters {
   sql?: string
@@ -6587,8 +6587,8 @@ export interface ActionBigtableSetCellParameters {
 }
 
 export type ActionBigtablePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionBigtablePutBridgeV2 {
   connector: string
@@ -6609,8 +6609,8 @@ export const ActionBigtablePostBridgeV2Type = {
 } as const
 
 export type ActionBigtablePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionBigtablePostBridgeV2 {
   connector: string
@@ -6644,8 +6644,8 @@ export const ActionBigtableGetBridgeV2Status = {
 } as const
 
 export type ActionBigtableGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionBigtableActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -6712,8 +6712,8 @@ export interface ActionBigtableGetBridgeV2 {
 }
 
 export type ActionBigqueryPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionBigqueryPutBridgeV2 {
   connector: string
@@ -6734,8 +6734,8 @@ export const ActionBigqueryPostBridgeV2Type = {
 } as const
 
 export type ActionBigqueryPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionBigqueryPostBridgeV2 {
   connector: string
@@ -6769,8 +6769,8 @@ export const ActionBigqueryGetBridgeV2Status = {
 } as const
 
 export type ActionBigqueryGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionBigqueryGetBridgeV2 {
   connector: string
@@ -6835,8 +6835,8 @@ export interface ActionBigqueryActionParameters {
 }
 
 export type ActionAzureBlobStoragePutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export type ActionAzureBlobStoragePostBridgeV2Type =
   (typeof ActionAzureBlobStoragePostBridgeV2Type)[keyof typeof ActionAzureBlobStoragePostBridgeV2Type]
@@ -6847,12 +6847,12 @@ export const ActionAzureBlobStoragePostBridgeV2Type = {
 } as const
 
 export type ActionAzureBlobStoragePostBridgeV2Parameters =
-  | ActionAzureBlobStorageDirectParameters
   | ActionAzureBlobStorageAggregParameters
+  | ActionAzureBlobStorageDirectParameters
 
 export type ActionAzureBlobStoragePostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAzureBlobStoragePostBridgeV2 {
   connector: string
@@ -6886,8 +6886,8 @@ export const ActionAzureBlobStorageGetBridgeV2Status = {
 } as const
 
 export type ActionAzureBlobStorageGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAzureBlobStorageGetBridgeV2 {
   connector: string
@@ -6920,17 +6920,17 @@ export interface ActionAzureBlobStorageDirectParameters {
 }
 
 export type ActionAzureBlobStoragePutBridgeV2Parameters =
-  | ActionAzureBlobStorageDirectParameters
   | ActionAzureBlobStorageAggregParameters
+  | ActionAzureBlobStorageDirectParameters
 
 export type ActionAzureBlobStorageGetBridgeV2Parameters =
-  | ActionAzureBlobStorageDirectParameters
   | ActionAzureBlobStorageAggregParameters
+  | ActionAzureBlobStorageDirectParameters
 
 export type ActionAzureBlobStorageAggregationContainer =
-  | ConnectorAggregatorContainerParquet
-  | ConnectorAggregatorContainerJsonLines
   | ConnectorAggregatorContainerCsv
+  | ConnectorAggregatorContainerJsonLines
+  | ConnectorAggregatorContainerParquet
 
 export interface ActionAzureBlobStorageAggregation {
   container: ActionAzureBlobStorageAggregationContainer
@@ -7007,8 +7007,8 @@ export interface ActionAzureBlobStoragePutBridgeV2 {
 }
 
 export type ActionAwsTimestreamPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAwsTimestreamPutBridgeV2 {
   connector: string
@@ -7029,8 +7029,8 @@ export const ActionAwsTimestreamPostBridgeV2Type = {
 } as const
 
 export type ActionAwsTimestreamPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAwsTimestreamPostBridgeV2 {
   connector: string
@@ -7064,8 +7064,8 @@ export const ActionAwsTimestreamGetBridgeV2Status = {
 } as const
 
 export type ActionAwsTimestreamGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAwsTimestreamGetBridgeV2 {
   connector: string
@@ -7099,8 +7099,8 @@ export interface ActionAwsTimestreamActionParameters {
 }
 
 export type ActionAlloydbPutBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAlloydbPutBridgeV2 {
   connector: string
@@ -7121,8 +7121,8 @@ export const ActionAlloydbPostBridgeV2Type = {
 } as const
 
 export type ActionAlloydbPostBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAlloydbPostBridgeV2 {
   connector: string
@@ -7156,8 +7156,8 @@ export const ActionAlloydbGetBridgeV2Status = {
 } as const
 
 export type ActionAlloydbGetBridgeV2FallbackActionsItem =
-  | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+  | ActionsAndSourcesFallbackActionRepublish
 
 export interface ActionAlloydbActionParameters {
   sql?: string

--- a/src/types/schemas/actions.schemas.ts
+++ b/src/types/schemas/actions.schemas.ts
@@ -1018,6 +1018,16 @@ export type RedisPutBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
+export interface RedisPutBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: RedisPutBridgeV2FallbackActionsItem[]
+  parameters: BridgeRedisActionParameters
+  resource_opts?: RedisActionResourceOpts
+  tags?: string[]
+}
+
 export type RedisPostBridgeV2Type =
   (typeof RedisPostBridgeV2Type)[keyof typeof RedisPostBridgeV2Type]
 
@@ -1121,16 +1131,6 @@ export interface RedisActionResourceOpts {
   worker_pool_size?: number
 }
 
-export interface RedisPutBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: RedisPutBridgeV2FallbackActionsItem[]
-  parameters: BridgeRedisActionParameters
-  resource_opts?: RedisActionResourceOpts
-  tags?: string[]
-}
-
 export type PulsarPutBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
@@ -1196,6 +1196,21 @@ export const PulsarGetBridgeV2Status = {
 export type PulsarGetBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+
+export interface PulsarGetBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: PulsarGetBridgeV2FallbackActionsItem[]
+  name: string
+  node_status?: ActionsAndSourcesNodeStatus[]
+  parameters: PulsarActionParameters
+  resource_opts?: PulsarActionResourceOpts
+  status?: PulsarGetBridgeV2Status
+  status_reason?: string
+  tags?: string[]
+  type: PulsarGetBridgeV2Type
+}
 
 /**
  * @deprecated
@@ -1819,6 +1834,16 @@ export type BridgeTablestorePutBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
+export interface BridgeTablestorePutBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: BridgeTablestorePutBridgeV2FallbackActionsItem[]
+  parameters: BridgeTablestoreActionParameters
+  resource_opts?: BridgeTablestoreActionResourceOpts
+  tags?: string[]
+}
+
 export type BridgeTablestorePostBridgeV2Type =
   (typeof BridgeTablestorePostBridgeV2Type)[keyof typeof BridgeTablestorePostBridgeV2Type]
 
@@ -1865,6 +1890,21 @@ export const BridgeTablestoreGetBridgeV2Status = {
 export type BridgeTablestoreGetBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
+
+export interface BridgeTablestoreGetBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: BridgeTablestoreGetBridgeV2FallbackActionsItem[]
+  name: string
+  node_status?: ActionsAndSourcesNodeStatus[]
+  parameters: BridgeTablestoreActionParameters
+  resource_opts?: BridgeTablestoreActionResourceOpts
+  status?: BridgeTablestoreGetBridgeV2Status
+  status_reason?: string
+  tags?: string[]
+  type: BridgeTablestoreGetBridgeV2Type
+}
 
 export type BridgeTablestoreActionResourceOptsRequestTtl = 'infinity' | string
 
@@ -1938,31 +1978,6 @@ export interface BridgeTablestoreActionParameters {
   table_name: string
   tags?: BridgeTablestoreActionParametersTags
   timestamp?: BridgeTablestoreActionParametersTimestamp
-}
-
-export interface BridgeTablestorePutBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeTablestorePutBridgeV2FallbackActionsItem[]
-  parameters: BridgeTablestoreActionParameters
-  resource_opts?: BridgeTablestoreActionResourceOpts
-  tags?: string[]
-}
-
-export interface BridgeTablestoreGetBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeTablestoreGetBridgeV2FallbackActionsItem[]
-  name: string
-  node_status?: ActionsAndSourcesNodeStatus[]
-  parameters: BridgeTablestoreActionParameters
-  resource_opts?: BridgeTablestoreActionResourceOpts
-  status?: BridgeTablestoreGetBridgeV2Status
-  status_reason?: string
-  tags?: string[]
-  type: BridgeTablestoreGetBridgeV2Type
 }
 
 export type BridgeSqlserverPutBridgeV2FallbackActionsItem =
@@ -2389,6 +2404,21 @@ export type BridgeRabbitmqGetBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
+export interface BridgeRabbitmqGetBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: BridgeRabbitmqGetBridgeV2FallbackActionsItem[]
+  name: string
+  node_status?: ActionsAndSourcesNodeStatus[]
+  parameters: BridgeRabbitmqActionParameters
+  resource_opts?: BridgeRabbitmqActionResourceOpts
+  status?: BridgeRabbitmqGetBridgeV2Status
+  status_reason?: string
+  tags?: string[]
+  type: BridgeRabbitmqGetBridgeV2Type
+}
+
 export type BridgeRabbitmqActionResourceOptsRequestTtl = 'infinity' | string
 
 export type BridgeRabbitmqActionResourceOptsQueryMode =
@@ -2449,33 +2479,6 @@ export interface BridgeRabbitmqActionParameters {
   publish_confirmation_timeout?: string
   routing_key: string
   wait_for_publish_confirmations?: boolean
-}
-
-export interface BridgeRabbitmqPostBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeRabbitmqPostBridgeV2FallbackActionsItem[]
-  name: string
-  parameters: BridgeRabbitmqActionParameters
-  resource_opts?: BridgeRabbitmqActionResourceOpts
-  tags?: string[]
-  type: BridgeRabbitmqPostBridgeV2Type
-}
-
-export interface BridgeRabbitmqGetBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeRabbitmqGetBridgeV2FallbackActionsItem[]
-  name: string
-  node_status?: ActionsAndSourcesNodeStatus[]
-  parameters: BridgeRabbitmqActionParameters
-  resource_opts?: BridgeRabbitmqActionResourceOpts
-  status?: BridgeRabbitmqGetBridgeV2Status
-  status_reason?: string
-  tags?: string[]
-  type: BridgeRabbitmqGetBridgeV2Type
 }
 
 export type BridgePulsarProducerBufferMode =
@@ -3299,18 +3302,6 @@ export type BridgeKinesisPostBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
-export interface BridgeKinesisPostBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeKinesisPostBridgeV2FallbackActionsItem[]
-  name: string
-  parameters: BridgeKinesisActionParameters
-  resource_opts?: BridgeKinesisActionResourceOpts
-  tags?: string[]
-  type: BridgeKinesisPostBridgeV2Type
-}
-
 export type BridgeKinesisGetBridgeV2Type =
   (typeof BridgeKinesisGetBridgeV2Type)[keyof typeof BridgeKinesisGetBridgeV2Type]
 
@@ -3485,23 +3476,6 @@ export const BridgeKafkaProducerKafkaOptsCompression = {
 export interface BridgeKafkaProducerKafkaExtHeaders {
   kafka_ext_header_key: string
   kafka_ext_header_value: string
-}
-
-export type BridgeKafkaProducerBufferMode =
-  (typeof BridgeKafkaProducerBufferMode)[keyof typeof BridgeKafkaProducerBufferMode]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BridgeKafkaProducerBufferMode = {
-  disk: 'disk',
-  hybrid: 'hybrid',
-  memory: 'memory',
-} as const
-
-export interface BridgeKafkaProducerBuffer {
-  memory_overload_protection?: boolean
-  mode?: BridgeKafkaProducerBufferMode
-  per_partition_limit?: string
-  segment_bytes?: string
 }
 
 export interface BridgeKafkaProducerKafkaOpts {
@@ -3855,18 +3829,6 @@ export type BridgeInfluxdbPostBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
-export interface BridgeInfluxdbPostBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeInfluxdbPostBridgeV2FallbackActionsItem[]
-  name: string
-  parameters: BridgeInfluxdbActionParameters
-  resource_opts?: BridgeInfluxdbActionResourceOpts
-  tags?: string[]
-  type: BridgeInfluxdbPostBridgeV2Type
-}
-
 export type BridgeInfluxdbGetBridgeV2Type =
   (typeof BridgeInfluxdbGetBridgeV2Type)[keyof typeof BridgeInfluxdbGetBridgeV2Type]
 
@@ -3988,16 +3950,6 @@ export interface BridgeInfluxdbPostBridgeV2 {
 export type BridgeHttpPutBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
-
-export interface BridgeHttpPutBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: BridgeHttpPutBridgeV2FallbackActionsItem[]
-  parameters: BridgeHttpParametersOpts
-  resource_opts?: BridgeHttpActionResourceOpts
-  tags?: string[]
-}
 
 export type BridgeHttpPostBridgeV2Type =
   (typeof BridgeHttpPostBridgeV2Type)[keyof typeof BridgeHttpPostBridgeV2Type]
@@ -4297,11 +4249,6 @@ export type BridgeElasticsearchPostBridgeV2Type =
 export const BridgeElasticsearchPostBridgeV2Type = {
   elasticsearch: 'elasticsearch',
 } as const
-
-export type BridgeElasticsearchPostBridgeV2Parameters =
-  | BridgeElasticsearchActionUpdate
-  | BridgeElasticsearchActionDelete
-  | BridgeElasticsearchActionCreate
 
 export type BridgeElasticsearchPostBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
@@ -5200,53 +5147,53 @@ export interface ActionsAndSourcesFallbackActionRepublish {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ActionsAndSourcesFallbackActionReferenceType = {
-  emqx_tables: 'emqx_tables',
-  tdengine: 'tdengine',
-  iotdb: 'iotdb',
-  kafka_producer: 'kafka_producer',
-  rocketmq: 'rocketmq',
-  alloydb: 'alloydb',
-  tablestore: 'tablestore',
-  disk_log: 'disk_log',
-  snowflake: 'snowflake',
-  sqlserver: 'sqlserver',
-  mqtt: 'mqtt',
-  matrix: 'matrix',
-  bigtable: 'bigtable',
-  greptimedb: 'greptimedb',
-  cassandra: 'cassandra',
-  cockroachdb: 'cockroachdb',
-  mysql: 'mysql',
-  http: 'http',
-  oracle: 'oracle',
-  clickhouse: 'clickhouse',
-  snowflake_streaming: 'snowflake_streaming',
-  redis: 'redis',
-  redshift: 'redshift',
-  opents: 'opents',
-  rabbitmq: 'rabbitmq',
-  azure_event_grid: 'azure_event_grid',
   pulsar: 'pulsar',
-  kinesis: 'kinesis',
-  gcp_pubsub_producer: 'gcp_pubsub_producer',
-  couchbase: 'couchbase',
-  dynamo: 'dynamo',
-  s3: 's3',
-  datalayers: 'datalayers',
-  s3tables: 's3tables',
-  syskeeper_forwarder: 'syskeeper_forwarder',
-  bigquery: 'bigquery',
-  azure_event_hub_producer: 'azure_event_hub_producer',
   doris: 'doris',
   influxdb: 'influxdb',
-  pgsql: 'pgsql',
-  confluent_producer: 'confluent_producer',
-  elasticsearch: 'elasticsearch',
+  couchbase: 'couchbase',
   azure_blob_storage: 'azure_blob_storage',
-  quasardb: 'quasardb',
-  timescale: 'timescale',
+  matrix: 'matrix',
+  cockroachdb: 'cockroachdb',
+  greptimedb: 'greptimedb',
+  mqtt: 'mqtt',
   mongodb: 'mongodb',
+  redshift: 'redshift',
+  bigquery: 'bigquery',
+  oracle: 'oracle',
+  s3: 's3',
+  http: 'http',
   aws_timestream: 'aws_timestream',
+  kinesis: 'kinesis',
+  s3tables: 's3tables',
+  syskeeper_forwarder: 'syskeeper_forwarder',
+  rocketmq: 'rocketmq',
+  quasardb: 'quasardb',
+  disk_log: 'disk_log',
+  kafka_producer: 'kafka_producer',
+  datalayers: 'datalayers',
+  snowflake: 'snowflake',
+  gcp_pubsub_producer: 'gcp_pubsub_producer',
+  iotdb: 'iotdb',
+  rabbitmq: 'rabbitmq',
+  clickhouse: 'clickhouse',
+  cassandra: 'cassandra',
+  mysql: 'mysql',
+  opents: 'opents',
+  confluent_producer: 'confluent_producer',
+  emqx_tables: 'emqx_tables',
+  snowflake_streaming: 'snowflake_streaming',
+  pgsql: 'pgsql',
+  sqlserver: 'sqlserver',
+  timescale: 'timescale',
+  azure_event_grid: 'azure_event_grid',
+  dynamo: 'dynamo',
+  bigtable: 'bigtable',
+  redis: 'redis',
+  elasticsearch: 'elasticsearch',
+  tablestore: 'tablestore',
+  azure_event_hub_producer: 'azure_event_hub_producer',
+  tdengine: 'tdengine',
+  alloydb: 'alloydb',
 } as const
 
 export type ActionsAndSourcesFallbackActionReferenceKind =
@@ -5385,6 +5332,16 @@ export type ActionSnowflakeStreamingPutBridgeV2FallbackActionsItem =
   | ActionsAndSourcesFallbackActionRepublish
   | ActionsAndSourcesFallbackActionReference
 
+export interface ActionSnowflakeStreamingPutBridgeV2 {
+  connector: string
+  description?: string
+  enable?: boolean
+  fallback_actions?: ActionSnowflakeStreamingPutBridgeV2FallbackActionsItem[]
+  parameters: ActionSnowflakeStreamingParameters
+  resource_opts?: ActionSnowflakeStreamingActionResourceOpts
+  tags?: string[]
+}
+
 export type ActionSnowflakeStreamingPostBridgeV2Type =
   (typeof ActionSnowflakeStreamingPostBridgeV2Type)[keyof typeof ActionSnowflakeStreamingPostBridgeV2Type]
 
@@ -5409,16 +5366,6 @@ export interface ActionSnowflakeStreamingParameters {
   /** @minimum 1 */
   pool_size?: number
   schema: string
-}
-
-export interface ActionSnowflakeStreamingPutBridgeV2 {
-  connector: string
-  description?: string
-  enable?: boolean
-  fallback_actions?: ActionSnowflakeStreamingPutBridgeV2FallbackActionsItem[]
-  parameters: ActionSnowflakeStreamingParameters
-  resource_opts?: ActionSnowflakeStreamingActionResourceOpts
-  tags?: string[]
 }
 
 export interface ActionSnowflakeStreamingPostBridgeV2 {
@@ -6635,7 +6582,7 @@ export interface ActionBigtableSetCellParameters {
   column_qualifier: string
   family_name: string
   timestamp_micros: string
-  type?: ActionBigtableSetCellParametersType
+  type: ActionBigtableSetCellParametersType
   value: string
 }
 
@@ -6743,10 +6690,10 @@ export interface ActionBigtableActionResourceOpts {
 }
 
 export interface ActionBigtableActionParameters {
-  instance_id?: string
-  mutations?: ActionBigtableSetCellParameters[]
-  row_key?: string
-  table_id?: string
+  instance_id: string
+  mutations: ActionBigtableSetCellParameters[]
+  row_key: string
+  table_id: string
 }
 
 export interface ActionBigtableGetBridgeV2 {

--- a/src/types/schemas/aiCompletion.schemas.ts
+++ b/src/types/schemas/aiCompletion.schemas.ts
@@ -180,9 +180,9 @@ export type GetAiProviders503 = {
 }
 
 export type GetAiProviders200Item =
-  | AiOpenaiResponseProviderApiGet
-  | AiOpenaiProviderApiGet
   | AiAnthropicProviderApiGet
+  | AiOpenaiProviderApiGet
+  | AiOpenaiResponseProviderApiGet
 
 export type PostAiModels503Code = (typeof PostAiModels503Code)[keyof typeof PostAiModels503Code]
 
@@ -463,9 +463,9 @@ export interface AiOpenaiResponseCompletionProfileApiGet {
 }
 
 export type GetAiCompletionProfiles200Item =
-  | AiOpenaiResponseCompletionProfileApiGet
-  | AiOpenaiCompletionProfileApiGet
   | AiAnthropicCompletionProfileApiGet
+  | AiOpenaiCompletionProfileApiGet
+  | AiOpenaiResponseCompletionProfileApiGet
 
 export type AiOpenaiResponseCompletionProfileType =
   (typeof AiOpenaiResponseCompletionProfileType)[keyof typeof AiOpenaiResponseCompletionProfileType]

--- a/src/types/schemas/alarms.schemas.ts
+++ b/src/types/schemas/alarms.schemas.ts
@@ -3,8 +3,8 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetAlarmsParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
   activated?: boolean
 }
 

--- a/src/types/schemas/apiKeys.schemas.ts
+++ b/src/types/schemas/apiKeys.schemas.ts
@@ -22,13 +22,13 @@ export type PutApiKeyName400 = {
   message?: string
 }
 
-export type PutApiKeyName200Scopes = string[] | 'unset'
+export type PutApiKeyName200Scopes = 'unset' | string[]
 
-export type PutApiKeyName200ExpiredAtOneOf = number | string
+export type PutApiKeyName200ExpiredAtOneOf = string | number
 
-export type PutApiKeyName200ExpiredAt = PutApiKeyName200ExpiredAtOneOf | 'infinity'
+export type PutApiKeyName200ExpiredAt = 'infinity' | PutApiKeyName200ExpiredAtOneOf
 
-export type PutApiKeyName200CreatedAt = number | string
+export type PutApiKeyName200CreatedAt = string | number
 
 export type PutApiKeyName200 = {
   api_key?: string
@@ -43,9 +43,9 @@ export type PutApiKeyName200 = {
   scopes?: PutApiKeyName200Scopes
 }
 
-export type PutApiKeyNameBodyExpiredAtOneOf = number | string
+export type PutApiKeyNameBodyExpiredAtOneOf = string | number
 
-export type PutApiKeyNameBodyExpiredAt = PutApiKeyNameBodyExpiredAtOneOf | 'infinity'
+export type PutApiKeyNameBodyExpiredAt = 'infinity' | PutApiKeyNameBodyExpiredAtOneOf
 
 export type PutApiKeyNameBody = {
   desc?: string
@@ -69,13 +69,13 @@ export type GetApiKeyName404 = {
   message?: string
 }
 
-export type GetApiKeyName200Scopes = string[] | 'unset'
+export type GetApiKeyName200Scopes = 'unset' | string[]
 
-export type GetApiKeyName200ExpiredAtOneOf = number | string
+export type GetApiKeyName200ExpiredAtOneOf = string | number
 
-export type GetApiKeyName200ExpiredAt = GetApiKeyName200ExpiredAtOneOf | 'infinity'
+export type GetApiKeyName200ExpiredAt = 'infinity' | GetApiKeyName200ExpiredAtOneOf
 
-export type GetApiKeyName200CreatedAt = number | string
+export type GetApiKeyName200CreatedAt = string | number
 
 export type GetApiKeyName200 = {
   api_key?: string
@@ -127,9 +127,9 @@ export type PostApiKey400 = {
   message?: string
 }
 
-export type PostApiKeyBodyExpiredAtOneOf = number | string
+export type PostApiKeyBodyExpiredAtOneOf = string | number
 
-export type PostApiKeyBodyExpiredAt = PostApiKeyBodyExpiredAtOneOf | 'infinity'
+export type PostApiKeyBodyExpiredAt = 'infinity' | PostApiKeyBodyExpiredAtOneOf
 
 export type PostApiKeyBody = {
   desc?: string
@@ -142,13 +142,13 @@ export type PostApiKeyBody = {
   scopes?: string[]
 }
 
-export type GetApiKey200Scopes = string[] | 'unset'
+export type GetApiKey200Scopes = 'unset' | string[]
 
-export type GetApiKey200ExpiredAtOneOf = number | string
+export type GetApiKey200ExpiredAtOneOf = string | number
 
-export type GetApiKey200ExpiredAt = GetApiKey200ExpiredAtOneOf | 'infinity'
+export type GetApiKey200ExpiredAt = 'infinity' | GetApiKey200ExpiredAtOneOf
 
-export type GetApiKey200CreatedAt = number | string
+export type GetApiKey200CreatedAt = string | number
 
 export type GetApiKey200 = {
   api_key?: string
@@ -172,13 +172,13 @@ export interface ApiKeyScopesResponse {
   scopes?: ApiKeyScopeInfo[]
 }
 
-export type ApiKeyAppResponseScopes = string[] | 'unset'
+export type ApiKeyAppResponseScopes = 'unset' | string[]
 
-export type ApiKeyAppResponseExpiredAtOneOf = number | string
+export type ApiKeyAppResponseExpiredAtOneOf = string | number
 
-export type ApiKeyAppResponseExpiredAt = ApiKeyAppResponseExpiredAtOneOf | 'infinity'
+export type ApiKeyAppResponseExpiredAt = 'infinity' | ApiKeyAppResponseExpiredAtOneOf
 
-export type ApiKeyAppResponseCreatedAt = number | string
+export type ApiKeyAppResponseCreatedAt = string | number
 
 export interface ApiKeyAppResponse {
   api_key?: string

--- a/src/types/schemas/audit.schemas.ts
+++ b/src/types/schemas/audit.schemas.ts
@@ -43,21 +43,21 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetAuditParams = {
-  node?: string
-  from?: GetAuditFrom
-  source?: string
-  source_ip?: string
+  limit?: PublicLimitParameter
+  page?: PublicPageParameter
   operation_id?: string
-  operation_type?: string
+  source_ip?: string
+  gte_created_at?: string | number
+  lte_created_at?: string | number
+  source?: string
+  from?: GetAuditFrom
+  node?: string
   operation_result?: GetAuditOperationResult
-  http_status_code?: number
   http_method?: GetAuditHttpMethod
+  operation_type?: string
   gte_duration_ms?: number
   lte_duration_ms?: number
-  gte_created_at?: number | string
-  lte_created_at?: number | string
-  page?: PublicPageParameter
-  limit?: PublicLimitParameter
+  http_status_code?: number
 }
 
 export interface PublicMeta {
@@ -129,7 +129,7 @@ export const AuditAuditFrom = {
   rest_api: 'rest_api',
 } as const
 
-export type AuditAuditCreatedAt = number | string
+export type AuditAuditCreatedAt = string | number
 
 export interface AuditAudit {
   args?: string[]

--- a/src/types/schemas/authentication.schemas.ts
+++ b/src/types/schemas/authentication.schemas.ts
@@ -1,55 +1,3 @@
-export type PutAuthenticationSettings400Code =
-  (typeof PutAuthenticationSettings400Code)[keyof typeof PutAuthenticationSettings400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutAuthenticationSettings400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PutAuthenticationSettings400 = {
-  code?: PutAuthenticationSettings400Code
-  message?: string
-}
-
-export type PutAuthenticationOrder400Code =
-  (typeof PutAuthenticationOrder400Code)[keyof typeof PutAuthenticationOrder400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutAuthenticationOrder400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PutAuthenticationOrder400 = {
-  code?: PutAuthenticationOrder400Code
-  message?: string
-}
-
-export type GetAuthenticationNodeCacheStatus500Code =
-  (typeof GetAuthenticationNodeCacheStatus500Code)[keyof typeof GetAuthenticationNodeCacheStatus500Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetAuthenticationNodeCacheStatus500Code = {
-  INTERNAL_ERROR: 'INTERNAL_ERROR',
-} as const
-
-export type GetAuthenticationNodeCacheStatus500 = {
-  code?: GetAuthenticationNodeCacheStatus500Code
-  message?: string
-}
-
-export type PostAuthenticationNodeCacheReset500Code =
-  (typeof PostAuthenticationNodeCacheReset500Code)[keyof typeof PostAuthenticationNodeCacheReset500Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostAuthenticationNodeCacheReset500Code = {
-  INTERNAL_ERROR: 'INTERNAL_ERROR',
-} as const
-
-export type PostAuthenticationNodeCacheReset500 = {
-  code?: PostAuthenticationNodeCacheReset500Code
-  message?: string
-}
-
 export type PutAuthenticationIdUsersUserId404Code =
   (typeof PutAuthenticationIdUsersUserId404Code)[keyof typeof PutAuthenticationIdUsersUserId404Code]
 
@@ -158,11 +106,11 @@ export type GetAuthenticationIdUsers404 = {
 }
 
 export type GetAuthenticationIdUsersParams = {
-  ns?: string
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
-  like_user_id?: string
+  page?: PublicPageParameter
   is_superuser?: boolean
+  like_user_id?: string
+  ns?: string
 }
 
 export type GetAuthenticationIdStatus500Code =
@@ -381,6 +329,58 @@ export type GetAuthenticationId200 =
   | AuthnScramRestapiGet
   | AuthnScramRestapiPost
 
+export type PutAuthenticationSettings400Code =
+  (typeof PutAuthenticationSettings400Code)[keyof typeof PutAuthenticationSettings400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutAuthenticationSettings400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PutAuthenticationSettings400 = {
+  code?: PutAuthenticationSettings400Code
+  message?: string
+}
+
+export type PutAuthenticationOrder400Code =
+  (typeof PutAuthenticationOrder400Code)[keyof typeof PutAuthenticationOrder400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutAuthenticationOrder400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PutAuthenticationOrder400 = {
+  code?: PutAuthenticationOrder400Code
+  message?: string
+}
+
+export type GetAuthenticationNodeCacheStatus500Code =
+  (typeof GetAuthenticationNodeCacheStatus500Code)[keyof typeof GetAuthenticationNodeCacheStatus500Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetAuthenticationNodeCacheStatus500Code = {
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const
+
+export type GetAuthenticationNodeCacheStatus500 = {
+  code?: GetAuthenticationNodeCacheStatus500Code
+  message?: string
+}
+
+export type PostAuthenticationNodeCacheReset500Code =
+  (typeof PostAuthenticationNodeCacheReset500Code)[keyof typeof PostAuthenticationNodeCacheReset500Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostAuthenticationNodeCacheReset500Code = {
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const
+
+export type PostAuthenticationNodeCacheReset500 = {
+  code?: PostAuthenticationNodeCacheReset500Code
+  message?: string
+}
+
 export type PostAuthentication409Code =
   (typeof PostAuthentication409Code)[keyof typeof PostAuthentication409Code]
 
@@ -454,27 +454,27 @@ export type PostAuthenticationBody =
   | AuthnScramRestapiPost
 
 export type GetAuthentication200Item =
+  | AuthnBuiltinDb
   | AuthnCinfo
-  | AuthnKerberos
-  | AuthnScramRestapiPost
-  | AuthnScramRestapiGet
   | AuthnGcpDevice
-  | AuthnLdap
-  | AuthnScram
+  | AuthnHttpGet
+  | AuthnHttpPost
+  | AuthnJwtHmac
   | AuthnJwtJwks
   | AuthnJwtPublicKey
-  | AuthnJwtHmac
-  | AuthnHttpPost
-  | AuthnHttpGet
-  | AuthnRedisSentinel
-  | AuthnRedisCluster
-  | AuthnRedisSingle
-  | AuthnMongoSharded
+  | AuthnKerberos
+  | AuthnLdap
   | AuthnMongoRs
+  | AuthnMongoSharded
   | AuthnMongoSingle
-  | AuthnPostgresql
   | AuthnMysql
-  | AuthnBuiltinDb
+  | AuthnPostgresql
+  | AuthnRedisCluster
+  | AuthnRedisSentinel
+  | AuthnRedisSingle
+  | AuthnScram
+  | AuthnScramRestapiGet
+  | AuthnScramRestapiPost
 
 export type PublicPageParameter = number
 
@@ -515,15 +515,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -567,6 +567,48 @@ export interface LdapSsl {
   versions?: string[]
 }
 
+export interface EmqxAuthnApiResponseUser {
+  is_superuser?: boolean
+  namespace?: string
+  user_id: string
+}
+
+export interface EmqxAuthnApiResponseUsers {
+  data?: EmqxAuthnApiResponseUser[]
+  meta?: PublicMeta
+}
+
+export interface EmqxAuthnApiResponseAuthnSettings {
+  ignore_backend_failures?: boolean
+  node_cache?: AuthCacheConfig
+}
+
+export interface EmqxAuthnApiRequestUserUpdate {
+  is_superuser?: boolean
+  namespace?: string
+  password: string
+}
+
+export interface EmqxAuthnApiRequestUserDelete {
+  namespace?: string
+}
+
+export interface EmqxAuthnApiRequestUserCreate {
+  is_superuser?: boolean
+  namespace?: string
+  password: string
+  user_id: string
+}
+
+export interface EmqxAuthnApiRequestAuthnSettings {
+  ignore_backend_failures?: boolean
+  node_cache?: AuthCacheConfig
+}
+
+export interface EmqxAuthnApiRequestAuthnOrder {
+  id: string
+}
+
 export type EmqxSslClientOptsVerify =
   (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
 
@@ -576,16 +618,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -635,48 +677,6 @@ export interface EmqxSslClientOpts {
   versions?: string[]
 }
 
-export interface EmqxAuthnApiResponseUser {
-  is_superuser?: boolean
-  namespace?: string
-  user_id: string
-}
-
-export interface EmqxAuthnApiResponseUsers {
-  data?: EmqxAuthnApiResponseUser[]
-  meta?: PublicMeta
-}
-
-export interface EmqxAuthnApiResponseAuthnSettings {
-  ignore_backend_failures?: boolean
-  node_cache?: AuthCacheConfig
-}
-
-export interface EmqxAuthnApiRequestUserUpdate {
-  is_superuser?: boolean
-  namespace?: string
-  password: string
-}
-
-export interface EmqxAuthnApiRequestUserDelete {
-  namespace?: string
-}
-
-export interface EmqxAuthnApiRequestUserCreate {
-  is_superuser?: boolean
-  namespace?: string
-  password: string
-  user_id: string
-}
-
-export interface EmqxAuthnApiRequestAuthnSettings {
-  ignore_backend_failures?: boolean
-  node_cache?: AuthCacheConfig
-}
-
-export interface EmqxAuthnApiRequestAuthnOrder {
-  id: string
-}
-
 export type ConnectorHttpRequestHeaders = { [key: string]: unknown }
 
 export interface ConnectorHttpRequest {
@@ -687,6 +687,108 @@ export interface ConnectorHttpRequest {
   method?: string
   path?: string
   request_timeout?: string
+}
+
+export type AuthnHashSimpleSaltPosition =
+  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleSaltPosition = {
+  disable: 'disable',
+  prefix: 'prefix',
+  suffix: 'suffix',
+} as const
+
+export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleName = {
+  md5: 'md5',
+  plain: 'plain',
+  sha: 'sha',
+  sha256: 'sha256',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashSimple {
+  name: AuthnHashSimpleName
+  salt_position?: AuthnHashSimpleSaltPosition
+}
+
+export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2Name = {
+  pbkdf2: 'pbkdf2',
+} as const
+
+export type AuthnHashPbkdf2MacFun =
+  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2MacFun = {
+  md4: 'md4',
+  md5: 'md5',
+  ripemd160: 'ripemd160',
+  sha: 'sha',
+  sha224: 'sha224',
+  sha256: 'sha256',
+  sha384: 'sha384',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashPbkdf2 {
+  /** @minimum 1 */
+  dk_length?: number
+  /** @minimum 1 */
+  iterations: number
+  mac_fun: AuthnHashPbkdf2MacFun
+  name: AuthnHashPbkdf2Name
+}
+
+export type AuthnHashBcryptRwApiName =
+  (typeof AuthnHashBcryptRwApiName)[keyof typeof AuthnHashBcryptRwApiName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptRwApiName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcryptRwApi {
+  name: AuthnHashBcryptRwApiName
+  /**
+   * @minimum 5
+   * @maximum 10
+   */
+  salt_rounds?: number
+}
+
+export type AuthnHashBcryptRwName =
+  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptRwName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcryptRw {
+  name: AuthnHashBcryptRwName
+  /**
+   * @minimum 5
+   * @maximum 10
+   */
+  salt_rounds?: number
+}
+
+export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcrypt {
+  name: AuthnHashBcryptName
 }
 
 export type AuthnScramRestapiPostMethod =
@@ -873,9 +975,9 @@ export const AuthnRedisSingleRedisType = {
 } as const
 
 export type AuthnRedisSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSingleMechanism =
   (typeof AuthnRedisSingleMechanism)[keyof typeof AuthnRedisSingleMechanism]
@@ -922,9 +1024,9 @@ export const AuthnRedisSentinelRedisType = {
 } as const
 
 export type AuthnRedisSentinelPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSentinelMechanism =
   (typeof AuthnRedisSentinelMechanism)[keyof typeof AuthnRedisSentinelMechanism]
@@ -974,9 +1076,9 @@ export const AuthnRedisClusterRedisType = {
 } as const
 
 export type AuthnRedisClusterPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisClusterMechanism =
   (typeof AuthnRedisClusterMechanism)[keyof typeof AuthnRedisClusterMechanism]
@@ -1013,9 +1115,9 @@ export interface AuthnRedisCluster {
 }
 
 export type AuthnPostgresqlPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnPostgresqlMechanism =
   (typeof AuthnPostgresqlMechanism)[keyof typeof AuthnPostgresqlMechanism]
@@ -1083,7 +1185,7 @@ export interface AuthnNodeError {
   node?: string
 }
 
-export type AuthnMysqlPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMysqlPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMysqlMechanism = (typeof AuthnMysqlMechanism)[keyof typeof AuthnMysqlMechanism]
 
@@ -1134,15 +1236,15 @@ export type AuthnMongoSingleUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoSingleUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoSingleMongoType =
   (typeof AuthnMongoSingleMongoType)[keyof typeof AuthnMongoSingleMongoType]
@@ -1211,15 +1313,15 @@ export type AuthnMongoShardedUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoShardedUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoShardedPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoShardedMongoType =
   (typeof AuthnMongoShardedMongoType)[keyof typeof AuthnMongoShardedMongoType]
@@ -1287,9 +1389,9 @@ export type AuthnMongoRsUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoRsUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoRsRMode = (typeof AuthnMongoRsRMode)[keyof typeof AuthnMongoRsRMode]
@@ -1300,7 +1402,7 @@ export const AuthnMongoRsRMode = {
   slave_ok: 'slave_ok',
 } as const
 
-export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMongoRsMongoType =
   (typeof AuthnMongoRsMongoType)[keyof typeof AuthnMongoRsMongoType]
@@ -1611,16 +1713,16 @@ export const AuthnJwksClientSslOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type AuthnJwksClientSslOptsServerNameIndication = string | 'disable'
+export type AuthnJwksClientSslOptsServerNameIndication = 'disable' | string
 
 export type AuthnJwksClientSslOptsPartialChain =
   (typeof AuthnJwksClientSslOptsPartialChain)[keyof typeof AuthnJwksClientSslOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnJwksClientSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -1840,9 +1942,9 @@ export const AuthnBuiltinDbApiUserIdType = {
 } as const
 
 export type AuthnBuiltinDbApiPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcryptRwApi
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnBuiltinDbApiMechanism =
   (typeof AuthnBuiltinDbApiMechanism)[keyof typeof AuthnBuiltinDbApiMechanism]
@@ -1890,9 +1992,9 @@ export const AuthnBuiltinDbUserIdType = {
 } as const
 
 export type AuthnBuiltinDbPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcryptRw
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnBuiltinDbMechanism =
   (typeof AuthnBuiltinDbMechanism)[keyof typeof AuthnBuiltinDbMechanism]
@@ -1944,108 +2046,6 @@ export interface AuthnBindMethod {
   type?: AuthnBindMethodType
 }
 
-export type AuthnHashSimpleSaltPosition =
-  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleSaltPosition = {
-  disable: 'disable',
-  prefix: 'prefix',
-  suffix: 'suffix',
-} as const
-
-export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleName = {
-  md5: 'md5',
-  plain: 'plain',
-  sha: 'sha',
-  sha256: 'sha256',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashSimple {
-  name: AuthnHashSimpleName
-  salt_position?: AuthnHashSimpleSaltPosition
-}
-
-export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2Name = {
-  pbkdf2: 'pbkdf2',
-} as const
-
-export type AuthnHashPbkdf2MacFun =
-  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2MacFun = {
-  md4: 'md4',
-  md5: 'md5',
-  ripemd160: 'ripemd160',
-  sha: 'sha',
-  sha224: 'sha224',
-  sha256: 'sha256',
-  sha384: 'sha384',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashPbkdf2 {
-  /** @minimum 1 */
-  dk_length?: number
-  /** @minimum 1 */
-  iterations: number
-  mac_fun: AuthnHashPbkdf2MacFun
-  name: AuthnHashPbkdf2Name
-}
-
-export type AuthnHashBcryptRwApiName =
-  (typeof AuthnHashBcryptRwApiName)[keyof typeof AuthnHashBcryptRwApiName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptRwApiName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcryptRwApi {
-  name: AuthnHashBcryptRwApiName
-  /**
-   * @minimum 5
-   * @maximum 10
-   */
-  salt_rounds?: number
-}
-
-export type AuthnHashBcryptRwName =
-  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptRwName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcryptRw {
-  name: AuthnHashBcryptRwName
-  /**
-   * @minimum 5
-   * @maximum 10
-   */
-  salt_rounds?: number
-}
-
-export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcrypt {
-  name: AuthnHashBcryptName
-}
-
 export interface AuthCacheRate {
   rate?: number
   rate_last5m?: number
@@ -2075,9 +2075,9 @@ export interface AuthCacheStatus {
   node_metrics?: AuthCacheNodeMetrics[]
 }
 
-export type AuthCacheConfigMaxMemory = string | 'unlimited'
+export type AuthCacheConfigMaxMemory = 'unlimited' | string
 
-export type AuthCacheConfigMaxCount = number | 'unlimited'
+export type AuthCacheConfigMaxCount = 'unlimited' | number
 
 export interface AuthCacheConfig {
   cache_ttl?: string

--- a/src/types/schemas/authorization.schemas.ts
+++ b/src/types/schemas/authorization.schemas.ts
@@ -1,3 +1,137 @@
+export type GetAuthorizationSourcesTypeStatus404Code =
+  (typeof GetAuthorizationSourcesTypeStatus404Code)[keyof typeof GetAuthorizationSourcesTypeStatus404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetAuthorizationSourcesTypeStatus404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type GetAuthorizationSourcesTypeStatus404 = {
+  code?: GetAuthorizationSourcesTypeStatus404Code
+  message?: string
+}
+
+export type GetAuthorizationSourcesTypeStatus400Code =
+  (typeof GetAuthorizationSourcesTypeStatus400Code)[keyof typeof GetAuthorizationSourcesTypeStatus400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetAuthorizationSourcesTypeStatus400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type GetAuthorizationSourcesTypeStatus400 = {
+  code?: GetAuthorizationSourcesTypeStatus400Code
+  message?: string
+}
+
+export type PostAuthorizationSourcesTypeMove404Code =
+  (typeof PostAuthorizationSourcesTypeMove404Code)[keyof typeof PostAuthorizationSourcesTypeMove404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostAuthorizationSourcesTypeMove404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostAuthorizationSourcesTypeMove404 = {
+  code?: PostAuthorizationSourcesTypeMove404Code
+  message?: string
+}
+
+export type PostAuthorizationSourcesTypeMove400Code =
+  (typeof PostAuthorizationSourcesTypeMove400Code)[keyof typeof PostAuthorizationSourcesTypeMove400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostAuthorizationSourcesTypeMove400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PostAuthorizationSourcesTypeMove400 = {
+  code?: PostAuthorizationSourcesTypeMove400Code
+  message?: string
+}
+
+export type PostAuthorizationSourcesTypeMetricsReset404Code =
+  (typeof PostAuthorizationSourcesTypeMetricsReset404Code)[keyof typeof PostAuthorizationSourcesTypeMetricsReset404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostAuthorizationSourcesTypeMetricsReset404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostAuthorizationSourcesTypeMetricsReset404 = {
+  code?: PostAuthorizationSourcesTypeMetricsReset404Code
+  message?: string
+}
+
+export type PutAuthorizationSourcesType400Code =
+  (typeof PutAuthorizationSourcesType400Code)[keyof typeof PutAuthorizationSourcesType400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutAuthorizationSourcesType400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PutAuthorizationSourcesType400 = {
+  code?: PutAuthorizationSourcesType400Code
+  message?: string
+}
+
+export type PutAuthorizationSourcesTypeBody =
+  | AuthzApiFile
+  | AuthzBuiltinDb
+  | AuthzHttpGet
+  | AuthzHttpPost
+  | AuthzLdap
+  | AuthzMongoRs
+  | AuthzMongoSharded
+  | AuthzMongoSingle
+  | AuthzMysql
+  | AuthzPostgresql
+  | AuthzRedisCluster
+  | AuthzRedisSentinel
+  | AuthzRedisSingle
+
+export type GetAuthorizationSourcesType404Code =
+  (typeof GetAuthorizationSourcesType404Code)[keyof typeof GetAuthorizationSourcesType404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetAuthorizationSourcesType404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type GetAuthorizationSourcesType404 = {
+  code?: GetAuthorizationSourcesType404Code
+  message?: string
+}
+
+export type GetAuthorizationSourcesType200 =
+  | AuthzApiFile
+  | AuthzBuiltinDb
+  | AuthzHttpGet
+  | AuthzHttpPost
+  | AuthzLdap
+  | AuthzMongoRs
+  | AuthzMongoSharded
+  | AuthzMongoSingle
+  | AuthzMysql
+  | AuthzPostgresql
+  | AuthzRedisCluster
+  | AuthzRedisSentinel
+  | AuthzRedisSingle
+
+export type DeleteAuthorizationSourcesType400Code =
+  (typeof DeleteAuthorizationSourcesType400Code)[keyof typeof DeleteAuthorizationSourcesType400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DeleteAuthorizationSourcesType400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type DeleteAuthorizationSourcesType400 = {
+  code?: DeleteAuthorizationSourcesType400Code
+  message?: string
+}
+
 export type PutAuthorizationSourcesOrder400Code =
   (typeof PutAuthorizationSourcesOrder400Code)[keyof typeof PutAuthorizationSourcesOrder400Code]
 
@@ -171,8 +305,8 @@ export type GetAuthorizationSourcesBuiltInDatabaseRulesUsers403 = {
 }
 
 export type GetAuthorizationSourcesBuiltInDatabaseRulesUsersParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
   like_username?: string
   ns?: string
 }
@@ -324,8 +458,8 @@ export type GetAuthorizationSourcesBuiltInDatabaseRulesClients403 = {
 }
 
 export type GetAuthorizationSourcesBuiltInDatabaseRulesClientsParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
   like_clientid?: string
   ns?: string
 }
@@ -422,140 +556,6 @@ export type DeleteAuthorizationSourcesBuiltInDatabaseRules400 = {
 
 export type DeleteAuthorizationSourcesBuiltInDatabaseRulesParams = {
   ns?: string
-}
-
-export type GetAuthorizationSourcesTypeStatus404Code =
-  (typeof GetAuthorizationSourcesTypeStatus404Code)[keyof typeof GetAuthorizationSourcesTypeStatus404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetAuthorizationSourcesTypeStatus404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type GetAuthorizationSourcesTypeStatus404 = {
-  code?: GetAuthorizationSourcesTypeStatus404Code
-  message?: string
-}
-
-export type GetAuthorizationSourcesTypeStatus400Code =
-  (typeof GetAuthorizationSourcesTypeStatus400Code)[keyof typeof GetAuthorizationSourcesTypeStatus400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetAuthorizationSourcesTypeStatus400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type GetAuthorizationSourcesTypeStatus400 = {
-  code?: GetAuthorizationSourcesTypeStatus400Code
-  message?: string
-}
-
-export type PostAuthorizationSourcesTypeMove404Code =
-  (typeof PostAuthorizationSourcesTypeMove404Code)[keyof typeof PostAuthorizationSourcesTypeMove404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostAuthorizationSourcesTypeMove404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PostAuthorizationSourcesTypeMove404 = {
-  code?: PostAuthorizationSourcesTypeMove404Code
-  message?: string
-}
-
-export type PostAuthorizationSourcesTypeMove400Code =
-  (typeof PostAuthorizationSourcesTypeMove400Code)[keyof typeof PostAuthorizationSourcesTypeMove400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostAuthorizationSourcesTypeMove400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PostAuthorizationSourcesTypeMove400 = {
-  code?: PostAuthorizationSourcesTypeMove400Code
-  message?: string
-}
-
-export type PostAuthorizationSourcesTypeMetricsReset404Code =
-  (typeof PostAuthorizationSourcesTypeMetricsReset404Code)[keyof typeof PostAuthorizationSourcesTypeMetricsReset404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostAuthorizationSourcesTypeMetricsReset404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PostAuthorizationSourcesTypeMetricsReset404 = {
-  code?: PostAuthorizationSourcesTypeMetricsReset404Code
-  message?: string
-}
-
-export type PutAuthorizationSourcesType400Code =
-  (typeof PutAuthorizationSourcesType400Code)[keyof typeof PutAuthorizationSourcesType400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutAuthorizationSourcesType400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PutAuthorizationSourcesType400 = {
-  code?: PutAuthorizationSourcesType400Code
-  message?: string
-}
-
-export type PutAuthorizationSourcesTypeBody =
-  | AuthzApiFile
-  | AuthzBuiltinDb
-  | AuthzHttpGet
-  | AuthzHttpPost
-  | AuthzLdap
-  | AuthzMongoRs
-  | AuthzMongoSharded
-  | AuthzMongoSingle
-  | AuthzMysql
-  | AuthzPostgresql
-  | AuthzRedisCluster
-  | AuthzRedisSentinel
-  | AuthzRedisSingle
-
-export type GetAuthorizationSourcesType404Code =
-  (typeof GetAuthorizationSourcesType404Code)[keyof typeof GetAuthorizationSourcesType404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetAuthorizationSourcesType404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type GetAuthorizationSourcesType404 = {
-  code?: GetAuthorizationSourcesType404Code
-  message?: string
-}
-
-export type GetAuthorizationSourcesType200 =
-  | AuthzApiFile
-  | AuthzBuiltinDb
-  | AuthzHttpGet
-  | AuthzHttpPost
-  | AuthzLdap
-  | AuthzMongoRs
-  | AuthzMongoSharded
-  | AuthzMongoSingle
-  | AuthzMysql
-  | AuthzPostgresql
-  | AuthzRedisCluster
-  | AuthzRedisSentinel
-  | AuthzRedisSingle
-
-export type DeleteAuthorizationSourcesType400Code =
-  (typeof DeleteAuthorizationSourcesType400Code)[keyof typeof DeleteAuthorizationSourcesType400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeleteAuthorizationSourcesType400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type DeleteAuthorizationSourcesType400 = {
-  code?: DeleteAuthorizationSourcesType400Code
-  message?: string
 }
 
 export type PostAuthorizationSources400Code =
@@ -768,15 +768,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -820,6 +820,190 @@ export interface LdapSsl {
   versions?: string[]
 }
 
+export interface EmqxAuthzSchemaResourceMetrics {
+  failed?: number
+  matched?: number
+  rate?: number
+  rate_last5m?: number
+  rate_max?: number
+  success?: number
+}
+
+export type EmqxAuthzSchemaNodeStatusStatus =
+  (typeof EmqxAuthzSchemaNodeStatusStatus)[keyof typeof EmqxAuthzSchemaNodeStatusStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxAuthzSchemaNodeStatusStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+} as const
+
+export interface EmqxAuthzSchemaNodeStatus {
+  node?: string
+  status?: EmqxAuthzSchemaNodeStatusStatus
+}
+
+export interface EmqxAuthzSchemaNodeResourceMetrics {
+  metrics?: EmqxAuthzSchemaResourceMetrics
+  node?: string
+}
+
+export interface EmqxAuthzSchemaNodeError {
+  error?: string
+  node?: string
+}
+
+export type EmqxAuthzSchemaMetricsStatusFieldsStatus =
+  (typeof EmqxAuthzSchemaMetricsStatusFieldsStatus)[keyof typeof EmqxAuthzSchemaMetricsStatusFieldsStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxAuthzSchemaMetricsStatusFieldsStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+  inconsistent: 'inconsistent',
+} as const
+
+export interface EmqxAuthzSchemaMetrics {
+  allow?: number
+  deny?: number
+  ignore?: number
+  nomatch?: number
+  rate?: number
+  rate_last5m?: number
+  rate_max?: number
+  total?: number
+}
+
+export interface EmqxAuthzSchemaNodeMetrics {
+  metrics?: EmqxAuthzSchemaMetrics
+  node?: string
+}
+
+export interface EmqxAuthzSchemaMetricsStatusFields {
+  metrics?: EmqxAuthzSchemaMetrics
+  node_error?: EmqxAuthzSchemaNodeError[]
+  node_metrics?: EmqxAuthzSchemaNodeMetrics[]
+  node_resource_metrics?: EmqxAuthzSchemaNodeResourceMetrics[]
+  node_status?: EmqxAuthzSchemaNodeStatus[]
+  resource_metrics?: EmqxAuthzSchemaResourceMetrics
+  status?: EmqxAuthzSchemaMetricsStatusFieldsStatus
+}
+
+export type EmqxAuthzApiSourcesSourcesSourcesItem =
+  | AuthzBuiltinDb
+  | AuthzFile
+  | AuthzHttpGet
+  | AuthzHttpPost
+  | AuthzLdap
+  | AuthzMongoRs
+  | AuthzMongoSharded
+  | AuthzMongoSingle
+  | AuthzMysql
+  | AuthzPostgresql
+  | AuthzRedisCluster
+  | AuthzRedisSentinel
+  | AuthzRedisSingle
+
+export interface EmqxAuthzApiSourcesSources {
+  sources?: EmqxAuthzApiSourcesSourcesSourcesItem[]
+}
+
+export type EmqxAuthzApiSourcesRequestSourcesOrderType =
+  (typeof EmqxAuthzApiSourcesRequestSourcesOrderType)[keyof typeof EmqxAuthzApiSourcesRequestSourcesOrderType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxAuthzApiSourcesRequestSourcesOrderType = {
+  built_in_database: 'built_in_database',
+  file: 'file',
+  http: 'http',
+  ldap: 'ldap',
+  mongodb: 'mongodb',
+  mysql: 'mysql',
+  postgresql: 'postgresql',
+  redis: 'redis',
+} as const
+
+export interface EmqxAuthzApiSourcesRequestSourcesOrder {
+  type: EmqxAuthzApiSourcesRequestSourcesOrderType
+}
+
+export interface EmqxAuthzApiSourcesPosition {
+  position: string
+}
+
+export interface EmqxAuthzApiMnesiaRulesForUsername {
+  rules?: EmqxAuthzApiMnesiaRuleItem[]
+  username: string
+}
+
+export interface EmqxAuthzApiMnesiaUsernameResponseData {
+  data?: EmqxAuthzApiMnesiaRulesForUsername[]
+  meta?: PublicMeta
+}
+
+export interface EmqxAuthzApiMnesiaRulesForClientid {
+  clientid: string
+  rules?: EmqxAuthzApiMnesiaRuleItem[]
+}
+
+export interface EmqxAuthzApiMnesiaRules {
+  rules?: EmqxAuthzApiMnesiaRuleItem[]
+}
+
+export type EmqxAuthzApiMnesiaRuleItemRetain = 'all' | boolean
+
+export type EmqxAuthzApiMnesiaRuleItemPermission =
+  (typeof EmqxAuthzApiMnesiaRuleItemPermission)[keyof typeof EmqxAuthzApiMnesiaRuleItemPermission]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxAuthzApiMnesiaRuleItemPermission = {
+  allow: 'allow',
+  deny: 'deny',
+} as const
+
+export type EmqxAuthzApiMnesiaRuleItemAction =
+  (typeof EmqxAuthzApiMnesiaRuleItemAction)[keyof typeof EmqxAuthzApiMnesiaRuleItemAction]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxAuthzApiMnesiaRuleItemAction = {
+  all: 'all',
+  publish: 'publish',
+  subscribe: 'subscribe',
+} as const
+
+export interface EmqxAuthzApiMnesiaRuleItem {
+  action: EmqxAuthzApiMnesiaRuleItemAction
+  clientid_re?: string
+  ipaddr?: string
+  listener?: string
+  listener_re?: string
+  permission: EmqxAuthzApiMnesiaRuleItemPermission
+  qos?: number[]
+  retain?: EmqxAuthzApiMnesiaRuleItemRetain
+  topic: string
+  username_re?: string
+  zone?: string
+  zone_re?: string
+}
+
+export interface EmqxAuthzApiMnesiaClientidResponseData {
+  data?: EmqxAuthzApiMnesiaRulesForClientid[]
+  meta?: PublicMeta
+}
+
+export type EmqxAuthzApiCacheResponseAuthzNodeCacheMaxMemory = 'unlimited' | string
+
+export type EmqxAuthzApiCacheResponseAuthzNodeCacheMaxCount = 'unlimited' | number
+
+export interface EmqxAuthzApiCacheResponseAuthzNodeCache {
+  cache_ttl?: string
+  enable?: boolean
+  max_count?: EmqxAuthzApiCacheResponseAuthzNodeCacheMaxCount
+  max_memory?: EmqxAuthzApiCacheResponseAuthzNodeCacheMaxMemory
+}
+
 export type EmqxSslClientOptsVerify =
   (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
 
@@ -829,16 +1013,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -897,190 +1081,6 @@ export interface EmqxAuthzCache {
    */
   max_size?: number
   ttl?: string
-}
-
-export interface EmqxAuthzSchemaResourceMetrics {
-  failed?: number
-  matched?: number
-  rate?: number
-  rate_last5m?: number
-  rate_max?: number
-  success?: number
-}
-
-export type EmqxAuthzSchemaNodeStatusStatus =
-  (typeof EmqxAuthzSchemaNodeStatusStatus)[keyof typeof EmqxAuthzSchemaNodeStatusStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxAuthzSchemaNodeStatusStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-} as const
-
-export interface EmqxAuthzSchemaNodeStatus {
-  node?: string
-  status?: EmqxAuthzSchemaNodeStatusStatus
-}
-
-export interface EmqxAuthzSchemaNodeResourceMetrics {
-  metrics?: EmqxAuthzSchemaResourceMetrics
-  node?: string
-}
-
-export interface EmqxAuthzSchemaNodeMetrics {
-  metrics?: EmqxAuthzSchemaMetrics
-  node?: string
-}
-
-export interface EmqxAuthzSchemaNodeError {
-  error?: string
-  node?: string
-}
-
-export type EmqxAuthzSchemaMetricsStatusFieldsStatus =
-  (typeof EmqxAuthzSchemaMetricsStatusFieldsStatus)[keyof typeof EmqxAuthzSchemaMetricsStatusFieldsStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxAuthzSchemaMetricsStatusFieldsStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-  inconsistent: 'inconsistent',
-} as const
-
-export interface EmqxAuthzSchemaMetrics {
-  allow?: number
-  deny?: number
-  ignore?: number
-  nomatch?: number
-  rate?: number
-  rate_last5m?: number
-  rate_max?: number
-  total?: number
-}
-
-export interface EmqxAuthzSchemaMetricsStatusFields {
-  metrics?: EmqxAuthzSchemaMetrics
-  node_error?: EmqxAuthzSchemaNodeError[]
-  node_metrics?: EmqxAuthzSchemaNodeMetrics[]
-  node_resource_metrics?: EmqxAuthzSchemaNodeResourceMetrics[]
-  node_status?: EmqxAuthzSchemaNodeStatus[]
-  resource_metrics?: EmqxAuthzSchemaResourceMetrics
-  status?: EmqxAuthzSchemaMetricsStatusFieldsStatus
-}
-
-export type EmqxAuthzApiSourcesSourcesSourcesItem =
-  | AuthzLdap
-  | AuthzMongoSharded
-  | AuthzMongoRs
-  | AuthzMongoSingle
-  | AuthzPostgresql
-  | AuthzMysql
-  | AuthzRedisCluster
-  | AuthzRedisSentinel
-  | AuthzRedisSingle
-  | AuthzHttpPost
-  | AuthzHttpGet
-  | AuthzBuiltinDb
-  | AuthzFile
-
-export interface EmqxAuthzApiSourcesSources {
-  sources?: EmqxAuthzApiSourcesSourcesSourcesItem[]
-}
-
-export type EmqxAuthzApiSourcesRequestSourcesOrderType =
-  (typeof EmqxAuthzApiSourcesRequestSourcesOrderType)[keyof typeof EmqxAuthzApiSourcesRequestSourcesOrderType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxAuthzApiSourcesRequestSourcesOrderType = {
-  built_in_database: 'built_in_database',
-  file: 'file',
-  http: 'http',
-  ldap: 'ldap',
-  mongodb: 'mongodb',
-  mysql: 'mysql',
-  postgresql: 'postgresql',
-  redis: 'redis',
-} as const
-
-export interface EmqxAuthzApiSourcesRequestSourcesOrder {
-  type: EmqxAuthzApiSourcesRequestSourcesOrderType
-}
-
-export interface EmqxAuthzApiSourcesPosition {
-  position: string
-}
-
-export interface EmqxAuthzApiMnesiaUsernameResponseData {
-  data?: EmqxAuthzApiMnesiaRulesForUsername[]
-  meta?: PublicMeta
-}
-
-export interface EmqxAuthzApiMnesiaRulesForClientid {
-  clientid: string
-  rules?: EmqxAuthzApiMnesiaRuleItem[]
-}
-
-export type EmqxAuthzApiMnesiaRuleItemRetain = boolean | 'all'
-
-export type EmqxAuthzApiMnesiaRuleItemPermission =
-  (typeof EmqxAuthzApiMnesiaRuleItemPermission)[keyof typeof EmqxAuthzApiMnesiaRuleItemPermission]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxAuthzApiMnesiaRuleItemPermission = {
-  allow: 'allow',
-  deny: 'deny',
-} as const
-
-export type EmqxAuthzApiMnesiaRuleItemAction =
-  (typeof EmqxAuthzApiMnesiaRuleItemAction)[keyof typeof EmqxAuthzApiMnesiaRuleItemAction]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxAuthzApiMnesiaRuleItemAction = {
-  all: 'all',
-  publish: 'publish',
-  subscribe: 'subscribe',
-} as const
-
-export interface EmqxAuthzApiMnesiaRuleItem {
-  action: EmqxAuthzApiMnesiaRuleItemAction
-  clientid_re?: string
-  ipaddr?: string
-  listener?: string
-  listener_re?: string
-  permission: EmqxAuthzApiMnesiaRuleItemPermission
-  qos?: number[]
-  retain?: EmqxAuthzApiMnesiaRuleItemRetain
-  topic: string
-  username_re?: string
-  zone?: string
-  zone_re?: string
-}
-
-export interface EmqxAuthzApiMnesiaRulesForUsername {
-  rules?: EmqxAuthzApiMnesiaRuleItem[]
-  username: string
-}
-
-export interface EmqxAuthzApiMnesiaRules {
-  rules?: EmqxAuthzApiMnesiaRuleItem[]
-}
-
-export interface EmqxAuthzApiMnesiaClientidResponseData {
-  data?: EmqxAuthzApiMnesiaRulesForClientid[]
-  meta?: PublicMeta
-}
-
-export type EmqxAuthzApiCacheResponseAuthzNodeCacheMaxMemory = string | 'unlimited'
-
-export type EmqxAuthzApiCacheResponseAuthzNodeCacheMaxCount = number | 'unlimited'
-
-export interface EmqxAuthzApiCacheResponseAuthzNodeCache {
-  cache_ttl?: string
-  enable?: boolean
-  max_count?: EmqxAuthzApiCacheResponseAuthzNodeCacheMaxCount
-  max_memory?: EmqxAuthzApiCacheResponseAuthzNodeCacheMaxMemory
 }
 
 export type ConnectorHttpRequestHeaders = { [key: string]: unknown }
@@ -1299,9 +1299,9 @@ export type AuthzMongoSingleUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthzMongoSingleUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthzMongoSingleType = (typeof AuthzMongoSingleType)[keyof typeof AuthzMongoSingleType]
@@ -1360,9 +1360,9 @@ export type AuthzMongoShardedUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthzMongoShardedUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthzMongoShardedType =
@@ -1421,9 +1421,9 @@ export type AuthzMongoRsUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthzMongoRsUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthzMongoRsType = (typeof AuthzMongoRsType)[keyof typeof AuthzMongoRsType]

--- a/src/types/schemas/authorization.schemas.ts
+++ b/src/types/schemas/authorization.schemas.ts
@@ -622,7 +622,6 @@ export type PutAuthorizationSettings200 = {
   deny_action: PutAuthorizationSettings200DenyAction
   ignore_backend_failures?: boolean
   include_mountpoint?: boolean
-  ignore_backend_failures?: boolean
   no_match: PutAuthorizationSettings200NoMatch
 }
 
@@ -649,7 +648,6 @@ export type PutAuthorizationSettingsBody = {
   deny_action: PutAuthorizationSettingsBodyDenyAction
   ignore_backend_failures?: boolean
   include_mountpoint?: boolean
-  ignore_backend_failures?: boolean
   no_match: PutAuthorizationSettingsBodyNoMatch
 }
 
@@ -676,7 +674,6 @@ export type GetAuthorizationSettings200 = {
   deny_action: GetAuthorizationSettings200DenyAction
   ignore_backend_failures?: boolean
   include_mountpoint?: boolean
-  ignore_backend_failures?: boolean
   no_match: GetAuthorizationSettings200NoMatch
 }
 

--- a/src/types/schemas/banned.schemas.ts
+++ b/src/types/schemas/banned.schemas.ts
@@ -50,15 +50,15 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetBannedParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
-  clientid?: string
-  username?: string
+  page?: PublicPageParameter
+  like_peerhost?: string
   peerhost?: string
+  like_peerhost_net?: string
+  clientid?: string
   like_clientid?: string
   like_username?: string
-  like_peerhost?: string
-  like_peerhost_net?: string
+  username?: string
 }
 
 export interface PublicMeta {
@@ -74,11 +74,11 @@ export interface PublicMeta {
   page?: number
 }
 
-export type EmqxMgmtApiBannedBanUntilOneOf = number | string
+export type EmqxMgmtApiBannedBanUntilOneOf = string | number
 
-export type EmqxMgmtApiBannedBanUntil = EmqxMgmtApiBannedBanUntilOneOf | 'infinity'
+export type EmqxMgmtApiBannedBanUntil = 'infinity' | EmqxMgmtApiBannedBanUntilOneOf
 
-export type EmqxMgmtApiBannedBanAt = number | string
+export type EmqxMgmtApiBannedBanAt = string | number
 
 export type EmqxMgmtApiBannedBanAs =
   (typeof EmqxMgmtApiBannedBanAs)[keyof typeof EmqxMgmtApiBannedBanAs]

--- a/src/types/schemas/clients.schemas.ts
+++ b/src/types/schemas/clients.schemas.ts
@@ -355,6 +355,7 @@ export const EmqxMgmtApiClientsRequestedClientFieldsParameterOneOfItem = {
   seqno_q2_rec: 'seqno_q2_rec',
   subscriptions_cnt: 'subscriptions_cnt',
   subscriptions_max: 'subscriptions_max',
+  total_payload_bytes: 'total_payload_bytes',
   username: 'username',
 } as const
 
@@ -530,6 +531,7 @@ export interface EmqxMgmtApiClientsClient {
   seqno_q2_rec?: number
   subscriptions_cnt?: number
   subscriptions_max?: number
+  total_payload_bytes?: number
   username?: string
 }
 

--- a/src/types/schemas/clients.schemas.ts
+++ b/src/types/schemas/clients.schemas.ts
@@ -98,8 +98,8 @@ export type GetClientsClientidMqueueMessages404Code =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GetClientsClientidMqueueMessages404Code = {
-  CLIENT_SHUTDOWN: 'CLIENT_SHUTDOWN',
   CLIENTID_NOT_FOUND: 'CLIENTID_NOT_FOUND',
+  CLIENT_SHUTDOWN: 'CLIENT_SHUTDOWN',
 } as const
 
 export type GetClientsClientidMqueueMessages404 = {
@@ -131,10 +131,10 @@ export const GetClientsClientidMqueueMessagesPayload = {
 } as const
 
 export type GetClientsClientidMqueueMessagesParams = {
-  payload?: GetClientsClientidMqueueMessagesPayload
-  max_payload_bytes?: string
-  position?: PublicPositionParameter
   limit?: PublicLimitParameter
+  position?: PublicPositionParameter
+  max_payload_bytes?: string
+  payload?: GetClientsClientidMqueueMessagesPayload
 }
 
 export type GetClientsClientidInflightMessages501Code =
@@ -155,8 +155,8 @@ export type GetClientsClientidInflightMessages404Code =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GetClientsClientidInflightMessages404Code = {
-  CLIENT_SHUTDOWN: 'CLIENT_SHUTDOWN',
   CLIENTID_NOT_FOUND: 'CLIENTID_NOT_FOUND',
+  CLIENT_SHUTDOWN: 'CLIENT_SHUTDOWN',
 } as const
 
 export type GetClientsClientidInflightMessages404 = {
@@ -188,10 +188,10 @@ export const GetClientsClientidInflightMessagesPayload = {
 } as const
 
 export type GetClientsClientidInflightMessagesParams = {
-  payload?: GetClientsClientidInflightMessagesPayload
-  max_payload_bytes?: string
-  position?: PublicPositionParameter
   limit?: PublicLimitParameter
+  position?: PublicPositionParameter
+  max_payload_bytes?: string
+  payload?: GetClientsClientidInflightMessagesPayload
 }
 
 export type GetClientsClientidAuthorizationCache404Code =
@@ -267,29 +267,29 @@ export const GetClientsConnState = {
   idle: 'idle',
 } as const
 
-export type PublicPositionParameter = string | 'end_of_data' | 'none'
+export type PublicPositionParameter = 'end_of_data' | 'none' | string
 
 export type PublicPageParameter = number
 
 export type PublicLimitParameter = number
 
 export type GetClientsParams = {
-  page?: PublicPageParameter
-  node?: string
+  fields?: EmqxMgmtApiClientsRequestedClientFieldsParameter
   limit?: PublicLimitParameter
-  username?: string[]
+  page?: PublicPageParameter
   ip_address?: string
-  conn_state?: GetClientsConnState
+  node?: string
   clean_start?: boolean
-  proto_ver?: string
+  clientid?: string[]
+  conn_state?: GetClientsConnState
+  gte_connected_at?: string | number
+  gte_created_at?: string | number
   like_clientid?: string
   like_username?: string
-  gte_created_at?: number | string
-  lte_created_at?: number | string
-  gte_connected_at?: number | string
-  lte_connected_at?: number | string
-  clientid?: string[]
-  fields?: EmqxMgmtApiClientsRequestedClientFieldsParameter
+  lte_connected_at?: string | number
+  lte_created_at?: string | number
+  proto_ver?: string
+  username?: string[]
 }
 
 export type EmqxMgmtApiClientsRequestedClientFieldsParameterOneOfItem =
@@ -360,8 +360,8 @@ export const EmqxMgmtApiClientsRequestedClientFieldsParameterOneOfItem = {
 } as const
 
 export type EmqxMgmtApiClientsRequestedClientFieldsParameter =
-  | EmqxMgmtApiClientsRequestedClientFieldsParameterOneOfItem[]
   | 'all'
+  | EmqxMgmtApiClientsRequestedClientFieldsParameterOneOfItem[]
 
 export interface PublicMeta {
   /** @minimum 0 */
@@ -376,9 +376,9 @@ export interface PublicMeta {
   page?: number
 }
 
-export type PublicContinuationMetaStart = string | 'none'
+export type PublicContinuationMetaStart = 'none' | string
 
-export type PublicContinuationMetaPosition = string | 'end_of_data' | 'none'
+export type PublicContinuationMetaPosition = 'end_of_data' | 'none' | string
 
 export interface PublicContinuationMeta {
   position?: PublicContinuationMetaPosition
@@ -459,11 +459,11 @@ export interface EmqxMgmtApiClientsInflightMessages {
   meta?: PublicContinuationMeta
 }
 
-export type EmqxMgmtApiClientsClientDisconnectedAt = number | string
+export type EmqxMgmtApiClientsClientDisconnectedAt = string | number
 
-export type EmqxMgmtApiClientsClientCreatedAt = number | string
+export type EmqxMgmtApiClientsClientCreatedAt = string | number
 
-export type EmqxMgmtApiClientsClientConnectedAt = number | string
+export type EmqxMgmtApiClientsClientConnectedAt = string | number
 
 export interface EmqxMgmtApiClientsClient {
   awaiting_rel_cnt?: number

--- a/src/types/schemas/cluster.schemas.ts
+++ b/src/types/schemas/cluster.schemas.ts
@@ -1,3 +1,42 @@
+export type PutClusterNodeInviteAsync400Code =
+  (typeof PutClusterNodeInviteAsync400Code)[keyof typeof PutClusterNodeInviteAsync400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutClusterNodeInviteAsync400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PutClusterNodeInviteAsync400 = {
+  code?: PutClusterNodeInviteAsync400Code
+  message?: string
+}
+
+export type PutClusterNodeInvite400Code =
+  (typeof PutClusterNodeInvite400Code)[keyof typeof PutClusterNodeInvite400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutClusterNodeInvite400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PutClusterNodeInvite400 = {
+  code?: PutClusterNodeInvite400Code
+  message?: string
+}
+
+export type DeleteClusterNodeForceLeave404Code =
+  (typeof DeleteClusterNodeForceLeave404Code)[keyof typeof DeleteClusterNodeForceLeave404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DeleteClusterNodeForceLeave404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type DeleteClusterNodeForceLeave404 = {
+  code?: DeleteClusterNodeForceLeave404Code
+  message?: string
+}
+
 export type PutClusterLinksLinkNameMetricsReset404Code =
   (typeof PutClusterLinksLinkNameMetricsReset404Code)[keyof typeof PutClusterLinksLinkNameMetricsReset404Code]
 
@@ -50,6 +89,23 @@ export type PutClusterLinksLinkName400 = {
   message?: string
 }
 
+export type PutClusterLinksLinkNameBody = {
+  clientid?: string
+  enable?: boolean
+  /** @minimum 0 */
+  max_inflight?: number
+  password?: string
+  /** @minimum 1 */
+  pool_size?: number
+  resource_opts?: ClusterCreationOpts
+  retry_interval?: string
+  server: string
+  ssl?: EmqxSslClientOpts
+  tcp_opts?: EmqxClientTcpOpts
+  topics: string[]
+  username?: string
+}
+
 export type GetClusterLinksLinkName404Code =
   (typeof GetClusterLinksLinkName404Code)[keyof typeof GetClusterLinksLinkName404Code]
 
@@ -90,45 +146,6 @@ export type PostClusterLinks400 = {
   message?: string
 }
 
-export type PutClusterNodeInviteAsync400Code =
-  (typeof PutClusterNodeInviteAsync400Code)[keyof typeof PutClusterNodeInviteAsync400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutClusterNodeInviteAsync400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PutClusterNodeInviteAsync400 = {
-  code?: PutClusterNodeInviteAsync400Code
-  message?: string
-}
-
-export type PutClusterNodeInvite400Code =
-  (typeof PutClusterNodeInvite400Code)[keyof typeof PutClusterNodeInvite400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutClusterNodeInvite400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PutClusterNodeInvite400 = {
-  code?: PutClusterNodeInvite400Code
-  message?: string
-}
-
-export type DeleteClusterNodeForceLeave404Code =
-  (typeof DeleteClusterNodeForceLeave404Code)[keyof typeof DeleteClusterNodeForceLeave404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeleteClusterNodeForceLeave404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type DeleteClusterNodeForceLeave404 = {
-  code?: DeleteClusterNodeForceLeave404Code
-  message?: string
-}
-
 export type PutCluster400Code = (typeof PutCluster400Code)[keyof typeof PutCluster400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -164,16 +181,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -234,11 +251,38 @@ export interface EmqxClientTcpOpts {
   sndbuf?: string
 }
 
-export type PutClusterLinksLinkNameBody = {
+export type ClusterLinkNodeMetricsMetrics = { [key: string]: unknown }
+
+export interface ClusterLinkNodeMetrics {
+  metrics?: ClusterLinkNodeMetricsMetrics
+  node?: string
+}
+
+export type ClusterLinkLinkMetricsResponseMetrics = { [key: string]: unknown }
+
+export interface ClusterLinkLinkMetricsResponse {
+  metrics?: ClusterLinkLinkMetricsResponseMetrics
+  node_metrics?: ClusterLinkNodeMetrics[]
+}
+
+export type ClusterLinkLinkConfigResponseStatus =
+  (typeof ClusterLinkLinkConfigResponseStatus)[keyof typeof ClusterLinkLinkConfigResponseStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ClusterLinkLinkConfigResponseStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+  inconsistent: 'inconsistent',
+} as const
+
+export interface ClusterLinkLinkConfigResponse {
   clientid?: string
   enable?: boolean
   /** @minimum 0 */
   max_inflight?: number
+  name: string
+  node?: string
   password?: string
   /** @minimum 1 */
   pool_size?: number
@@ -246,6 +290,7 @@ export type PutClusterLinksLinkNameBody = {
   retry_interval?: string
   server: string
   ssl?: EmqxSslClientOpts
+  status?: ClusterLinkLinkConfigResponseStatus
   tcp_opts?: EmqxClientTcpOpts
   topics: string[]
   username?: string
@@ -320,7 +365,7 @@ export const ClusterCreationOptsDispatchStrategy = {
 /**
  * @deprecated
  */
-export type ClusterCreationOptsAutoRestartInterval = string | 'infinity'
+export type ClusterCreationOptsAutoRestartInterval = 'infinity' | string
 
 export interface ClusterCreationOpts {
   /** @deprecated */
@@ -350,49 +395,4 @@ export interface ClusterCoreReplicants {
 
 export interface ClusterClusterInfoRequest {
   description?: string
-}
-
-export type ClusterLinkNodeMetricsMetrics = { [key: string]: unknown }
-
-export interface ClusterLinkNodeMetrics {
-  metrics?: ClusterLinkNodeMetricsMetrics
-  node?: string
-}
-
-export type ClusterLinkLinkMetricsResponseMetrics = { [key: string]: unknown }
-
-export interface ClusterLinkLinkMetricsResponse {
-  metrics?: ClusterLinkLinkMetricsResponseMetrics
-  node_metrics?: ClusterLinkNodeMetrics[]
-}
-
-export type ClusterLinkLinkConfigResponseStatus =
-  (typeof ClusterLinkLinkConfigResponseStatus)[keyof typeof ClusterLinkLinkConfigResponseStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ClusterLinkLinkConfigResponseStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-  inconsistent: 'inconsistent',
-} as const
-
-export interface ClusterLinkLinkConfigResponse {
-  clientid?: string
-  enable?: boolean
-  /** @minimum 0 */
-  max_inflight?: number
-  name: string
-  node?: string
-  password?: string
-  /** @minimum 1 */
-  pool_size?: number
-  resource_opts?: ClusterCreationOpts
-  retry_interval?: string
-  server: string
-  ssl?: EmqxSslClientOpts
-  status?: ClusterLinkLinkConfigResponseStatus
-  tcp_opts?: EmqxClientTcpOpts
-  topics: string[]
-  username?: string
 }

--- a/src/types/schemas/configs.schemas.ts
+++ b/src/types/schemas/configs.schemas.ts
@@ -809,6 +809,10 @@ export interface EmqxSysmonVm {
   process_low_watermark?: string
 }
 
+export interface EmqxSysmonSession {
+  total_payload_bytes_high_watermark?: string
+}
+
 export type EmqxSysmonOsMemCheckInterval = string | 'disabled'
 
 export interface EmqxSysmonOs {
@@ -826,6 +830,7 @@ export interface EmqxSysmon {
   /** @minimum 1 */
   mnesia_tm_mailbox_size_alarm_threshold?: number
   os?: EmqxSysmonOs
+  session?: EmqxSysmonSession
   vm?: EmqxSysmonVm
 }
 

--- a/src/types/schemas/configs.schemas.ts
+++ b/src/types/schemas/configs.schemas.ts
@@ -1,3 +1,34 @@
+export type PostConfigsResetRootname403Code =
+  (typeof PostConfigsResetRootname403Code)[keyof typeof PostConfigsResetRootname403Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostConfigsResetRootname403Code = {
+  RESET_FAILED: 'RESET_FAILED',
+} as const
+
+export type PostConfigsResetRootname403 = {
+  code?: PostConfigsResetRootname403Code
+  message?: string
+}
+
+export type PostConfigsResetRootname400Code =
+  (typeof PostConfigsResetRootname400Code)[keyof typeof PostConfigsResetRootname400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostConfigsResetRootname400Code = {
+  NO_DEFAULT_VALUE: 'NO_DEFAULT_VALUE',
+  RESET_FAILED: 'RESET_FAILED',
+} as const
+
+export type PostConfigsResetRootname400 = {
+  code?: PostConfigsResetRootname400Code
+  message?: string
+}
+
+export type PostConfigsResetRootnameParams = {
+  conf_path?: string
+}
+
 export type PutConfigsSysmon403Code =
   (typeof PutConfigsSysmon403Code)[keyof typeof PutConfigsSysmon403Code]
 
@@ -357,37 +388,6 @@ export type GetConfigsA2aRegistry404 = {
   message?: string
 }
 
-export type PostConfigsResetRootname403Code =
-  (typeof PostConfigsResetRootname403Code)[keyof typeof PostConfigsResetRootname403Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostConfigsResetRootname403Code = {
-  RESET_FAILED: 'RESET_FAILED',
-} as const
-
-export type PostConfigsResetRootname403 = {
-  code?: PostConfigsResetRootname403Code
-  message?: string
-}
-
-export type PostConfigsResetRootname400Code =
-  (typeof PostConfigsResetRootname400Code)[keyof typeof PostConfigsResetRootname400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostConfigsResetRootname400Code = {
-  NO_DEFAULT_VALUE: 'NO_DEFAULT_VALUE',
-  RESET_FAILED: 'RESET_FAILED',
-} as const
-
-export type PostConfigsResetRootname400 = {
-  code?: PostConfigsResetRootname400Code
-  message?: string
-}
-
-export type PostConfigsResetRootnameParams = {
-  conf_path?: string
-}
-
 export type PutConfigs400Code = (typeof PutConfigs400Code)[keyof typeof PutConfigs400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -409,8 +409,8 @@ export const PutConfigsMode = {
 } as const
 
 export type PutConfigsParams = {
-  mode?: PutConfigsMode
   ignore_readonly?: boolean
+  mode?: PutConfigsMode
 }
 
 export type GetConfigs500Code = (typeof GetConfigs500Code)[keyof typeof GetConfigs500Code]
@@ -663,15 +663,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -792,11 +792,11 @@ export interface FileTransferFileTransfer {
   store_segment_timeout?: string
 }
 
-export type EmqxSysmonVmLongSchedule = string | 'disabled'
+export type EmqxSysmonVmLongSchedule = 'disabled' | string
 
-export type EmqxSysmonVmLongGc = string | 'disabled'
+export type EmqxSysmonVmLongGc = 'disabled' | string
 
-export type EmqxSysmonVmLargeHeap = string | 'disabled'
+export type EmqxSysmonVmLargeHeap = 'disabled' | string
 
 export interface EmqxSysmonVm {
   busy_dist_port?: boolean
@@ -813,7 +813,7 @@ export interface EmqxSysmonSession {
   total_payload_bytes_high_watermark?: string
 }
 
-export type EmqxSysmonOsMemCheckInterval = string | 'disabled'
+export type EmqxSysmonOsMemCheckInterval = 'disabled' | string
 
 export interface EmqxSysmonOs {
   cpu_check_interval?: string
@@ -834,9 +834,9 @@ export interface EmqxSysmon {
   vm?: EmqxSysmonVm
 }
 
-export type EmqxSysTopicsSysMsgInterval = string | 'disabled'
+export type EmqxSysTopicsSysMsgInterval = 'disabled' | string
 
-export type EmqxSysTopicsSysHeartbeatInterval = string | 'disabled'
+export type EmqxSysTopicsSysHeartbeatInterval = 'disabled' | string
 
 export interface EmqxSysTopics {
   sys_event_messages?: EmqxEventNames
@@ -853,16 +853,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -943,7 +943,7 @@ export const EmqxMqttSharedSubscriptionInitialStickyPick = {
 
 export type EmqxMqttServerKeepalive = 'disabled' | number
 
-export type EmqxMqttRetryInterval = string | 'infinity'
+export type EmqxMqttRetryInterval = 'infinity' | string
 
 export type EmqxMqttPeerCertAsUsername =
   (typeof EmqxMqttPeerCertAsUsername)[keyof typeof EmqxMqttPeerCertAsUsername]
@@ -973,7 +973,7 @@ export const EmqxMqttPeerCertAsClientid = {
 
 export type EmqxMqttMqueuePrioritiesOneOf = { [key: string]: unknown }
 
-export type EmqxMqttMqueuePriorities = EmqxMqttMqueuePrioritiesOneOf | 'disabled'
+export type EmqxMqttMqueuePriorities = 'disabled' | EmqxMqttMqueuePrioritiesOneOf
 
 export type EmqxMqttMqueueDefaultPriority =
   (typeof EmqxMqttMqueueDefaultPriority)[keyof typeof EmqxMqttMqueueDefaultPriority]
@@ -994,9 +994,9 @@ export type EmqxMqttMaxMqueueLen = 'infinity' | number
 
 export type EmqxMqttMaxAwaitingRel = 'infinity' | number
 
-export type EmqxMqttIdleTimeout = string | 'infinity'
+export type EmqxMqttIdleTimeout = 'infinity' | string
 
-export type EmqxMqttClientidOverride = string | 'disabled'
+export type EmqxMqttClientidOverride = 'disabled' | string
 
 export interface EmqxMqtt {
   await_rel_timeout?: string
@@ -1085,7 +1085,7 @@ export const EmqxLogFileHandlerTimestampFormat = {
   rfc3339: 'rfc3339',
 } as const
 
-export type EmqxLogFileHandlerRotationSize = string | 'infinity'
+export type EmqxLogFileHandlerRotationSize = 'infinity' | string
 
 export type EmqxLogFileHandlerPayloadEncode =
   (typeof EmqxLogFileHandlerPayloadEncode)[keyof typeof EmqxLogFileHandlerPayloadEncode]
@@ -1148,7 +1148,7 @@ export const EmqxLogAuditHandlerTimestampFormat = {
   rfc3339: 'rfc3339',
 } as const
 
-export type EmqxLogAuditHandlerRotationSize = string | 'infinity'
+export type EmqxLogAuditHandlerRotationSize = 'infinity' | string
 
 export type EmqxLogAuditHandlerPayloadEncode =
   (typeof EmqxLogAuditHandlerPayloadEncode)[keyof typeof EmqxLogAuditHandlerPayloadEncode]
@@ -1184,7 +1184,7 @@ export type EmqxLogFileOneOf = {
   $handler_name?: EmqxLogFileHandler
 }
 
-export type EmqxLogFile = EmqxLogFileOneOf | EmqxLogFileHandler
+export type EmqxLogFile = EmqxLogFileHandler | EmqxLogFileOneOf
 
 export interface EmqxLog {
   audit?: EmqxLogAuditHandler
@@ -1349,13 +1349,13 @@ export type DashboardSslOptionsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DashboardSslOptionsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type DashboardSslOptionsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type DashboardSslOptionsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type DashboardSslOptionsLogLevel =
   (typeof DashboardSslOptionsLogLevel)[keyof typeof DashboardSslOptionsLogLevel]

--- a/src/types/schemas/connectors.schemas.ts
+++ b/src/types/schemas/connectors.schemas.ts
@@ -884,6 +884,23 @@ export const RocketmqPostConnectorType = {
   rocketmq: 'rocketmq',
 } as const
 
+export interface RocketmqPostConnector {
+  access_key?: string
+  description?: string
+  enable?: boolean
+  name: string
+  namespace?: string
+  /** @minimum 1 */
+  pool_size?: number
+  resource_opts?: RocketmqConnectorResourceOpts
+  secret_key?: string
+  security_token?: string
+  servers: string
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+  type: RocketmqPostConnectorType
+}
+
 export type RocketmqGetConnectorType =
   (typeof RocketmqGetConnectorType)[keyof typeof RocketmqGetConnectorType]
 
@@ -1059,6 +1076,15 @@ export type RedisGetConnectorParameters =
   | RedisRedisSentinelConnector
   | RedisRedisSingleConnector
 
+export type RedisConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface RedisConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: RedisConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
 export interface RedisGetConnector {
   description?: string
   enable?: boolean
@@ -1086,7 +1112,7 @@ export interface RabbitmqPut {
    */
   port?: number
   resource_opts?: RabbitmqConnectorResourceOpts
-  server?: string
+  servers?: string
   ssl?: EmqxSslClientOpts
   tags?: string[]
   timeout?: string
@@ -1125,7 +1151,7 @@ export interface RabbitmqGet {
    */
   port?: number
   resource_opts?: RabbitmqConnectorResourceOpts
-  server?: string
+  servers?: string
   ssl?: EmqxSslClientOpts
   status?: RabbitmqGetStatus
   status_reason?: string
@@ -1144,10 +1170,11 @@ export interface RabbitmqConnectorResourceOpts {
   start_timeout?: string
 }
 
-export interface RabbitmqPut {
+export interface RabbitmqPost {
   description?: string
   enable?: boolean
   heartbeat?: string
+  name: string
   password: string
   /** @minimum 1 */
   pool_size?: number
@@ -1157,15 +1184,27 @@ export interface RabbitmqPut {
    */
   port?: number
   resource_opts?: RabbitmqConnectorResourceOpts
-  server?: string
+  servers?: string
   ssl?: EmqxSslClientOpts
   tags?: string[]
   timeout?: string
+  type: RabbitmqPostType
   username: string
   virtual_host?: string
 }
 
 export type PulsarPutAuthentication = BridgePulsarAuthToken | BridgePulsarAuthBasic | 'none'
+
+export interface PulsarPut {
+  authentication?: PulsarPutAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  resource_opts?: PulsarConnectorResourceOpts
+  servers: string
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+}
 
 export type PulsarPostType = (typeof PulsarPostType)[keyof typeof PulsarPostType]
 
@@ -1201,26 +1240,6 @@ export const PulsarGetStatus = {
 
 export type PulsarGetAuthentication = BridgePulsarAuthToken | BridgePulsarAuthBasic | 'none'
 
-export type PulsarConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface PulsarConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: PulsarConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
-
-export interface PulsarPut {
-  authentication?: PulsarPutAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  resource_opts?: PulsarConnectorResourceOpts
-  servers: string
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-}
-
 export interface PulsarGet {
   authentication?: PulsarGetAuthentication
   connect_timeout?: string
@@ -1233,6 +1252,15 @@ export interface PulsarGet {
   status?: PulsarGetStatus
   status_reason?: string
   tags?: string[]
+}
+
+export type PulsarConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface PulsarConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: PulsarConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
 }
 
 export interface OpentsConnectorPut {
@@ -1288,6 +1316,15 @@ export const OpentsConnectorGetStatus = {
   inconsistent: 'inconsistent',
 } as const
 
+export type OpentsConnectorConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface OpentsConnectorConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: OpentsConnectorConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
 export interface OpentsConnectorGet {
   description?: string
   details?: boolean
@@ -1303,15 +1340,6 @@ export interface OpentsConnectorGet {
   summary?: boolean
   tags?: string[]
   type: OpentsConnectorGetType
-}
-
-export type OpentsConnectorConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface OpentsConnectorConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: OpentsConnectorConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
 }
 
 export interface MongoTopology {
@@ -1770,6 +1798,30 @@ export const IotdbGetThriftDriver = {
   thrift: 'thrift',
 } as const
 
+export interface IotdbGetThrift {
+  connect_timeout?: string
+  description?: string
+  driver?: IotdbGetThriftDriver
+  enable?: boolean
+  name: string
+  node_status?: ActionsAndSourcesNodeStatus[]
+  password: string
+  /** @minimum 1 */
+  pool_size?: number
+  protocol_version?: IotdbGetThriftProtocolVersion
+  recv_timeout?: string
+  resource_opts?: IotdbConnectorResourceOpts
+  server: string
+  sql?: IotdbGetThriftSql
+  ssl?: EmqxSslClientOpts
+  status?: IotdbGetThriftStatus
+  status_reason?: string
+  tags?: string[]
+  type: IotdbGetThriftType
+  username: string
+  zoneId?: string
+}
+
 export type IotdbGetRestapiType = (typeof IotdbGetRestapiType)[keyof typeof IotdbGetRestapiType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -1818,6 +1870,31 @@ export type IotdbGetRestapiDriver =
 export const IotdbGetRestapiDriver = {
   restapi: 'restapi',
 } as const
+
+export interface IotdbGetRestapi {
+  authentication?: IotdbAuthentication
+  base_url: string
+  connect_timeout?: string
+  description?: string
+  driver?: IotdbGetRestapiDriver
+  enable?: boolean
+  /** @minimum 1 */
+  enable_pipelining?: number
+  iotdb_version?: IotdbGetRestapiIotdbVersion
+  max_inactive?: string
+  name: string
+  node_status?: ActionsAndSourcesNodeStatus[]
+  /** @minimum 1 */
+  pool_size?: number
+  pool_type?: IotdbGetRestapiPoolType
+  resource_opts?: BridgeHttpConnectorResourceOpts
+  sql?: IotdbGetRestapiSql
+  ssl?: EmqxSslClientOpts
+  status?: IotdbGetRestapiStatus
+  status_reason?: string
+  tags?: string[]
+  type: IotdbGetRestapiType
+}
 
 export type IotdbConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
 
@@ -1928,27 +2005,6 @@ export type GcpPubsubProducerPostConnectorAuthentication =
   | GcpPubsubAuthWif
   | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubProducerPostConnector {
-  authentication: GcpPubsubProducerPostConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  name: string
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubProducerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-  type: GcpPubsubProducerPostConnectorType
-}
 
 export interface GcpPubsubProducerPostConnector {
   authentication: GcpPubsubProducerPostConnectorAuthentication
@@ -2154,79 +2210,6 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export interface EmqxSslClientOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  /** @minimum 0 */
-  depth?: number
-  enable?: boolean
-  hibernate_after?: string
-  keyfile?: string
-  log_level?: EmqxSslClientOptsLogLevel
-  managed_certs?: EmqxManagedCerts
-  middlebox_comp_mode?: boolean
-  partial_chain?: EmqxSslClientOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  server_name_indication?: EmqxSslClientOptsServerNameIndication
-  verify?: EmqxSslClientOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export interface IotdbGetThrift {
-  connect_timeout?: string
-  description?: string
-  driver?: IotdbGetThriftDriver
-  enable?: boolean
-  name: string
-  node_status?: ActionsAndSourcesNodeStatus[]
-  password: string
-  /** @minimum 1 */
-  pool_size?: number
-  protocol_version?: IotdbGetThriftProtocolVersion
-  recv_timeout?: string
-  resource_opts?: IotdbConnectorResourceOpts
-  server: string
-  sql?: IotdbGetThriftSql
-  ssl?: EmqxSslClientOpts
-  status?: IotdbGetThriftStatus
-  status_reason?: string
-  tags?: string[]
-  type: IotdbGetThriftType
-  username: string
-  zoneId?: string
-}
-
-export interface IotdbGetRestapi {
-  authentication?: IotdbAuthentication
-  base_url: string
-  connect_timeout?: string
-  description?: string
-  driver?: IotdbGetRestapiDriver
-  enable?: boolean
-  /** @minimum 1 */
-  enable_pipelining?: number
-  iotdb_version?: IotdbGetRestapiIotdbVersion
-  max_inactive?: string
-  name: string
-  node_status?: ActionsAndSourcesNodeStatus[]
-  /** @minimum 1 */
-  pool_size?: number
-  pool_type?: IotdbGetRestapiPoolType
-  resource_opts?: BridgeHttpConnectorResourceOpts
-  sql?: IotdbGetRestapiSql
-  ssl?: EmqxSslClientOpts
-  status?: IotdbGetRestapiStatus
-  status_reason?: string
-  tags?: string[]
-  type: IotdbGetRestapiType
-}
-
 export type EmqxSslClientOptsServerNameIndication = string | 'disable'
 
 export type EmqxSslClientOptsPartialChain =
@@ -2260,6 +2243,30 @@ export const EmqxSslClientOptsLogLevel = {
 export interface EmqxManagedCerts {
   bundle_name: string
   namespace?: string
+}
+
+export interface EmqxSslClientOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  /** @minimum 0 */
+  depth?: number
+  enable?: boolean
+  hibernate_after?: string
+  keyfile?: string
+  log_level?: EmqxSslClientOptsLogLevel
+  managed_certs?: EmqxManagedCerts
+  middlebox_comp_mode?: boolean
+  partial_chain?: EmqxSslClientOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  server_name_indication?: EmqxSslClientOptsServerNameIndication
+  verify?: EmqxSslClientOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
 }
 
 export interface EmqxClientTcpOpts {
@@ -2466,6 +2473,15 @@ export const ConnectorSyskeeperProxyGetStatus = {
   inconsistent: 'inconsistent',
 } as const
 
+export type ConnectorSyskeeperProxyConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface ConnectorSyskeeperProxyConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: ConnectorSyskeeperProxyConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
 export interface ConnectorSyskeeperProxyGet {
   /** @minimum 0 */
   acceptors?: number
@@ -2481,15 +2497,6 @@ export interface ConnectorSyskeeperProxyGet {
   status_reason?: string
   tags?: string[]
   type: ConnectorSyskeeperProxyGetType
-}
-
-export type ConnectorSyskeeperProxyConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface ConnectorSyskeeperProxyConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: ConnectorSyskeeperProxyConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
 }
 
 export interface ConnectorSnowflakeStreamingProxyConfig {
@@ -2608,6 +2615,15 @@ export interface ConnectorSnowflakeStreamingGetConnector {
   type: ConnectorSnowflakeStreamingGetConnectorType
 }
 
+export interface ConnectorSnowflakeAggregatedProxyConfig {
+  host: string
+  /**
+   * @minimum 1
+   * @maximum 65535
+   */
+  port: number
+}
+
 export type ConnectorSnowflakeAggregatedPutConnectorProxy =
   | ConnectorSnowflakeAggregatedProxyConfig
   | 'none'
@@ -2630,15 +2646,6 @@ export interface ConnectorSnowflakeAggregatedPutConnector {
   ssl?: EmqxSslClientOpts
   tags?: string[]
   username?: string
-}
-
-export interface ConnectorSnowflakeAggregatedProxyConfig {
-  host: string
-  /**
-   * @minimum 1
-   * @maximum 65535
-   */
-  port: number
 }
 
 export type ConnectorSnowflakeAggregatedPostConnectorType =
@@ -2985,48 +2992,6 @@ export interface ConnectorPostgresResourceOpts {
   health_check_timeout?: ConnectorPostgresResourceOptsHealthCheckTimeout
   start_after_created?: boolean
   start_timeout?: string
-}
-
-export interface ConnectorRedshiftPostConnector {
-  /** @deprecated */
-  auto_reconnect?: boolean
-  database: string
-  description?: string
-  disable_prepared_statements?: boolean
-  enable?: boolean
-  name: string
-  password?: string
-  /** @minimum 1 */
-  pool_size?: number
-  resource_opts?: ConnectorPostgresResourceOpts
-  server: string
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-  type: ConnectorRedshiftPostConnectorType
-  username: string
-}
-
-export interface ConnectorRedshiftGetConnector {
-  actions?: string[]
-  /** @deprecated */
-  auto_reconnect?: boolean
-  database: string
-  description?: string
-  disable_prepared_statements?: boolean
-  enable?: boolean
-  name: string
-  node_status?: ConnectorNodeStatus[]
-  password?: string
-  /** @minimum 1 */
-  pool_size?: number
-  resource_opts?: ConnectorPostgresResourceOpts
-  server: string
-  ssl?: EmqxSslClientOpts
-  status?: ConnectorRedshiftGetConnectorStatus
-  status_reason?: string
-  tags?: string[]
-  type: ConnectorRedshiftGetConnectorType
-  username: string
 }
 
 export interface ConnectorPostgresPutConnector {
@@ -4645,6 +4610,18 @@ export const ConfluentAuthOauthClientCredentialsGrantType = {
 
 export type ConfluentAuthOauthClientCredentialsExtensions = { [key: string]: unknown }
 
+export interface ConfluentAuthOauthClientCredentials {
+  client_id: string
+  client_secret: string
+  endpoint_uri: string
+  extensions?: ConfluentAuthOauthClientCredentialsExtensions
+  grant_type: ConfluentAuthOauthClientCredentialsGrantType
+  identity_pool_id?: string
+  logical_cluster: string
+  mechanism: ConfluentAuthOauthClientCredentialsMechanism
+  scope?: string
+}
+
 export interface BridgeTimescalePutConnector {
   application_name?: string
   /** @deprecated */
@@ -4771,22 +4748,6 @@ export type BridgeTablestorePostConnectorStorageModelType =
 export const BridgeTablestorePostConnectorStorageModelType = {
   timeseries: 'timeseries',
 } as const
-
-export interface BridgeTablestorePostConnector {
-  access_key_id: string
-  access_key_secret: string
-  description?: string
-  enable?: boolean
-  endpoint: string
-  instance_name: string
-  name: string
-  pool_size?: number
-  resource_opts?: BridgeTablestoreConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  storage_model_type?: BridgeTablestorePostConnectorStorageModelType
-  tags?: string[]
-  type: BridgeTablestorePostConnectorType
-}
 
 export type BridgeTablestoreGetConnectorType =
   (typeof BridgeTablestoreGetConnectorType)[keyof typeof BridgeTablestoreGetConnectorType]
@@ -4920,6 +4881,28 @@ export const BridgeSqlserverGetConnectorStatus = {
   disconnected: 'disconnected',
   inconsistent: 'inconsistent',
 } as const
+
+export interface BridgeSqlserverGetConnector {
+  actions?: string[]
+  /** @deprecated */
+  auto_reconnect?: boolean
+  database: string
+  description?: string
+  driver?: string
+  enable?: boolean
+  name: string
+  node_status?: ConnectorNodeStatus[]
+  password?: string
+  /** @minimum 1 */
+  pool_size?: number
+  resource_opts?: BridgeSqlserverConnectorResourceOpts
+  server: string
+  status?: BridgeSqlserverGetConnectorStatus
+  status_reason?: string
+  tags?: string[]
+  type: BridgeSqlserverGetConnectorType
+  username?: string
+}
 
 export type BridgeSqlserverConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
 
@@ -5061,6 +5044,23 @@ export const BridgeOraclePutConnectorRole = {
   sysdba: 'sysdba',
 } as const
 
+export interface BridgeOraclePutConnector {
+  /** @deprecated */
+  auto_reconnect?: boolean
+  description?: string
+  enable?: boolean
+  password?: string
+  /** @minimum 1 */
+  pool_size?: number
+  resource_opts?: BridgeOracleConnectorResourceOpts
+  role?: BridgeOraclePutConnectorRole
+  server: string
+  service_name?: string
+  sid?: string
+  tags?: string[]
+  username: string
+}
+
 export type BridgeOraclePostConnectorType =
   (typeof BridgeOraclePostConnectorType)[keyof typeof BridgeOraclePostConnectorType]
 
@@ -5125,6 +5125,15 @@ export const BridgeOracleGetConnectorRole = {
   sysdba: 'sysdba',
 } as const
 
+export type BridgeOracleConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface BridgeOracleConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: BridgeOracleConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
 export interface BridgeOracleGetConnector {
   actions?: string[]
   /** @deprecated */
@@ -5148,30 +5157,20 @@ export interface BridgeOracleGetConnector {
   username: string
 }
 
-export type BridgeOracleConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface BridgeOracleConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: BridgeOracleConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
-
-export interface BridgeOraclePutConnector {
+export interface BridgeMysqlPutConnector {
   /** @deprecated */
   auto_reconnect?: boolean
+  database: string
   description?: string
   enable?: boolean
   password?: string
   /** @minimum 1 */
   pool_size?: number
-  resource_opts?: BridgeOracleConnectorResourceOpts
-  role?: BridgeOraclePutConnectorRole
+  resource_opts?: BridgeMysqlConnectorResourceOpts
   server: string
-  service_name?: string
-  sid?: string
+  ssl?: EmqxSslClientOpts
   tags?: string[]
-  username: string
+  username?: string
 }
 
 export type BridgeMysqlPostConnectorType =
@@ -5219,6 +5218,15 @@ export const BridgeMysqlGetConnectorStatus = {
   inconsistent: 'inconsistent',
 } as const
 
+export type BridgeMysqlConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface BridgeMysqlConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: BridgeMysqlConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
 export interface BridgeMysqlGetConnector {
   actions?: string[]
   /** @deprecated */
@@ -5238,31 +5246,6 @@ export interface BridgeMysqlGetConnector {
   status_reason?: string
   tags?: string[]
   type: BridgeMysqlGetConnectorType
-  username?: string
-}
-
-export type BridgeMysqlConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface BridgeMysqlConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: BridgeMysqlConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
-
-export interface BridgeMysqlPutConnector {
-  /** @deprecated */
-  auto_reconnect?: boolean
-  database: string
-  description?: string
-  enable?: boolean
-  password?: string
-  /** @minimum 1 */
-  pool_size?: number
-  resource_opts?: BridgeMysqlConnectorResourceOpts
-  server: string
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
   username?: string
 }
 
@@ -5321,26 +5304,6 @@ export type BridgeMongodbPostConnectorParameters =
   | MongoConnectorRs
   | MongoConnectorSharded
   | MongoConnectorSingle
-
-export interface BridgeMongodbPostConnector {
-  auth_source?: string
-  database: string
-  description?: string
-  enable?: boolean
-  name: string
-  parameters: BridgeMongodbPostConnectorParameters
-  password?: string
-  /** @minimum 1 */
-  pool_size?: number
-  resource_opts?: BridgeMongodbConnectorResourceOpts
-  srv_record?: boolean
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-  topology?: MongoTopology
-  type: BridgeMongodbPostConnectorType
-  use_legacy_protocol?: BridgeMongodbPostConnectorUseLegacyProtocol
-  username?: string
-}
 
 export type BridgeMongodbGetConnectorUseLegacyProtocol =
   (typeof BridgeMongodbGetConnectorUseLegacyProtocol)[keyof typeof BridgeMongodbGetConnectorUseLegacyProtocol]

--- a/src/types/schemas/connectors.schemas.ts
+++ b/src/types/schemas/connectors.schemas.ts
@@ -54,33 +54,74 @@ export type PostNodesNodeConnectorsIdOperationParams = {
   ns?: string
 }
 
-export type PutConnectorsIdEnableEnable503Code =
-  (typeof PutConnectorsIdEnableEnable503Code)[keyof typeof PutConnectorsIdEnableEnable503Code]
+export type PostConnectorsProbe400Code =
+  (typeof PostConnectorsProbe400Code)[keyof typeof PostConnectorsProbe400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutConnectorsIdEnableEnable503Code = {
-  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+export const PostConnectorsProbe400Code = {
+  TEST_FAILED: 'TEST_FAILED',
 } as const
 
-export type PutConnectorsIdEnableEnable503 = {
-  code?: PutConnectorsIdEnableEnable503Code
+export type PostConnectorsProbe400 = {
+  code?: PostConnectorsProbe400Code
   message?: string
 }
 
-export type PutConnectorsIdEnableEnable404Code =
-  (typeof PutConnectorsIdEnableEnable404Code)[keyof typeof PutConnectorsIdEnableEnable404Code]
+export type PostConnectorsProbeBodyOneOf = IotdbPostRestapi | IotdbPostThrift
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutConnectorsIdEnableEnable404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
+export type PostConnectorsProbeBody =
+  | BridgeAzureEventHubPostConnector
+  | BridgeCassaPostConnector
+  | BridgeClickhousePostConnector
+  | BridgeDatalayersPostConnector
+  | BridgeDynamoPostConnector
+  | BridgeGreptimedbPostConnector
+  | BridgeHttpPostConnector
+  | BridgeInfluxdbPostConnector
+  | BridgeKafkaPostConnector
+  | BridgeKinesisPostConnector
+  | BridgeMatrixPostConnector
+  | BridgeMongodbPostConnector
+  | BridgeMysqlPostConnector
+  | BridgeOraclePostConnector
+  | BridgeS3PostConnector
+  | BridgeSqlserverPostConnector
+  | BridgeTablestorePostConnector
+  | BridgeTimescalePostConnector
+  | ConfluentPostConnector
+  | ConnectorAlloydbPostConnector
+  | ConnectorAwsTimestreamPostConnector
+  | ConnectorAzureBlobStoragePostConnector
+  | ConnectorAzureEventGridPostConnector
+  | ConnectorBigqueryPostConnector
+  | ConnectorBigtablePostConnector
+  | ConnectorCockroachdbPostConnector
+  | ConnectorCouchbasePostConnector
+  | ConnectorDiskLogPostConnector
+  | ConnectorDorisPostConnector
+  | ConnectorEmqxTablesPostConnector
+  | ConnectorMqttPostConnector
+  | ConnectorPostgresPostConnector
+  | ConnectorQuasardbPostConnector
+  | ConnectorRedshiftPostConnector
+  | ConnectorS3tablesPostConnector
+  | ConnectorSnowflakeAggregatedPostConnector
+  | ConnectorSnowflakeStreamingPostConnector
+  | ConnectorSyskeeperProxyPost
+  | ElasticsearchPost
+  | GcpPubsubConsumerPostConnector
+  | GcpPubsubProducerPostConnector
+  | KafkaConsumerPostConnector
+  | OpentsConnectorPost
+  | PulsarPost
+  | RabbitmqPost
+  | RedisPostConnector
+  | RocketmqPostConnector
+  | SyskeeperForwarderPost
+  | TdengineConnectorPost
+  | PostConnectorsProbeBodyOneOf
 
-export type PutConnectorsIdEnableEnable404 = {
-  code?: PutConnectorsIdEnableEnable404Code
-  message?: string
-}
-
-export type PutConnectorsIdEnableEnableParams = {
+export type PostConnectorsProbeParams = {
   ns?: string
 }
 
@@ -140,6 +181,36 @@ export type PostConnectorsIdOperationParams = {
   ns?: string
 }
 
+export type PutConnectorsIdEnableEnable503Code =
+  (typeof PutConnectorsIdEnableEnable503Code)[keyof typeof PutConnectorsIdEnableEnable503Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutConnectorsIdEnableEnable503Code = {
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+} as const
+
+export type PutConnectorsIdEnableEnable503 = {
+  code?: PutConnectorsIdEnableEnable503Code
+  message?: string
+}
+
+export type PutConnectorsIdEnableEnable404Code =
+  (typeof PutConnectorsIdEnableEnable404Code)[keyof typeof PutConnectorsIdEnableEnable404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutConnectorsIdEnableEnable404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PutConnectorsIdEnableEnable404 = {
+  code?: PutConnectorsIdEnableEnable404Code
+  message?: string
+}
+
+export type PutConnectorsIdEnableEnableParams = {
+  ns?: string
+}
+
 export type PutConnectorsId404Code =
   (typeof PutConnectorsId404Code)[keyof typeof PutConnectorsId404Code]
 
@@ -166,7 +237,7 @@ export type PutConnectorsId400 = {
   message?: string
 }
 
-export type PutConnectorsId200OneOf = IotdbGetThrift | IotdbGetRestapi
+export type PutConnectorsId200OneOf = IotdbGetRestapi | IotdbGetThrift
 
 export type PutConnectorsId200 =
   | BridgeAzureEventHubGetConnector
@@ -217,10 +288,10 @@ export type PutConnectorsId200 =
   | RedisGetConnector
   | RocketmqGetConnector
   | SyskeeperForwarderGet
-  | PutConnectorsId200OneOf
   | TdengineConnectorGet
+  | PutConnectorsId200OneOf
 
-export type PutConnectorsIdBodyOneOf = IotdbPutThrift | IotdbPutRestapi
+export type PutConnectorsIdBodyOneOf = IotdbPutRestapi | IotdbPutThrift
 
 export type PutConnectorsIdBody =
   | BridgeAzureEventHubPutConnector
@@ -271,8 +342,8 @@ export type PutConnectorsIdBody =
   | RedisPutConnector
   | RocketmqPutConnector
   | SyskeeperForwarderPut
-  | PutConnectorsIdBodyOneOf
   | TdengineConnectorPut
+  | PutConnectorsIdBodyOneOf
 
 export type PutConnectorsIdParams = {
   ns?: string
@@ -291,7 +362,7 @@ export type GetConnectorsId404 = {
   message?: string
 }
 
-export type GetConnectorsId200OneOf = IotdbGetThrift | IotdbGetRestapi
+export type GetConnectorsId200OneOf = IotdbGetRestapi | IotdbGetThrift
 
 export type GetConnectorsId200 =
   | BridgeAzureEventHubGetConnector
@@ -342,8 +413,8 @@ export type GetConnectorsId200 =
   | RedisGetConnector
   | RocketmqGetConnector
   | SyskeeperForwarderGet
-  | GetConnectorsId200OneOf
   | TdengineConnectorGet
+  | GetConnectorsId200OneOf
 
 export type GetConnectorsIdParams = {
   ns?: string
@@ -392,77 +463,6 @@ export type DeleteConnectorsIdParams = {
   ns?: string
 }
 
-export type PostConnectorsProbe400Code =
-  (typeof PostConnectorsProbe400Code)[keyof typeof PostConnectorsProbe400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostConnectorsProbe400Code = {
-  TEST_FAILED: 'TEST_FAILED',
-} as const
-
-export type PostConnectorsProbe400 = {
-  code?: PostConnectorsProbe400Code
-  message?: string
-}
-
-export type PostConnectorsProbeBodyOneOf = IotdbPostThrift | IotdbPostRestapi
-
-export type PostConnectorsProbeBody =
-  | BridgeAzureEventHubPostConnector
-  | BridgeCassaPostConnector
-  | BridgeClickhousePostConnector
-  | BridgeDatalayersPostConnector
-  | BridgeDynamoPostConnector
-  | BridgeGreptimedbPostConnector
-  | BridgeHttpPostConnector
-  | BridgeInfluxdbPostConnector
-  | BridgeKafkaPostConnector
-  | BridgeKinesisPostConnector
-  | BridgeMatrixPostConnector
-  | BridgeMongodbPostConnector
-  | BridgeMysqlPostConnector
-  | BridgeOraclePostConnector
-  | BridgeS3PostConnector
-  | BridgeSqlserverPostConnector
-  | BridgeTablestorePostConnector
-  | BridgeTimescalePostConnector
-  | ConfluentPostConnector
-  | ConnectorAlloydbPostConnector
-  | ConnectorAwsTimestreamPostConnector
-  | ConnectorAzureBlobStoragePostConnector
-  | ConnectorAzureEventGridPostConnector
-  | ConnectorBigqueryPostConnector
-  | ConnectorBigtablePostConnector
-  | ConnectorCockroachdbPostConnector
-  | ConnectorCouchbasePostConnector
-  | ConnectorDiskLogPostConnector
-  | ConnectorDorisPostConnector
-  | ConnectorEmqxTablesPostConnector
-  | ConnectorMqttPostConnector
-  | ConnectorPostgresPostConnector
-  | ConnectorQuasardbPostConnector
-  | ConnectorRedshiftPostConnector
-  | ConnectorS3tablesPostConnector
-  | ConnectorSnowflakeAggregatedPostConnector
-  | ConnectorSnowflakeStreamingPostConnector
-  | ConnectorSyskeeperProxyPost
-  | ElasticsearchPost
-  | GcpPubsubConsumerPostConnector
-  | GcpPubsubProducerPostConnector
-  | KafkaConsumerPostConnector
-  | OpentsConnectorPost
-  | PulsarPost
-  | RabbitmqPost
-  | RedisPostConnector
-  | RocketmqPostConnector
-  | SyskeeperForwarderPost
-  | PostConnectorsProbeBodyOneOf
-  | TdengineConnectorPost
-
-export type PostConnectorsProbeParams = {
-  ns?: string
-}
-
 export type PostConnectors400Code =
   (typeof PostConnectors400Code)[keyof typeof PostConnectors400Code]
 
@@ -476,7 +476,7 @@ export type PostConnectors400 = {
   message?: string
 }
 
-export type PostConnectors201OneOf = IotdbGetThrift | IotdbGetRestapi
+export type PostConnectors201OneOf = IotdbGetRestapi | IotdbGetThrift
 
 export type PostConnectors201 =
   | BridgeAzureEventHubGetConnector
@@ -527,68 +527,68 @@ export type PostConnectors201 =
   | RedisGetConnector
   | RocketmqGetConnector
   | SyskeeperForwarderGet
-  | PostConnectors201OneOf
   | TdengineConnectorGet
+  | PostConnectors201OneOf
 
-export type PostConnectorsBodyOneOf = IotdbPostThrift | IotdbPostRestapi
+export type PostConnectorsBodyOneOf = IotdbPostRestapi | IotdbPostThrift
 
 export type PostConnectorsParams = {
   ns?: string
 }
 
-export type GetConnectors200ItemOneOf = IotdbGetThrift | IotdbGetRestapi
+export type GetConnectors200ItemOneOf = IotdbGetRestapi | IotdbGetThrift
 
 export type GetConnectors200Item =
-  | KafkaConsumerGetConnector
-  | ConnectorEmqxTablesGetConnector
-  | ConnectorDiskLogGetConnector
-  | OpentsConnectorGet
   | BridgeAzureEventHubGetConnector
-  | BridgeMatrixGetConnector
-  | ConnectorDorisGetConnector
-  | ConfluentGetConnector
-  | BridgeMysqlGetConnector
-  | ConnectorQuasardbGetConnector
-  | BridgeKafkaGetConnector
-  | ConnectorPostgresGetConnector
-  | BridgeKinesisGetConnector
-  | ConnectorCockroachdbGetConnector
-  | PulsarGet
-  | BridgeDatalayersGetConnector
-  | ConnectorAlloydbGetConnector
-  | BridgeTablestoreGetConnector
-  | BridgeMongodbGetConnector
-  | GcpPubsubProducerGetConnector
-  | ConnectorSnowflakeAggregatedGetConnector
-  | BridgeHttpGetConnector
-  | ConnectorSyskeeperProxyGet
-  | ConnectorAzureEventGridGetConnector
-  | SyskeeperForwarderGet
   | BridgeCassaGetConnector
-  | RabbitmqGet
-  | ConnectorRedshiftGetConnector
-  | GcpPubsubConsumerGetConnector
-  | ConnectorAzureBlobStorageGetConnector
-  | RedisGetConnector
-  | ConnectorAwsTimestreamGetConnector
-  | BridgeInfluxdbGetConnector
-  | ConnectorBigtableGetConnector
   | BridgeClickhouseGetConnector
-  | ConnectorS3tablesGetConnector
-  | BridgeS3GetConnector
-  | BridgeGreptimedbGetConnector
-  | ConnectorBigqueryGetConnector
-  | ConnectorMqttGetConnector
-  | ConnectorCouchbaseGetConnector
-  | BridgeTimescaleGetConnector
+  | BridgeDatalayersGetConnector
   | BridgeDynamoGetConnector
-  | ConnectorSnowflakeStreamingGetConnector
-  | GetConnectors200ItemOneOf
-  | RocketmqGetConnector
-  | TdengineConnectorGet
-  | BridgeSqlserverGetConnector
+  | BridgeGreptimedbGetConnector
+  | BridgeHttpGetConnector
+  | BridgeInfluxdbGetConnector
+  | BridgeKafkaGetConnector
+  | BridgeKinesisGetConnector
+  | BridgeMatrixGetConnector
+  | BridgeMongodbGetConnector
+  | BridgeMysqlGetConnector
   | BridgeOracleGetConnector
+  | BridgeS3GetConnector
+  | BridgeSqlserverGetConnector
+  | BridgeTablestoreGetConnector
+  | BridgeTimescaleGetConnector
+  | ConfluentGetConnector
+  | ConnectorAlloydbGetConnector
+  | ConnectorAwsTimestreamGetConnector
+  | ConnectorAzureBlobStorageGetConnector
+  | ConnectorAzureEventGridGetConnector
+  | ConnectorBigqueryGetConnector
+  | ConnectorBigtableGetConnector
+  | ConnectorCockroachdbGetConnector
+  | ConnectorCouchbaseGetConnector
+  | ConnectorDiskLogGetConnector
+  | ConnectorDorisGetConnector
+  | ConnectorEmqxTablesGetConnector
+  | ConnectorMqttGetConnector
+  | ConnectorPostgresGetConnector
+  | ConnectorQuasardbGetConnector
+  | ConnectorRedshiftGetConnector
+  | ConnectorS3tablesGetConnector
+  | ConnectorSnowflakeAggregatedGetConnector
+  | ConnectorSnowflakeStreamingGetConnector
+  | ConnectorSyskeeperProxyGet
   | ElasticsearchGet
+  | GcpPubsubConsumerGetConnector
+  | GcpPubsubProducerGetConnector
+  | KafkaConsumerGetConnector
+  | OpentsConnectorGet
+  | PulsarGet
+  | RabbitmqGet
+  | RedisGetConnector
+  | RocketmqGetConnector
+  | SyskeeperForwarderGet
+  | TdengineConnectorGet
+  | GetConnectors200ItemOneOf
 
 export type GetConnectorsParams = {
   ns?: string
@@ -784,8 +784,8 @@ export type PostConnectorsBody =
   | RedisPostConnector
   | RocketmqPostConnector
   | SyskeeperForwarderPost
-  | PostConnectorsBodyOneOf
   | TdengineConnectorPost
+  | PostConnectorsBodyOneOf
 
 export type SyskeeperForwarderGetType =
   (typeof SyskeeperForwarderGetType)[keyof typeof SyskeeperForwarderGetType]
@@ -1193,7 +1193,7 @@ export interface RabbitmqPost {
   virtual_host?: string
 }
 
-export type PulsarPutAuthentication = BridgePulsarAuthToken | BridgePulsarAuthBasic | 'none'
+export type PulsarPutAuthentication = BridgePulsarAuthBasic | BridgePulsarAuthToken | 'none'
 
 export interface PulsarPut {
   authentication?: PulsarPutAuthentication
@@ -1213,7 +1213,7 @@ export const PulsarPostType = {
   pulsar: 'pulsar',
 } as const
 
-export type PulsarPostAuthentication = BridgePulsarAuthToken | BridgePulsarAuthBasic | 'none'
+export type PulsarPostAuthentication = BridgePulsarAuthBasic | BridgePulsarAuthToken | 'none'
 
 export interface PulsarPost {
   authentication?: PulsarPostAuthentication
@@ -1238,7 +1238,7 @@ export const PulsarGetStatus = {
   inconsistent: 'inconsistent',
 } as const
 
-export type PulsarGetAuthentication = BridgePulsarAuthToken | BridgePulsarAuthBasic | 'none'
+export type PulsarGetAuthentication = BridgePulsarAuthBasic | BridgePulsarAuthToken | 'none'
 
 export interface PulsarGet {
   authentication?: PulsarGetAuthentication
@@ -1438,9 +1438,9 @@ export interface MongoConnectorRs {
 
 export type KafkaConsumerPutConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -1469,9 +1469,9 @@ export const KafkaConsumerPostConnectorType = {
 
 export type KafkaConsumerPostConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -1513,9 +1513,9 @@ export const KafkaConsumerGetConnectorStatus = {
 
 export type KafkaConsumerGetConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -1910,6 +1910,218 @@ export interface IotdbAuthentication {
   username: string
 }
 
+export type GcpPubsubProducerPutConnectorAuthentication =
+  | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
+
+export interface GcpPubsubProducerPutConnector {
+  authentication: GcpPubsubProducerPutConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubProducerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+}
+
+export type GcpPubsubProducerPostConnectorType =
+  (typeof GcpPubsubProducerPostConnectorType)[keyof typeof GcpPubsubProducerPostConnectorType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubProducerPostConnectorType = {
+  gcp_pubsub_producer: 'gcp_pubsub_producer',
+} as const
+
+export interface GcpPubsubProducerPostConnector {
+  authentication: GcpPubsubProducerPostConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  name: string
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubProducerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+  type: GcpPubsubProducerPostConnectorType
+}
+
+export type GcpPubsubProducerGetConnectorType =
+  (typeof GcpPubsubProducerGetConnectorType)[keyof typeof GcpPubsubProducerGetConnectorType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubProducerGetConnectorType = {
+  gcp_pubsub_producer: 'gcp_pubsub_producer',
+} as const
+
+export type GcpPubsubProducerGetConnectorStatus =
+  (typeof GcpPubsubProducerGetConnectorStatus)[keyof typeof GcpPubsubProducerGetConnectorStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubProducerGetConnectorStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+  inconsistent: 'inconsistent',
+} as const
+
+export type GcpPubsubProducerGetConnectorAuthentication =
+  | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
+
+export type GcpPubsubProducerConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface GcpPubsubProducerConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: GcpPubsubProducerConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
+export interface GcpPubsubProducerGetConnector {
+  actions?: string[]
+  authentication: GcpPubsubProducerGetConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  name: string
+  node_status?: ConnectorNodeStatus[]
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubProducerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  status?: GcpPubsubProducerGetConnectorStatus
+  status_reason?: string
+  tags?: string[]
+  type: GcpPubsubProducerGetConnectorType
+}
+
+export interface GcpPubsubConsumerPutConnector {
+  authentication: GcpPubsubConsumerPutConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+}
+
+export type GcpPubsubConsumerPostConnectorType =
+  (typeof GcpPubsubConsumerPostConnectorType)[keyof typeof GcpPubsubConsumerPostConnectorType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubConsumerPostConnectorType = {
+  gcp_pubsub_consumer: 'gcp_pubsub_consumer',
+} as const
+
+export interface GcpPubsubConsumerPostConnector {
+  authentication: GcpPubsubConsumerPostConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  name: string
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  tags?: string[]
+  type: GcpPubsubConsumerPostConnectorType
+}
+
+export type GcpPubsubConsumerGetConnectorType =
+  (typeof GcpPubsubConsumerGetConnectorType)[keyof typeof GcpPubsubConsumerGetConnectorType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubConsumerGetConnectorType = {
+  gcp_pubsub_consumer: 'gcp_pubsub_consumer',
+} as const
+
+export type GcpPubsubConsumerGetConnectorStatus =
+  (typeof GcpPubsubConsumerGetConnectorStatus)[keyof typeof GcpPubsubConsumerGetConnectorStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GcpPubsubConsumerGetConnectorStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+  inconsistent: 'inconsistent',
+} as const
+
+export type GcpPubsubConsumerConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface GcpPubsubConsumerConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: GcpPubsubConsumerConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
+export interface GcpPubsubConsumerGetConnector {
+  actions?: string[]
+  authentication: GcpPubsubConsumerGetConnectorAuthentication
+  connect_timeout?: string
+  description?: string
+  enable?: boolean
+  max_inactive?: string
+  /** @minimum 0 */
+  max_retries?: number
+  name: string
+  node_status?: ConnectorNodeStatus[]
+  /** @minimum 1 */
+  pipelining?: number
+  /** @minimum 1 */
+  pool_size?: number
+  /** @deprecated */
+  request_timeout?: string
+  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
+  ssl?: EmqxSslClientOpts
+  status?: GcpPubsubConsumerGetConnectorStatus
+  status_reason?: string
+  tags?: string[]
+  type: GcpPubsubConsumerGetConnectorType
+}
+
 export type GcpPubsubAuthWifOidcClientCredentialsType =
   (typeof GcpPubsubAuthWifOidcClientCredentialsType)[keyof typeof GcpPubsubAuthWifOidcClientCredentialsType]
 
@@ -1957,6 +2169,11 @@ export interface GcpPubsubAuthServiceAccountJson {
   type: GcpPubsubAuthServiceAccountJsonType
 }
 
+export type GcpPubsubConsumerGetConnectorAuthentication =
+  | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
+
 export type GcpPubsubAuthAttachedServiceAccountType =
   (typeof GcpPubsubAuthAttachedServiceAccountType)[keyof typeof GcpPubsubAuthAttachedServiceAccountType]
 
@@ -1969,237 +2186,20 @@ export interface GcpPubsubAuthAttachedServiceAccount {
   type: GcpPubsubAuthAttachedServiceAccountType
 }
 
-export type GcpPubsubProducerPutConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
-  | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubProducerPutConnector {
-  authentication: GcpPubsubProducerPutConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubProducerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-}
-
-export type GcpPubsubProducerPostConnectorType =
-  (typeof GcpPubsubProducerPostConnectorType)[keyof typeof GcpPubsubProducerPostConnectorType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubProducerPostConnectorType = {
-  gcp_pubsub_producer: 'gcp_pubsub_producer',
-} as const
-
 export type GcpPubsubProducerPostConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubProducerPostConnector {
-  authentication: GcpPubsubProducerPostConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  name: string
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubProducerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-  type: GcpPubsubProducerPostConnectorType
-}
-
-export type GcpPubsubProducerGetConnectorType =
-  (typeof GcpPubsubProducerGetConnectorType)[keyof typeof GcpPubsubProducerGetConnectorType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubProducerGetConnectorType = {
-  gcp_pubsub_producer: 'gcp_pubsub_producer',
-} as const
-
-export type GcpPubsubProducerGetConnectorStatus =
-  (typeof GcpPubsubProducerGetConnectorStatus)[keyof typeof GcpPubsubProducerGetConnectorStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubProducerGetConnectorStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-  inconsistent: 'inconsistent',
-} as const
-
-export type GcpPubsubProducerGetConnectorAuthentication =
-  | GcpPubsubAuthWif
   | GcpPubsubAuthServiceAccountJson
-  | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubProducerGetConnector {
-  actions?: string[]
-  authentication: GcpPubsubProducerGetConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  name: string
-  node_status?: ConnectorNodeStatus[]
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubProducerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  status?: GcpPubsubProducerGetConnectorStatus
-  status_reason?: string
-  tags?: string[]
-  type: GcpPubsubProducerGetConnectorType
-}
-
-export type GcpPubsubProducerConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface GcpPubsubProducerConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: GcpPubsubProducerConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
+  | GcpPubsubAuthWif
 
 export type GcpPubsubConsumerPutConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubConsumerPutConnector {
-  authentication: GcpPubsubConsumerPutConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-}
-
-export type GcpPubsubConsumerPostConnectorType =
-  (typeof GcpPubsubConsumerPostConnectorType)[keyof typeof GcpPubsubConsumerPostConnectorType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubConsumerPostConnectorType = {
-  gcp_pubsub_consumer: 'gcp_pubsub_consumer',
-} as const
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export type GcpPubsubConsumerPostConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
-
-export interface GcpPubsubConsumerPostConnector {
-  authentication: GcpPubsubConsumerPostConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  name: string
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  tags?: string[]
-  type: GcpPubsubConsumerPostConnectorType
-}
-
-export type GcpPubsubConsumerGetConnectorType =
-  (typeof GcpPubsubConsumerGetConnectorType)[keyof typeof GcpPubsubConsumerGetConnectorType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubConsumerGetConnectorType = {
-  gcp_pubsub_consumer: 'gcp_pubsub_consumer',
-} as const
-
-export type GcpPubsubConsumerGetConnectorStatus =
-  (typeof GcpPubsubConsumerGetConnectorStatus)[keyof typeof GcpPubsubConsumerGetConnectorStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GcpPubsubConsumerGetConnectorStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-  inconsistent: 'inconsistent',
-} as const
-
-export type GcpPubsubConsumerGetConnectorAuthentication =
-  | GcpPubsubAuthWif
   | GcpPubsubAuthServiceAccountJson
-  | GcpPubsubAuthAttachedServiceAccount
-
-export type GcpPubsubConsumerConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface GcpPubsubConsumerConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: GcpPubsubConsumerConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
-
-export interface GcpPubsubConsumerGetConnector {
-  actions?: string[]
-  authentication: GcpPubsubConsumerGetConnectorAuthentication
-  connect_timeout?: string
-  description?: string
-  enable?: boolean
-  max_inactive?: string
-  /** @minimum 0 */
-  max_retries?: number
-  name: string
-  node_status?: ConnectorNodeStatus[]
-  /** @minimum 1 */
-  pipelining?: number
-  /** @minimum 1 */
-  pool_size?: number
-  /** @deprecated */
-  request_timeout?: string
-  resource_opts?: GcpPubsubConsumerConnectorResourceOpts
-  ssl?: EmqxSslClientOpts
-  status?: GcpPubsubConsumerGetConnectorStatus
-  status_reason?: string
-  tags?: string[]
-  type: GcpPubsubConsumerGetConnectorType
-}
+  | GcpPubsubAuthWif
 
 export type EmqxSslClientOptsVerify =
   (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
@@ -2210,16 +2210,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -2396,43 +2396,6 @@ export interface ElasticsearchGet {
   type: ElasticsearchGetType
 }
 
-export type ConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
-
-export interface ConnectorResourceOpts {
-  health_check_interval?: string
-  health_check_timeout?: ConnectorResourceOptsHealthCheckTimeout
-  start_after_created?: boolean
-  start_timeout?: string
-}
-
-export type ConnectorNodeStatusStatus =
-  (typeof ConnectorNodeStatusStatus)[keyof typeof ConnectorNodeStatusStatus]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ConnectorNodeStatusStatus = {
-  connected: 'connected',
-  connecting: 'connecting',
-  disconnected: 'disconnected',
-  inconsistent: 'inconsistent',
-} as const
-
-export interface ConnectorNodeStatus {
-  node?: string
-  status?: ConnectorNodeStatusStatus
-  status_reason?: string
-}
-
-export interface ConnectorSyskeeperProxyPut {
-  /** @minimum 0 */
-  acceptors?: number
-  description?: string
-  enable?: boolean
-  handshake_timeout?: string
-  listen: string
-  resource_opts?: ConnectorSyskeeperProxyConnectorResourceOpts
-  tags?: string[]
-}
-
 export type ConnectorSyskeeperProxyPostType =
   (typeof ConnectorSyskeeperProxyPostType)[keyof typeof ConnectorSyskeeperProxyPostType]
 
@@ -2440,19 +2403,6 @@ export type ConnectorSyskeeperProxyPostType =
 export const ConnectorSyskeeperProxyPostType = {
   syskeeper_proxy: 'syskeeper_proxy',
 } as const
-
-export interface ConnectorSyskeeperProxyPost {
-  /** @minimum 0 */
-  acceptors?: number
-  description?: string
-  enable?: boolean
-  handshake_timeout?: string
-  listen: string
-  name: string
-  resource_opts?: ConnectorSyskeeperProxyConnectorResourceOpts
-  tags?: string[]
-  type: ConnectorSyskeeperProxyPostType
-}
 
 export type ConnectorSyskeeperProxyGetType =
   (typeof ConnectorSyskeeperProxyGetType)[keyof typeof ConnectorSyskeeperProxyGetType]
@@ -2480,6 +2430,30 @@ export interface ConnectorSyskeeperProxyConnectorResourceOpts {
   health_check_timeout?: ConnectorSyskeeperProxyConnectorResourceOptsHealthCheckTimeout
   start_after_created?: boolean
   start_timeout?: string
+}
+
+export interface ConnectorSyskeeperProxyPut {
+  /** @minimum 0 */
+  acceptors?: number
+  description?: string
+  enable?: boolean
+  handshake_timeout?: string
+  listen: string
+  resource_opts?: ConnectorSyskeeperProxyConnectorResourceOpts
+  tags?: string[]
+}
+
+export interface ConnectorSyskeeperProxyPost {
+  /** @minimum 0 */
+  acceptors?: number
+  description?: string
+  enable?: boolean
+  handshake_timeout?: string
+  listen: string
+  name: string
+  resource_opts?: ConnectorSyskeeperProxyConnectorResourceOpts
+  tags?: string[]
+  type: ConnectorSyskeeperProxyPostType
 }
 
 export interface ConnectorSyskeeperProxyGet {
@@ -3420,16 +3394,16 @@ export const ConnectorDorisSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type ConnectorDorisSslServerNameIndication = string | 'disable'
+export type ConnectorDorisSslServerNameIndication = 'disable' | string
 
 export type ConnectorDorisSslPartialChain =
   (typeof ConnectorDorisSslPartialChain)[keyof typeof ConnectorDorisSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ConnectorDorisSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -3818,9 +3792,9 @@ export interface ConnectorCockroachdbGetConnector {
 }
 
 export type ConnectorBigtablePutConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigtablePutConnector {
   authentication: ConnectorBigtablePutConnectorAuthentication
@@ -3843,9 +3817,9 @@ export const ConnectorBigtablePostConnectorType = {
 } as const
 
 export type ConnectorBigtablePostConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigtablePostConnector {
   authentication: ConnectorBigtablePostConnectorAuthentication
@@ -3881,9 +3855,9 @@ export const ConnectorBigtableGetConnectorStatus = {
 } as const
 
 export type ConnectorBigtableGetConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigtableGetConnector {
   actions?: string[]
@@ -3904,9 +3878,9 @@ export interface ConnectorBigtableGetConnector {
 }
 
 export type ConnectorBigqueryPutConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigqueryPutConnector {
   authentication: ConnectorBigqueryPutConnectorAuthentication
@@ -3934,9 +3908,9 @@ export const ConnectorBigqueryPostConnectorType = {
 } as const
 
 export type ConnectorBigqueryPostConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigqueryPostConnector {
   authentication: ConnectorBigqueryPostConnectorAuthentication
@@ -3977,9 +3951,9 @@ export const ConnectorBigqueryGetConnectorStatus = {
 } as const
 
 export type ConnectorBigqueryGetConnectorAuthentication =
-  | GcpPubsubAuthWif
-  | GcpPubsubAuthServiceAccountJson
   | GcpPubsubAuthAttachedServiceAccount
+  | GcpPubsubAuthServiceAccountJson
+  | GcpPubsubAuthWif
 
 export interface ConnectorBigqueryGetConnector {
   actions?: string[]
@@ -4258,8 +4232,8 @@ export interface ConnectorAzureBlobStorageGetConnector {
 }
 
 export type ConnectorAwsTimestreamPutConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
   | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export interface ConnectorAwsTimestreamPutConnector {
   description?: string
@@ -4282,8 +4256,8 @@ export const ConnectorAwsTimestreamPostConnectorType = {
 } as const
 
 export type ConnectorAwsTimestreamPostConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
   | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export interface ConnectorAwsTimestreamPostConnector {
   description?: string
@@ -4319,8 +4293,8 @@ export const ConnectorAwsTimestreamGetConnectorStatus = {
 } as const
 
 export type ConnectorAwsTimestreamGetConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
   | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export interface ConnectorAwsTimestreamGetConnector {
   actions?: string[]
@@ -4429,6 +4403,32 @@ export interface ConnectorAlloydbGetConnector {
   username: string
 }
 
+export type ConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
+
+export interface ConnectorResourceOpts {
+  health_check_interval?: string
+  health_check_timeout?: ConnectorResourceOptsHealthCheckTimeout
+  start_after_created?: boolean
+  start_timeout?: string
+}
+
+export type ConnectorNodeStatusStatus =
+  (typeof ConnectorNodeStatusStatus)[keyof typeof ConnectorNodeStatusStatus]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ConnectorNodeStatusStatus = {
+  connected: 'connected',
+  connecting: 'connecting',
+  disconnected: 'disconnected',
+  inconsistent: 'inconsistent',
+} as const
+
+export interface ConnectorNodeStatus {
+  node?: string
+  status?: ConnectorNodeStatusStatus
+  status_reason?: string
+}
+
 export type ConfluentSslClientOptsVerify =
   (typeof ConfluentSslClientOptsVerify)[keyof typeof ConfluentSslClientOptsVerify]
 
@@ -4438,16 +4438,16 @@ export const ConfluentSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type ConfluentSslClientOptsServerNameIndication = string | 'disable' | 'auto'
+export type ConfluentSslClientOptsServerNameIndication = 'auto' | 'disable' | string
 
 export type ConfluentSslClientOptsPartialChain =
   (typeof ConfluentSslClientOptsPartialChain)[keyof typeof ConfluentSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ConfluentSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -5254,9 +5254,9 @@ export type BridgeMongodbPutConnectorUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BridgeMongodbPutConnectorUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type BridgeMongodbPutConnectorParameters =
@@ -5287,9 +5287,9 @@ export type BridgeMongodbPostConnectorUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BridgeMongodbPostConnectorUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type BridgeMongodbPostConnectorType =
@@ -5310,9 +5310,9 @@ export type BridgeMongodbGetConnectorUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BridgeMongodbGetConnectorUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type BridgeMongodbGetConnectorType =
@@ -5576,16 +5576,16 @@ export const BridgeKafkaSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type BridgeKafkaSslClientOptsServerNameIndication = string | 'disable' | 'auto'
+export type BridgeKafkaSslClientOptsServerNameIndication = 'auto' | 'disable' | string
 
 export type BridgeKafkaSslClientOptsPartialChain =
   (typeof BridgeKafkaSslClientOptsPartialChain)[keyof typeof BridgeKafkaSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BridgeKafkaSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -5639,9 +5639,9 @@ export interface BridgeKafkaSocketOpts {
 
 export type BridgeKafkaPutConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -5671,9 +5671,9 @@ export const BridgeKafkaPostConnectorType = {
 
 export type BridgeKafkaPostConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -5716,9 +5716,9 @@ export const BridgeKafkaGetConnectorStatus = {
 
 export type BridgeKafkaGetConnectorAuthentication =
   | BridgeKafkaAuthGssapiKerberos
-  | BridgeKafkaAuthUsernamePassword
-  | BridgeKafkaAuthOauthClientCredentials
   | BridgeKafkaAuthMskIamRolesAnywhere
+  | BridgeKafkaAuthOauthClientCredentials
+  | BridgeKafkaAuthUsernamePassword
   | 'msk_iam'
   | 'none'
 
@@ -5817,9 +5817,9 @@ export interface BridgeKafkaAuthGssapiKerberos {
 }
 
 export type BridgeInfluxdbPutConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
-  | ConnectorInfluxdbConnectorInfluxdbApiV2
   | ConnectorInfluxdbConnectorInfluxdbApiV1
+  | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export interface BridgeInfluxdbPutConnector {
   description?: string
@@ -5842,9 +5842,9 @@ export const BridgeInfluxdbPostConnectorType = {
 } as const
 
 export type BridgeInfluxdbPostConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
-  | ConnectorInfluxdbConnectorInfluxdbApiV2
   | ConnectorInfluxdbConnectorInfluxdbApiV1
+  | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export interface BridgeInfluxdbPostConnector {
   description?: string
@@ -5880,9 +5880,9 @@ export const BridgeInfluxdbGetConnectorStatus = {
 } as const
 
 export type BridgeInfluxdbGetConnectorParameters =
-  | ConnectorInfluxdbConnectorInfluxdbApiV3
-  | ConnectorInfluxdbConnectorInfluxdbApiV2
   | ConnectorInfluxdbConnectorInfluxdbApiV1
+  | ConnectorInfluxdbConnectorInfluxdbApiV2
+  | ConnectorInfluxdbConnectorInfluxdbApiV3
 
 export type BridgeInfluxdbConnectorResourceOptsHealthCheckTimeout = 'infinity' | string
 
@@ -6513,16 +6513,16 @@ export const BridgeAzureEventHubSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type BridgeAzureEventHubSslClientOptsServerNameIndication = string | 'disable' | 'auto'
+export type BridgeAzureEventHubSslClientOptsServerNameIndication = 'auto' | 'disable' | string
 
 export type BridgeAzureEventHubSslClientOptsPartialChain =
   (typeof BridgeAzureEventHubSslClientOptsPartialChain)[keyof typeof BridgeAzureEventHubSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BridgeAzureEventHubSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 

--- a/src/types/schemas/dashboard.schemas.ts
+++ b/src/types/schemas/dashboard.schemas.ts
@@ -125,7 +125,7 @@ export type PutUsersUsername400 = {
   message?: string
 }
 
-export type PutUsersUsername200Scopes = string[] | 'unset'
+export type PutUsersUsername200Scopes = 'unset' | string[]
 
 export type PutUsersUsername200Mfa =
   (typeof PutUsersUsername200Mfa)[keyof typeof PutUsersUsername200Mfa]
@@ -210,7 +210,7 @@ export type DeleteUsersUsernameParams = {
   backend?: DeleteUsersUsernameBackend
 }
 
-export type PostUsers200Scopes = string[] | 'unset'
+export type PostUsers200Scopes = 'unset' | string[]
 
 export type PostUsers200Mfa = (typeof PostUsers200Mfa)[keyof typeof PostUsers200Mfa]
 
@@ -318,7 +318,7 @@ export type PostLoginBody = {
   username?: string
 }
 
-export type DashboardUserScopes = string[] | 'unset'
+export type DashboardUserScopes = 'unset' | string[]
 
 export type DashboardUserMfa = (typeof DashboardUserMfa)[keyof typeof DashboardUserMfa]
 

--- a/src/types/schemas/dashboardSingleSignOn.schemas.ts
+++ b/src/types/schemas/dashboardSingleSignOn.schemas.ts
@@ -1,3 +1,46 @@
+export type PutSsoBackend404Code = (typeof PutSsoBackend404Code)[keyof typeof PutSsoBackend404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutSsoBackend404Code = {
+  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
+} as const
+
+export type PutSsoBackend404 = {
+  code?: PutSsoBackend404Code
+  message?: string
+}
+
+export type PutSsoBackend200 = DashboardSaml | SsoLdap | SsoOidc
+
+export type PutSsoBackendBody = DashboardSaml | SsoLdap | SsoOidc
+
+export type GetSsoBackend404Code = (typeof GetSsoBackend404Code)[keyof typeof GetSsoBackend404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetSsoBackend404Code = {
+  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
+} as const
+
+export type GetSsoBackend404 = {
+  code?: GetSsoBackend404Code
+  message?: string
+}
+
+export type GetSsoBackend200 = DashboardSaml | SsoLdap | SsoOidc
+
+export type DeleteSsoBackend404Code =
+  (typeof DeleteSsoBackend404Code)[keyof typeof DeleteSsoBackend404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DeleteSsoBackend404Code = {
+  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
+} as const
+
+export type DeleteSsoBackend404 = {
+  code?: DeleteSsoBackend404Code
+  message?: string
+}
+
 export type PostSsoTokenExchange400Code =
   (typeof PostSsoTokenExchange400Code)[keyof typeof PostSsoTokenExchange400Code]
 
@@ -265,49 +308,6 @@ export type PostSsoLoginBackend200 =
 
 export type PostSsoLoginBackendBody = DashboardLogin | SsoLogin | SsoLogin
 
-export type PutSsoBackend404Code = (typeof PutSsoBackend404Code)[keyof typeof PutSsoBackend404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutSsoBackend404Code = {
-  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
-} as const
-
-export type PutSsoBackend404 = {
-  code?: PutSsoBackend404Code
-  message?: string
-}
-
-export type PutSsoBackend200 = DashboardSaml | SsoLdap | SsoOidc
-
-export type PutSsoBackendBody = DashboardSaml | SsoLdap | SsoOidc
-
-export type GetSsoBackend404Code = (typeof GetSsoBackend404Code)[keyof typeof GetSsoBackend404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetSsoBackend404Code = {
-  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
-} as const
-
-export type GetSsoBackend404 = {
-  code?: GetSsoBackend404Code
-  message?: string
-}
-
-export type GetSsoBackend200 = DashboardSaml | SsoLdap | SsoOidc
-
-export type DeleteSsoBackend404Code =
-  (typeof DeleteSsoBackend404Code)[keyof typeof DeleteSsoBackend404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeleteSsoBackend404Code = {
-  BACKEND_NOT_FOUND: 'BACKEND_NOT_FOUND',
-} as const
-
-export type DeleteSsoBackend404 = {
-  code?: DeleteSsoBackend404Code
-  message?: string
-}
-
 export type SsoOidcRoleSource = (typeof SsoOidcRoleSource)[keyof typeof SsoOidcRoleSource]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -425,15 +425,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -502,16 +502,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -561,36 +561,29 @@ export interface EmqxSslClientOpts {
   versions?: string[]
 }
 
-export type DashboardSamlBackend = (typeof DashboardSamlBackend)[keyof typeof DashboardSamlBackend]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DashboardSamlBackend = {
-  saml: 'saml',
-} as const
-
-export interface DashboardSaml {
-  backend: DashboardSamlBackend
-  dashboard_addr?: string
-  enable?: boolean
-  force_mfa?: boolean
-  idp_metadata_url?: string
-  idp_signs_assertions?: boolean
-  idp_signs_envelopes?: boolean
-  sp_private_key?: string
-  sp_public_key?: string
-  sp_sign_request?: boolean
+export interface DashboardSsoMfaMfaVerifyRequest {
+  backend: string
+  totp_code: string
+  username: string
+  verify_token: string
 }
 
-export type DashboardLoginBackend =
-  (typeof DashboardLoginBackend)[keyof typeof DashboardLoginBackend]
+export interface DashboardSsoMfaMfaSetupRequest {
+  backend: string
+  setup_token: string
+  totp_code: string
+  username: string
+}
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DashboardLoginBackend = {
-  saml: 'saml',
-} as const
+export interface DashboardSsoMfaMfaSetupInfoResponse {
+  mechanism: string
+  secret: string
+}
 
-export interface DashboardLogin {
-  backend: DashboardLoginBackend
+export interface DashboardSsoMfaMfaSetupInfoRequest {
+  backend: string
+  setup_token: string
+  username: string
 }
 
 export interface DashboardSsoTokenExchangeRequest {
@@ -654,27 +647,34 @@ export interface DashboardSsoBackendStatus {
   running?: boolean
 }
 
-export interface DashboardSsoMfaMfaVerifyRequest {
-  backend: string
-  totp_code: string
-  username: string
-  verify_token: string
+export type DashboardSamlBackend = (typeof DashboardSamlBackend)[keyof typeof DashboardSamlBackend]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DashboardSamlBackend = {
+  saml: 'saml',
+} as const
+
+export interface DashboardSaml {
+  backend: DashboardSamlBackend
+  dashboard_addr?: string
+  enable?: boolean
+  force_mfa?: boolean
+  idp_metadata_url?: string
+  idp_signs_assertions?: boolean
+  idp_signs_envelopes?: boolean
+  sp_private_key?: string
+  sp_public_key?: string
+  sp_sign_request?: boolean
 }
 
-export interface DashboardSsoMfaMfaSetupRequest {
-  backend: string
-  setup_token: string
-  totp_code: string
-  username: string
-}
+export type DashboardLoginBackend =
+  (typeof DashboardLoginBackend)[keyof typeof DashboardLoginBackend]
 
-export interface DashboardSsoMfaMfaSetupInfoResponse {
-  mechanism: string
-  secret: string
-}
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DashboardLoginBackend = {
+  saml: 'saml',
+} as const
 
-export interface DashboardSsoMfaMfaSetupInfoRequest {
-  backend: string
-  setup_token: string
-  username: string
+export interface DashboardLogin {
+  backend: DashboardLoginBackend
 }

--- a/src/types/schemas/dataBackup.schemas.ts
+++ b/src/types/schemas/dataBackup.schemas.ts
@@ -46,8 +46,8 @@ export const GetDataFilesFilename200 = {
 } as const
 
 export type GetDataFilesFilenameParams = {
-  node?: string
   namespace?: string
+  node?: string
 }
 
 export type DeleteDataFilesFilename404Code =
@@ -77,8 +77,8 @@ export type DeleteDataFilesFilename400 = {
 }
 
 export type DeleteDataFilesFilenameParams = {
-  node?: string
   namespace?: string
+  node?: string
 }
 
 export type PostDataFiles400Code = (typeof PostDataFiles400Code)[keyof typeof PostDataFiles400Code]
@@ -128,8 +128,8 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetDataFilesParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
   namespace?: string
 }
 

--- a/src/types/schemas/exHook.schemas.ts
+++ b/src/types/schemas/exHook.schemas.ts
@@ -147,16 +147,16 @@ export const ExhookSslConfVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type ExhookSslConfServerNameIndication = string | 'disable'
+export type ExhookSslConfServerNameIndication = 'disable' | string
 
 export type ExhookSslConfPartialChain =
   (typeof ExhookSslConfPartialChain)[keyof typeof ExhookSslConfPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ExhookSslConfPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -217,7 +217,7 @@ export const ExhookServerConfigFailedAction = {
   ignore: 'ignore',
 } as const
 
-export type ExhookServerConfigAutoReconnect = string | false
+export type ExhookServerConfigAutoReconnect = false | string
 
 export interface ExhookServerConfig {
   auto_reconnect?: ExhookServerConfigAutoReconnect
@@ -294,7 +294,7 @@ export const ExhookDetailServerInfoFailedAction = {
   ignore: 'ignore',
 } as const
 
-export type ExhookDetailServerInfoAutoReconnect = string | false
+export type ExhookDetailServerInfoAutoReconnect = false | string
 
 export interface ExhookDetailServerInfo {
   auto_reconnect?: ExhookDetailServerInfoAutoReconnect

--- a/src/types/schemas/fileTransfer.schemas.ts
+++ b/src/types/schemas/fileTransfer.schemas.ts
@@ -212,16 +212,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 

--- a/src/types/schemas/gatewayAuthentication.schemas.ts
+++ b/src/types/schemas/gatewayAuthentication.schemas.ts
@@ -173,9 +173,9 @@ export type GetGatewaysNameAuthenticationUsers400 = {
 }
 
 export type GetGatewaysNameAuthenticationUsersParams = {
+  like_user_id?: string
   page?: number
   limit?: number
-  like_user_id?: string
   is_superuser?: boolean
 }
 
@@ -461,15 +461,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -513,6 +513,30 @@ export interface LdapSsl {
   versions?: string[]
 }
 
+export interface EmqxAuthnApiResponseUser {
+  is_superuser?: boolean
+  namespace?: string
+  user_id: string
+}
+
+export interface EmqxAuthnApiResponseUsers {
+  data?: EmqxAuthnApiResponseUser[]
+  meta?: PublicMeta
+}
+
+export interface EmqxAuthnApiRequestUserUpdate {
+  is_superuser?: boolean
+  namespace?: string
+  password: string
+}
+
+export interface EmqxAuthnApiRequestUserCreate {
+  is_superuser?: boolean
+  namespace?: string
+  password: string
+  user_id: string
+}
+
 export type EmqxSslClientOptsVerify =
   (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
 
@@ -522,16 +546,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -581,30 +605,6 @@ export interface EmqxSslClientOpts {
   versions?: string[]
 }
 
-export interface EmqxAuthnApiResponseUser {
-  is_superuser?: boolean
-  namespace?: string
-  user_id: string
-}
-
-export interface EmqxAuthnApiResponseUsers {
-  data?: EmqxAuthnApiResponseUser[]
-  meta?: PublicMeta
-}
-
-export interface EmqxAuthnApiRequestUserUpdate {
-  is_superuser?: boolean
-  namespace?: string
-  password: string
-}
-
-export interface EmqxAuthnApiRequestUserCreate {
-  is_superuser?: boolean
-  namespace?: string
-  password: string
-  user_id: string
-}
-
 export type ConnectorHttpRequestHeaders = { [key: string]: unknown }
 
 export interface ConnectorHttpRequest {
@@ -617,6 +617,91 @@ export interface ConnectorHttpRequest {
   request_timeout?: string
 }
 
+export type AuthnHashSimpleSaltPosition =
+  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleSaltPosition = {
+  disable: 'disable',
+  prefix: 'prefix',
+  suffix: 'suffix',
+} as const
+
+export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleName = {
+  md5: 'md5',
+  plain: 'plain',
+  sha: 'sha',
+  sha256: 'sha256',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashSimple {
+  name: AuthnHashSimpleName
+  salt_position?: AuthnHashSimpleSaltPosition
+}
+
+export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2Name = {
+  pbkdf2: 'pbkdf2',
+} as const
+
+export type AuthnHashPbkdf2MacFun =
+  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2MacFun = {
+  md4: 'md4',
+  md5: 'md5',
+  ripemd160: 'ripemd160',
+  sha: 'sha',
+  sha224: 'sha224',
+  sha256: 'sha256',
+  sha384: 'sha384',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashPbkdf2 {
+  /** @minimum 1 */
+  dk_length?: number
+  /** @minimum 1 */
+  iterations: number
+  mac_fun: AuthnHashPbkdf2MacFun
+  name: AuthnHashPbkdf2Name
+}
+
+export type AuthnHashBcryptRwName =
+  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptRwName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcryptRw {
+  name: AuthnHashBcryptRwName
+  /**
+   * @minimum 5
+   * @maximum 10
+   */
+  salt_rounds?: number
+}
+
+export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcrypt {
+  name: AuthnHashBcryptName
+}
+
 export type AuthnRedisSingleRedisType =
   (typeof AuthnRedisSingleRedisType)[keyof typeof AuthnRedisSingleRedisType]
 
@@ -626,9 +711,9 @@ export const AuthnRedisSingleRedisType = {
 } as const
 
 export type AuthnRedisSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSingleMechanism =
   (typeof AuthnRedisSingleMechanism)[keyof typeof AuthnRedisSingleMechanism]
@@ -675,9 +760,9 @@ export const AuthnRedisSentinelRedisType = {
 } as const
 
 export type AuthnRedisSentinelPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSentinelMechanism =
   (typeof AuthnRedisSentinelMechanism)[keyof typeof AuthnRedisSentinelMechanism]
@@ -727,9 +812,9 @@ export const AuthnRedisClusterRedisType = {
 } as const
 
 export type AuthnRedisClusterPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisClusterMechanism =
   (typeof AuthnRedisClusterMechanism)[keyof typeof AuthnRedisClusterMechanism]
@@ -766,9 +851,9 @@ export interface AuthnRedisCluster {
 }
 
 export type AuthnPostgresqlPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnPostgresqlMechanism =
   (typeof AuthnPostgresqlMechanism)[keyof typeof AuthnPostgresqlMechanism]
@@ -806,7 +891,7 @@ export interface AuthnPostgresql {
   username: string
 }
 
-export type AuthnMysqlPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMysqlPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMysqlMechanism = (typeof AuthnMysqlMechanism)[keyof typeof AuthnMysqlMechanism]
 
@@ -857,15 +942,15 @@ export type AuthnMongoSingleUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoSingleUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoSingleMongoType =
   (typeof AuthnMongoSingleMongoType)[keyof typeof AuthnMongoSingleMongoType]
@@ -934,15 +1019,15 @@ export type AuthnMongoShardedUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoShardedUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoShardedPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoShardedMongoType =
   (typeof AuthnMongoShardedMongoType)[keyof typeof AuthnMongoShardedMongoType]
@@ -1010,9 +1095,9 @@ export type AuthnMongoRsUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoRsUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoRsRMode = (typeof AuthnMongoRsRMode)[keyof typeof AuthnMongoRsRMode]
@@ -1023,7 +1108,7 @@ export const AuthnMongoRsRMode = {
   slave_ok: 'slave_ok',
 } as const
 
-export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMongoRsMongoType =
   (typeof AuthnMongoRsMongoType)[keyof typeof AuthnMongoRsMongoType]
@@ -1303,16 +1388,16 @@ export const AuthnJwksClientSslOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type AuthnJwksClientSslOptsServerNameIndication = string | 'disable'
+export type AuthnJwksClientSslOptsServerNameIndication = 'disable' | string
 
 export type AuthnJwksClientSslOptsPartialChain =
   (typeof AuthnJwksClientSslOptsPartialChain)[keyof typeof AuthnJwksClientSslOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnJwksClientSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -1531,6 +1616,11 @@ export const AuthnBuiltinDbUserIdType = {
   username: 'username',
 } as const
 
+export type AuthnBuiltinDbPasswordHashAlgorithm =
+  | AuthnHashBcryptRw
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
+
 export type AuthnBuiltinDbMechanism =
   (typeof AuthnBuiltinDbMechanism)[keyof typeof AuthnBuiltinDbMechanism]
 
@@ -1579,94 +1669,4 @@ export interface AuthnBindMethod {
   clientid_override_attribute?: string
   is_superuser_attribute?: string
   type?: AuthnBindMethodType
-}
-
-export type AuthnHashSimpleSaltPosition =
-  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleSaltPosition = {
-  disable: 'disable',
-  prefix: 'prefix',
-  suffix: 'suffix',
-} as const
-
-export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleName = {
-  md5: 'md5',
-  plain: 'plain',
-  sha: 'sha',
-  sha256: 'sha256',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashSimple {
-  name: AuthnHashSimpleName
-  salt_position?: AuthnHashSimpleSaltPosition
-}
-
-export type AuthnBuiltinDbPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
-  | AuthnHashBcryptRw
-
-export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2Name = {
-  pbkdf2: 'pbkdf2',
-} as const
-
-export type AuthnHashPbkdf2MacFun =
-  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2MacFun = {
-  md4: 'md4',
-  md5: 'md5',
-  ripemd160: 'ripemd160',
-  sha: 'sha',
-  sha224: 'sha224',
-  sha256: 'sha256',
-  sha384: 'sha384',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashPbkdf2 {
-  /** @minimum 1 */
-  dk_length?: number
-  /** @minimum 1 */
-  iterations: number
-  mac_fun: AuthnHashPbkdf2MacFun
-  name: AuthnHashPbkdf2Name
-}
-
-export type AuthnHashBcryptRwName =
-  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptRwName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcryptRw {
-  name: AuthnHashBcryptRwName
-  /**
-   * @minimum 5
-   * @maximum 10
-   */
-  salt_rounds?: number
-}
-
-export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcrypt {
-  name: AuthnHashBcryptName
 }

--- a/src/types/schemas/gatewayClients.schemas.ts
+++ b/src/types/schemas/gatewayClients.schemas.ts
@@ -168,23 +168,23 @@ export type GetGatewaysNameClients400 = {
 }
 
 export type GetGatewaysNameClientsParams = {
-  node?: string
-  clientid?: string
-  username?: string
-  ip_address?: string
-  conn_state?: string
-  proto_ver?: string
   clean_start?: boolean
-  like_clientid?: string
-  like_username?: string
-  gte_created_at?: number | string
-  lte_created_at?: number | string
-  gte_connected_at?: number | string
-  lte_connected_at?: number | string
+  clientid?: string
+  conn_state?: string
   endpoint_name?: string
-  like_endpoint_name?: string
+  gte_connected_at?: string | number
+  gte_created_at?: string | number
   gte_lifetime?: string
+  ip_address?: string
+  like_clientid?: string
+  like_endpoint_name?: string
+  like_username?: string
+  lte_connected_at?: string | number
+  lte_created_at?: string | number
   lte_lifetime?: string
+  node?: string
+  proto_ver?: string
+  username?: string
   page?: number
   limit?: number
 }
@@ -216,11 +216,11 @@ export interface EmqxGatewayApiClientsSubscription {
   topic?: string
 }
 
-export type EmqxGatewayApiClientsStompClientDisconnectedAt = number | string
+export type EmqxGatewayApiClientsStompClientDisconnectedAt = string | number
 
-export type EmqxGatewayApiClientsStompClientCreatedAt = number | string
+export type EmqxGatewayApiClientsStompClientCreatedAt = string | number
 
-export type EmqxGatewayApiClientsStompClientConnectedAt = number | string
+export type EmqxGatewayApiClientsStompClientConnectedAt = string | number
 
 export interface EmqxGatewayApiClientsStompClient {
   awaiting_rel_cnt?: number
@@ -262,17 +262,17 @@ export interface EmqxGatewayApiClientsStompClient {
 }
 
 export type GetGatewaysNameClients200Data =
+  | EmqxGatewayApiClientsCoapClient[]
   | EmqxGatewayApiClientsExprotoClient[]
   | EmqxGatewayApiClientsLwm2mClient[]
-  | EmqxGatewayApiClientsCoapClient[]
   | EmqxGatewayApiClientsMqttsnClient[]
   | EmqxGatewayApiClientsStompClient[]
 
-export type EmqxGatewayApiClientsMqttsnClientDisconnectedAt = number | string
+export type EmqxGatewayApiClientsMqttsnClientDisconnectedAt = string | number
 
-export type EmqxGatewayApiClientsMqttsnClientCreatedAt = number | string
+export type EmqxGatewayApiClientsMqttsnClientCreatedAt = string | number
 
-export type EmqxGatewayApiClientsMqttsnClientConnectedAt = number | string
+export type EmqxGatewayApiClientsMqttsnClientConnectedAt = string | number
 
 export interface EmqxGatewayApiClientsMqttsnClient {
   awaiting_rel_cnt?: number
@@ -313,11 +313,11 @@ export interface EmqxGatewayApiClientsMqttsnClient {
   username?: string
 }
 
-export type EmqxGatewayApiClientsLwm2mClientDisconnectedAt = number | string
+export type EmqxGatewayApiClientsLwm2mClientDisconnectedAt = string | number
 
-export type EmqxGatewayApiClientsLwm2mClientCreatedAt = number | string
+export type EmqxGatewayApiClientsLwm2mClientCreatedAt = string | number
 
-export type EmqxGatewayApiClientsLwm2mClientConnectedAt = number | string
+export type EmqxGatewayApiClientsLwm2mClientConnectedAt = string | number
 
 export interface EmqxGatewayApiClientsLwm2mClient {
   awaiting_rel_cnt?: number
@@ -364,11 +364,11 @@ export interface EmqxGatewayApiClientsExtraSubProps {
   subid?: string
 }
 
-export type EmqxGatewayApiClientsExprotoClientDisconnectedAt = number | string
+export type EmqxGatewayApiClientsExprotoClientDisconnectedAt = string | number
 
-export type EmqxGatewayApiClientsExprotoClientCreatedAt = number | string
+export type EmqxGatewayApiClientsExprotoClientCreatedAt = string | number
 
-export type EmqxGatewayApiClientsExprotoClientConnectedAt = number | string
+export type EmqxGatewayApiClientsExprotoClientConnectedAt = string | number
 
 export interface EmqxGatewayApiClientsExprotoClient {
   awaiting_rel_cnt?: number
@@ -409,11 +409,11 @@ export interface EmqxGatewayApiClientsExprotoClient {
   username?: string
 }
 
-export type EmqxGatewayApiClientsCoapClientDisconnectedAt = number | string
+export type EmqxGatewayApiClientsCoapClientDisconnectedAt = string | number
 
-export type EmqxGatewayApiClientsCoapClientCreatedAt = number | string
+export type EmqxGatewayApiClientsCoapClientCreatedAt = string | number
 
-export type EmqxGatewayApiClientsCoapClientConnectedAt = number | string
+export type EmqxGatewayApiClientsCoapClientConnectedAt = string | number
 
 export interface EmqxGatewayApiClientsCoapClient {
   awaiting_rel_cnt?: number

--- a/src/types/schemas/gatewayListeners.schemas.ts
+++ b/src/types/schemas/gatewayListeners.schemas.ts
@@ -523,9 +523,9 @@ export type GetGatewaysNameListeners400 = {
 
 export type GetGatewaysNameListeners200Item =
   | EmqxGatewayApiListenersDtlsListener
-  | EmqxGatewayApiListenersUdpListener
   | EmqxGatewayApiListenersSslListener
   | EmqxGatewayApiListenersTcpListener
+  | EmqxGatewayApiListenersUdpListener
 
 export interface MongoTopology {
   connect_timeout_ms?: string
@@ -541,9 +541,9 @@ export interface MongoTopology {
   wait_queue_timeout_ms?: string
 }
 
-export type ListenersStatusRunning = boolean | 'inconsistent'
+export type ListenersStatusRunning = 'inconsistent' | boolean
 
-export type ListenersStatusMaxConnections = number | 'infinity'
+export type ListenersStatusMaxConnections = 'infinity' | number
 
 export interface ListenersStatus {
   /** @minimum 0 */
@@ -565,15 +565,15 @@ export const LdapSslVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type LdapSslServerNameIndication = string | 'disable'
+export type LdapSslServerNameIndication = 'disable' | string
 
 export type LdapSslPartialChain = (typeof LdapSslPartialChain)[keyof typeof LdapSslPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const LdapSslPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -626,7 +626,7 @@ export const GatewayWebsocketPiggyback = {
   single: 'single',
 } as const
 
-export type GatewayWebsocketMaxFrameSize = number | 'infinity'
+export type GatewayWebsocketMaxFrameSize = 'infinity' | number
 
 export interface GatewayWebsocket {
   allow_origin_absence?: boolean
@@ -681,13 +681,13 @@ export type GatewayDtlsOptsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GatewayDtlsOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type GatewayDtlsOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type GatewayDtlsOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type GatewayDtlsOptsLogLevel =
   (typeof GatewayDtlsOptsLogLevel)[keyof typeof GatewayDtlsOptsLogLevel]
@@ -736,319 +736,123 @@ export interface GatewayDtlsOpts {
   versions?: string[]
 }
 
-export interface EmqxTcpOpts {
-  /** @minimum 0 */
-  active_n?: number
-  /** @minimum 1 */
-  backlog?: number
-  buffer?: string
-  high_watermark?: string
-  keepalive?: string
-  nodelay?: boolean
-  nolinger?: boolean
-  recbuf?: string
-  reuseaddr?: boolean
-  send_timeout?: string
-  send_timeout_close?: boolean
-  sndbuf?: string
-}
-
-export type EmqxSslClientOptsVerify =
-  (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
+export type EmqxGatewayApiListenersUdpListenerType =
+  (typeof EmqxGatewayApiListenersUdpListenerType)[keyof typeof EmqxGatewayApiListenersUdpListenerType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
+export const EmqxGatewayApiListenersUdpListenerType = {
+  udp: 'udp',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxGatewayApiListenersUdpListenerMaxConnections = 'infinity' | number
 
-export type EmqxSslClientOptsPartialChain =
-  (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxSslClientOptsLogLevel =
-  (typeof EmqxSslClientOptsLogLevel)[keyof typeof EmqxSslClientOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxSslClientOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  /** @minimum 0 */
-  depth?: number
+export interface EmqxGatewayApiListenersUdpListener {
+  access_rules?: string[]
+  bind?: string
   enable?: boolean
-  hibernate_after?: string
-  keyfile?: string
-  log_level?: EmqxSslClientOptsLogLevel
-  managed_certs?: EmqxManagedCerts
-  middlebox_comp_mode?: boolean
-  partial_chain?: EmqxSslClientOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  server_name_indication?: EmqxSslClientOptsServerNameIndication
-  verify?: EmqxSslClientOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
+  enable_authn?: boolean
+  health_check?: GatewayUdpHealthCheck
+  id?: string
+  max_conn_rate?: number
+  max_connections?: EmqxGatewayApiListenersUdpListenerMaxConnections
+  mountpoint?: string
+  name?: string
+  node_status?: ListenersNodeStatus[]
+  running?: boolean
+  status?: ListenersStatus
+  type?: EmqxGatewayApiListenersUdpListenerType
+  udp_options?: GatewayUdpOpts
 }
 
-export interface EmqxOcsp {
-  enable_ocsp_stapling?: boolean
-  issuer_pem?: string
-  refresh_http_timeout?: string
-  refresh_interval?: string
-  responder_url?: string
+export type EmqxGatewayApiListenersTcpListenerType =
+  (typeof EmqxGatewayApiListenersTcpListenerType)[keyof typeof EmqxGatewayApiListenersTcpListenerType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxGatewayApiListenersTcpListenerType = {
+  tcp: 'tcp',
+} as const
+
+export type EmqxGatewayApiListenersTcpListenerMaxConnections = 'infinity' | number
+
+export interface EmqxGatewayApiListenersTcpListener {
+  acceptors?: number
+  access_rules?: string[]
+  bind?: string
+  enable?: boolean
+  enable_authn?: boolean
+  id?: string
+  max_conn_rate?: number
+  max_connections?: EmqxGatewayApiListenersTcpListenerMaxConnections
+  mountpoint?: string
+  name?: string
+  node_status?: ListenersNodeStatus[]
+  proxy_protocol?: boolean
+  proxy_protocol_timeout?: string
+  running?: boolean
+  status?: ListenersStatus
+  tcp_options?: EmqxTcpOpts
+  type?: EmqxGatewayApiListenersTcpListenerType
 }
 
-export interface EmqxManagedCertsServer {
-  bundle_name: string
-  namespace?: string
-  sni?: string
+export type EmqxGatewayApiListenersSslListenerType =
+  (typeof EmqxGatewayApiListenersSslListenerType)[keyof typeof EmqxGatewayApiListenersSslListenerType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxGatewayApiListenersSslListenerType = {
+  ssl: 'ssl',
+} as const
+
+export type EmqxGatewayApiListenersSslListenerMaxConnections = 'infinity' | number
+
+export interface EmqxGatewayApiListenersSslListener {
+  acceptors?: number
+  access_rules?: string[]
+  bind?: string
+  enable?: boolean
+  enable_authn?: boolean
+  id?: string
+  max_conn_rate?: number
+  max_connections?: EmqxGatewayApiListenersSslListenerMaxConnections
+  mountpoint?: string
+  name?: string
+  node_status?: ListenersNodeStatus[]
+  proxy_protocol?: boolean
+  proxy_protocol_timeout?: string
+  running?: boolean
+  ssl_options?: EmqxListenerSslOpts
+  status?: ListenersStatus
+  tcp_options?: EmqxTcpOpts
+  type?: EmqxGatewayApiListenersSslListenerType
 }
 
-export interface EmqxManagedCerts {
-  bundle_name: string
-  namespace?: string
-}
-
-export type EmqxListenerWssOptsVerify =
-  (typeof EmqxListenerWssOptsVerify)[keyof typeof EmqxListenerWssOptsVerify]
+export type EmqxGatewayApiListenersDtlsListenerType =
+  (typeof EmqxGatewayApiListenersDtlsListenerType)[keyof typeof EmqxGatewayApiListenersDtlsListenerType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
+export const EmqxGatewayApiListenersDtlsListenerType = {
+  dtls: 'dtls',
 } as const
 
-export type EmqxListenerWssOptsSessionTickets =
-  (typeof EmqxListenerWssOptsSessionTickets)[keyof typeof EmqxListenerWssOptsSessionTickets]
+export type EmqxGatewayApiListenersDtlsListenerMaxConnections = 'infinity' | number
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsSessionTickets = {
-  disabled: 'disabled',
-  stateless: 'stateless',
-  stateless_with_cert: 'stateless_with_cert',
-} as const
-
-export type EmqxListenerWssOptsPartialChain =
-  (typeof EmqxListenerWssOptsPartialChain)[keyof typeof EmqxListenerWssOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
-
-export type EmqxListenerWssOptsLogLevel =
-  (typeof EmqxListenerWssOptsLogLevel)[keyof typeof EmqxListenerWssOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxListenerWssOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  client_renegotiation?: boolean
-  /** @minimum 0 */
-  depth?: number
-  dhfile?: string
-  fail_if_no_peer_cert?: boolean
-  handshake_timeout?: string
-  hibernate_after?: string
-  honor_cipher_order?: boolean
-  keyfile?: string
-  log_level?: EmqxListenerWssOptsLogLevel
-  managed_certs?: EmqxListenerWssOptsManagedCerts
-  partial_chain?: EmqxListenerWssOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  session_tickets?: EmqxListenerWssOptsSessionTickets
-  verify?: EmqxListenerWssOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export type EmqxListenerSslOptsVerify =
-  (typeof EmqxListenerSslOptsVerify)[keyof typeof EmqxListenerSslOptsVerify]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
-} as const
-
-export type EmqxListenerSslOptsSessionTickets =
-  (typeof EmqxListenerSslOptsSessionTickets)[keyof typeof EmqxListenerSslOptsSessionTickets]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsSessionTickets = {
-  disabled: 'disabled',
-  stateless: 'stateless',
-  stateless_with_cert: 'stateless_with_cert',
-} as const
-
-export type EmqxListenerSslOptsPartialChain =
-  (typeof EmqxListenerSslOptsPartialChain)[keyof typeof EmqxListenerSslOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
-
-export type EmqxListenerSslOptsLogLevel =
-  (typeof EmqxListenerSslOptsLogLevel)[keyof typeof EmqxListenerSslOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxListenerSslOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  client_renegotiation?: boolean
-  /** @minimum 0 */
-  depth?: number
-  dhfile?: string
-  enable_crl_check?: boolean
-  fail_if_no_peer_cert?: boolean
-  gc_after_handshake?: boolean
-  handshake_timeout?: string
-  hibernate_after?: string
-  honor_cipher_order?: boolean
-  keyfile?: string
-  log_level?: EmqxListenerSslOptsLogLevel
-  managed_certs?: EmqxListenerSslOptsManagedCerts
-  ocsp?: EmqxOcsp
-  partial_chain?: EmqxListenerSslOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  session_tickets?: EmqxListenerSslOptsSessionTickets
-  verify?: EmqxListenerSslOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export type EmqxDeflateOptsStrategy =
-  (typeof EmqxDeflateOptsStrategy)[keyof typeof EmqxDeflateOptsStrategy]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsStrategy = {
-  default: 'default',
-  filtered: 'filtered',
-  huffman_only: 'huffman_only',
-  rle: 'rle',
-} as const
-
-export type EmqxDeflateOptsServerContextTakeover =
-  (typeof EmqxDeflateOptsServerContextTakeover)[keyof typeof EmqxDeflateOptsServerContextTakeover]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsServerContextTakeover = {
-  no_takeover: 'no_takeover',
-  takeover: 'takeover',
-} as const
-
-export type EmqxDeflateOptsLevel = (typeof EmqxDeflateOptsLevel)[keyof typeof EmqxDeflateOptsLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsLevel = {
-  best_compression: 'best_compression',
-  best_speed: 'best_speed',
-  default: 'default',
-  none: 'none',
-} as const
-
-export type EmqxDeflateOptsClientContextTakeover =
-  (typeof EmqxDeflateOptsClientContextTakeover)[keyof typeof EmqxDeflateOptsClientContextTakeover]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsClientContextTakeover = {
-  no_takeover: 'no_takeover',
-  takeover: 'takeover',
-} as const
-
-export interface EmqxDeflateOpts {
-  client_context_takeover?: EmqxDeflateOptsClientContextTakeover
-  /**
-   * @minimum 8
-   * @maximum 15
-   */
-  client_max_window_bits?: number
-  level?: EmqxDeflateOptsLevel
-  /**
-   * @minimum 1
-   * @maximum 9
-   */
-  mem_level?: number
-  server_context_takeover?: EmqxDeflateOptsServerContextTakeover
-  /**
-   * @minimum 8
-   * @maximum 15
-   */
-  server_max_window_bits?: number
-  strategy?: EmqxDeflateOptsStrategy
+export interface EmqxGatewayApiListenersDtlsListener {
+  acceptors?: number
+  access_rules?: string[]
+  bind?: string
+  dtls_options?: GatewayDtlsOpts
+  enable?: boolean
+  enable_authn?: boolean
+  health_check?: GatewayUdpHealthCheck
+  id?: string
+  max_conn_rate?: number
+  max_connections?: EmqxGatewayApiListenersDtlsListenerMaxConnections
+  mountpoint?: string
+  name?: string
+  node_status?: ListenersNodeStatus[]
+  running?: boolean
+  status?: ListenersStatus
+  type?: EmqxGatewayApiListenersDtlsListenerType
+  udp_options?: GatewayUdpOpts
 }
 
 export type EmqxGatewayApiWssListenerType =
@@ -1221,125 +1025,6 @@ export interface EmqxGatewayApiDtlsListener {
   udp_options?: GatewayUdpOpts
 }
 
-export type EmqxGatewayApiListenersUdpListenerType =
-  (typeof EmqxGatewayApiListenersUdpListenerType)[keyof typeof EmqxGatewayApiListenersUdpListenerType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxGatewayApiListenersUdpListenerType = {
-  udp: 'udp',
-} as const
-
-export type EmqxGatewayApiListenersUdpListenerMaxConnections = 'infinity' | number
-
-export interface EmqxGatewayApiListenersUdpListener {
-  access_rules?: string[]
-  bind?: string
-  enable?: boolean
-  enable_authn?: boolean
-  health_check?: GatewayUdpHealthCheck
-  id?: string
-  max_conn_rate?: number
-  max_connections?: EmqxGatewayApiListenersUdpListenerMaxConnections
-  mountpoint?: string
-  name?: string
-  node_status?: ListenersNodeStatus[]
-  running?: boolean
-  status?: ListenersStatus
-  type?: EmqxGatewayApiListenersUdpListenerType
-  udp_options?: GatewayUdpOpts
-}
-
-export type EmqxGatewayApiListenersTcpListenerType =
-  (typeof EmqxGatewayApiListenersTcpListenerType)[keyof typeof EmqxGatewayApiListenersTcpListenerType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxGatewayApiListenersTcpListenerType = {
-  tcp: 'tcp',
-} as const
-
-export type EmqxGatewayApiListenersTcpListenerMaxConnections = 'infinity' | number
-
-export interface EmqxGatewayApiListenersTcpListener {
-  acceptors?: number
-  access_rules?: string[]
-  bind?: string
-  enable?: boolean
-  enable_authn?: boolean
-  id?: string
-  max_conn_rate?: number
-  max_connections?: EmqxGatewayApiListenersTcpListenerMaxConnections
-  mountpoint?: string
-  name?: string
-  node_status?: ListenersNodeStatus[]
-  proxy_protocol?: boolean
-  proxy_protocol_timeout?: string
-  running?: boolean
-  status?: ListenersStatus
-  tcp_options?: EmqxTcpOpts
-  type?: EmqxGatewayApiListenersTcpListenerType
-}
-
-export type EmqxGatewayApiListenersSslListenerType =
-  (typeof EmqxGatewayApiListenersSslListenerType)[keyof typeof EmqxGatewayApiListenersSslListenerType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxGatewayApiListenersSslListenerType = {
-  ssl: 'ssl',
-} as const
-
-export type EmqxGatewayApiListenersSslListenerMaxConnections = 'infinity' | number
-
-export interface EmqxGatewayApiListenersSslListener {
-  acceptors?: number
-  access_rules?: string[]
-  bind?: string
-  enable?: boolean
-  enable_authn?: boolean
-  id?: string
-  max_conn_rate?: number
-  max_connections?: EmqxGatewayApiListenersSslListenerMaxConnections
-  mountpoint?: string
-  name?: string
-  node_status?: ListenersNodeStatus[]
-  proxy_protocol?: boolean
-  proxy_protocol_timeout?: string
-  running?: boolean
-  ssl_options?: EmqxListenerSslOpts
-  status?: ListenersStatus
-  tcp_options?: EmqxTcpOpts
-  type?: EmqxGatewayApiListenersSslListenerType
-}
-
-export type EmqxGatewayApiListenersDtlsListenerType =
-  (typeof EmqxGatewayApiListenersDtlsListenerType)[keyof typeof EmqxGatewayApiListenersDtlsListenerType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxGatewayApiListenersDtlsListenerType = {
-  dtls: 'dtls',
-} as const
-
-export type EmqxGatewayApiListenersDtlsListenerMaxConnections = 'infinity' | number
-
-export interface EmqxGatewayApiListenersDtlsListener {
-  acceptors?: number
-  access_rules?: string[]
-  bind?: string
-  dtls_options?: GatewayDtlsOpts
-  enable?: boolean
-  enable_authn?: boolean
-  health_check?: GatewayUdpHealthCheck
-  id?: string
-  max_conn_rate?: number
-  max_connections?: EmqxGatewayApiListenersDtlsListenerMaxConnections
-  mountpoint?: string
-  name?: string
-  node_status?: ListenersNodeStatus[]
-  running?: boolean
-  status?: ListenersStatus
-  type?: EmqxGatewayApiListenersDtlsListenerType
-  udp_options?: GatewayUdpOpts
-}
-
 export interface EmqxAuthnApiResponseUser {
   is_superuser?: boolean
   namespace?: string
@@ -1359,6 +1044,321 @@ export interface EmqxAuthnApiRequestUserCreate {
   user_id: string
 }
 
+export interface EmqxTcpOpts {
+  /** @minimum 0 */
+  active_n?: number
+  /** @minimum 1 */
+  backlog?: number
+  buffer?: string
+  high_watermark?: string
+  keepalive?: string
+  nodelay?: boolean
+  nolinger?: boolean
+  recbuf?: string
+  reuseaddr?: boolean
+  send_timeout?: string
+  send_timeout_close?: boolean
+  sndbuf?: string
+}
+
+export type EmqxSslClientOptsVerify =
+  (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
+
+export type EmqxSslClientOptsPartialChain =
+  (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxSslClientOptsLogLevel =
+  (typeof EmqxSslClientOptsLogLevel)[keyof typeof EmqxSslClientOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxSslClientOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  /** @minimum 0 */
+  depth?: number
+  enable?: boolean
+  hibernate_after?: string
+  keyfile?: string
+  log_level?: EmqxSslClientOptsLogLevel
+  managed_certs?: EmqxManagedCerts
+  middlebox_comp_mode?: boolean
+  partial_chain?: EmqxSslClientOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  server_name_indication?: EmqxSslClientOptsServerNameIndication
+  verify?: EmqxSslClientOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export interface EmqxOcsp {
+  enable_ocsp_stapling?: boolean
+  issuer_pem?: string
+  refresh_http_timeout?: string
+  refresh_interval?: string
+  responder_url?: string
+}
+
+export interface EmqxManagedCertsServer {
+  bundle_name: string
+  namespace?: string
+  sni?: string
+}
+
+export interface EmqxManagedCerts {
+  bundle_name: string
+  namespace?: string
+}
+
+export type EmqxListenerWssOptsVerify =
+  (typeof EmqxListenerWssOptsVerify)[keyof typeof EmqxListenerWssOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxListenerWssOptsSessionTickets =
+  (typeof EmqxListenerWssOptsSessionTickets)[keyof typeof EmqxListenerWssOptsSessionTickets]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsSessionTickets = {
+  disabled: 'disabled',
+  stateless: 'stateless',
+  stateless_with_cert: 'stateless_with_cert',
+} as const
+
+export type EmqxListenerWssOptsPartialChain =
+  (typeof EmqxListenerWssOptsPartialChain)[keyof typeof EmqxListenerWssOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
+
+export type EmqxListenerWssOptsLogLevel =
+  (typeof EmqxListenerWssOptsLogLevel)[keyof typeof EmqxListenerWssOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxListenerWssOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  client_renegotiation?: boolean
+  /** @minimum 0 */
+  depth?: number
+  dhfile?: string
+  fail_if_no_peer_cert?: boolean
+  handshake_timeout?: string
+  hibernate_after?: string
+  honor_cipher_order?: boolean
+  keyfile?: string
+  log_level?: EmqxListenerWssOptsLogLevel
+  managed_certs?: EmqxListenerWssOptsManagedCerts
+  partial_chain?: EmqxListenerWssOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  session_tickets?: EmqxListenerWssOptsSessionTickets
+  verify?: EmqxListenerWssOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export type EmqxListenerSslOptsVerify =
+  (typeof EmqxListenerSslOptsVerify)[keyof typeof EmqxListenerSslOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxListenerSslOptsSessionTickets =
+  (typeof EmqxListenerSslOptsSessionTickets)[keyof typeof EmqxListenerSslOptsSessionTickets]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsSessionTickets = {
+  disabled: 'disabled',
+  stateless: 'stateless',
+  stateless_with_cert: 'stateless_with_cert',
+} as const
+
+export type EmqxListenerSslOptsPartialChain =
+  (typeof EmqxListenerSslOptsPartialChain)[keyof typeof EmqxListenerSslOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
+
+export type EmqxListenerSslOptsLogLevel =
+  (typeof EmqxListenerSslOptsLogLevel)[keyof typeof EmqxListenerSslOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxListenerSslOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  client_renegotiation?: boolean
+  /** @minimum 0 */
+  depth?: number
+  dhfile?: string
+  enable_crl_check?: boolean
+  fail_if_no_peer_cert?: boolean
+  gc_after_handshake?: boolean
+  handshake_timeout?: string
+  hibernate_after?: string
+  honor_cipher_order?: boolean
+  keyfile?: string
+  log_level?: EmqxListenerSslOptsLogLevel
+  managed_certs?: EmqxListenerSslOptsManagedCerts
+  ocsp?: EmqxOcsp
+  partial_chain?: EmqxListenerSslOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  session_tickets?: EmqxListenerSslOptsSessionTickets
+  verify?: EmqxListenerSslOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export type EmqxDeflateOptsStrategy =
+  (typeof EmqxDeflateOptsStrategy)[keyof typeof EmqxDeflateOptsStrategy]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsStrategy = {
+  default: 'default',
+  filtered: 'filtered',
+  huffman_only: 'huffman_only',
+  rle: 'rle',
+} as const
+
+export type EmqxDeflateOptsServerContextTakeover =
+  (typeof EmqxDeflateOptsServerContextTakeover)[keyof typeof EmqxDeflateOptsServerContextTakeover]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsServerContextTakeover = {
+  no_takeover: 'no_takeover',
+  takeover: 'takeover',
+} as const
+
+export type EmqxDeflateOptsLevel = (typeof EmqxDeflateOptsLevel)[keyof typeof EmqxDeflateOptsLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsLevel = {
+  best_compression: 'best_compression',
+  best_speed: 'best_speed',
+  default: 'default',
+  none: 'none',
+} as const
+
+export type EmqxDeflateOptsClientContextTakeover =
+  (typeof EmqxDeflateOptsClientContextTakeover)[keyof typeof EmqxDeflateOptsClientContextTakeover]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsClientContextTakeover = {
+  no_takeover: 'no_takeover',
+  takeover: 'takeover',
+} as const
+
+export interface EmqxDeflateOpts {
+  client_context_takeover?: EmqxDeflateOptsClientContextTakeover
+  /**
+   * @minimum 8
+   * @maximum 15
+   */
+  client_max_window_bits?: number
+  level?: EmqxDeflateOptsLevel
+  /**
+   * @minimum 1
+   * @maximum 9
+   */
+  mem_level?: number
+  server_context_takeover?: EmqxDeflateOptsServerContextTakeover
+  /**
+   * @minimum 8
+   * @maximum 15
+   */
+  server_max_window_bits?: number
+  strategy?: EmqxDeflateOptsStrategy
+}
+
 export type ConnectorHttpRequestHeaders = { [key: string]: unknown }
 
 export interface ConnectorHttpRequest {
@@ -1371,6 +1371,91 @@ export interface ConnectorHttpRequest {
   request_timeout?: string
 }
 
+export type AuthnHashSimpleSaltPosition =
+  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleSaltPosition = {
+  disable: 'disable',
+  prefix: 'prefix',
+  suffix: 'suffix',
+} as const
+
+export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashSimpleName = {
+  md5: 'md5',
+  plain: 'plain',
+  sha: 'sha',
+  sha256: 'sha256',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashSimple {
+  name: AuthnHashSimpleName
+  salt_position?: AuthnHashSimpleSaltPosition
+}
+
+export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2Name = {
+  pbkdf2: 'pbkdf2',
+} as const
+
+export type AuthnHashPbkdf2MacFun =
+  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashPbkdf2MacFun = {
+  md4: 'md4',
+  md5: 'md5',
+  ripemd160: 'ripemd160',
+  sha: 'sha',
+  sha224: 'sha224',
+  sha256: 'sha256',
+  sha384: 'sha384',
+  sha512: 'sha512',
+} as const
+
+export interface AuthnHashPbkdf2 {
+  /** @minimum 1 */
+  dk_length?: number
+  /** @minimum 1 */
+  iterations: number
+  mac_fun: AuthnHashPbkdf2MacFun
+  name: AuthnHashPbkdf2Name
+}
+
+export type AuthnHashBcryptRwName =
+  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptRwName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcryptRw {
+  name: AuthnHashBcryptRwName
+  /**
+   * @minimum 5
+   * @maximum 10
+   */
+  salt_rounds?: number
+}
+
+export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AuthnHashBcryptName = {
+  bcrypt: 'bcrypt',
+} as const
+
+export interface AuthnHashBcrypt {
+  name: AuthnHashBcryptName
+}
+
 export type AuthnRedisSingleRedisType =
   (typeof AuthnRedisSingleRedisType)[keyof typeof AuthnRedisSingleRedisType]
 
@@ -1380,9 +1465,9 @@ export const AuthnRedisSingleRedisType = {
 } as const
 
 export type AuthnRedisSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSingleMechanism =
   (typeof AuthnRedisSingleMechanism)[keyof typeof AuthnRedisSingleMechanism]
@@ -1429,9 +1514,9 @@ export const AuthnRedisSentinelRedisType = {
 } as const
 
 export type AuthnRedisSentinelPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisSentinelMechanism =
   (typeof AuthnRedisSentinelMechanism)[keyof typeof AuthnRedisSentinelMechanism]
@@ -1481,9 +1566,9 @@ export const AuthnRedisClusterRedisType = {
 } as const
 
 export type AuthnRedisClusterPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnRedisClusterMechanism =
   (typeof AuthnRedisClusterMechanism)[keyof typeof AuthnRedisClusterMechanism]
@@ -1520,9 +1605,9 @@ export interface AuthnRedisCluster {
 }
 
 export type AuthnPostgresqlPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnPostgresqlMechanism =
   (typeof AuthnPostgresqlMechanism)[keyof typeof AuthnPostgresqlMechanism]
@@ -1560,7 +1645,7 @@ export interface AuthnPostgresql {
   username: string
 }
 
-export type AuthnMysqlPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMysqlPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMysqlMechanism = (typeof AuthnMysqlMechanism)[keyof typeof AuthnMysqlMechanism]
 
@@ -1611,15 +1696,15 @@ export type AuthnMongoSingleUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoSingleUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoSinglePasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoSingleMongoType =
   (typeof AuthnMongoSingleMongoType)[keyof typeof AuthnMongoSingleMongoType]
@@ -1688,15 +1773,15 @@ export type AuthnMongoShardedUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoShardedUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoShardedPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
   | AuthnHashBcrypt
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
 
 export type AuthnMongoShardedMongoType =
   (typeof AuthnMongoShardedMongoType)[keyof typeof AuthnMongoShardedMongoType]
@@ -1764,9 +1849,9 @@ export type AuthnMongoRsUseLegacyProtocol =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnMongoRsUseLegacyProtocol = {
-  auto: 'auto',
   false: false,
   true: true,
+  auto: 'auto',
 } as const
 
 export type AuthnMongoRsRMode = (typeof AuthnMongoRsRMode)[keyof typeof AuthnMongoRsRMode]
@@ -1777,7 +1862,7 @@ export const AuthnMongoRsRMode = {
   slave_ok: 'slave_ok',
 } as const
 
-export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashSimple | AuthnHashPbkdf2 | AuthnHashBcrypt
+export type AuthnMongoRsPasswordHashAlgorithm = AuthnHashBcrypt | AuthnHashPbkdf2 | AuthnHashSimple
 
 export type AuthnMongoRsMongoType =
   (typeof AuthnMongoRsMongoType)[keyof typeof AuthnMongoRsMongoType]
@@ -2057,16 +2142,16 @@ export const AuthnJwksClientSslOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type AuthnJwksClientSslOptsServerNameIndication = string | 'disable'
+export type AuthnJwksClientSslOptsServerNameIndication = 'disable' | string
 
 export type AuthnJwksClientSslOptsPartialChain =
   (typeof AuthnJwksClientSslOptsPartialChain)[keyof typeof AuthnJwksClientSslOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthnJwksClientSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
@@ -2285,6 +2370,11 @@ export const AuthnBuiltinDbUserIdType = {
   username: 'username',
 } as const
 
+export type AuthnBuiltinDbPasswordHashAlgorithm =
+  | AuthnHashBcryptRw
+  | AuthnHashPbkdf2
+  | AuthnHashSimple
+
 export type AuthnBuiltinDbMechanism =
   (typeof AuthnBuiltinDbMechanism)[keyof typeof AuthnBuiltinDbMechanism]
 
@@ -2333,94 +2423,4 @@ export interface AuthnBindMethod {
   clientid_override_attribute?: string
   is_superuser_attribute?: string
   type?: AuthnBindMethodType
-}
-
-export type AuthnHashSimpleSaltPosition =
-  (typeof AuthnHashSimpleSaltPosition)[keyof typeof AuthnHashSimpleSaltPosition]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleSaltPosition = {
-  disable: 'disable',
-  prefix: 'prefix',
-  suffix: 'suffix',
-} as const
-
-export type AuthnHashSimpleName = (typeof AuthnHashSimpleName)[keyof typeof AuthnHashSimpleName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashSimpleName = {
-  md5: 'md5',
-  plain: 'plain',
-  sha: 'sha',
-  sha256: 'sha256',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashSimple {
-  name: AuthnHashSimpleName
-  salt_position?: AuthnHashSimpleSaltPosition
-}
-
-export type AuthnBuiltinDbPasswordHashAlgorithm =
-  | AuthnHashSimple
-  | AuthnHashPbkdf2
-  | AuthnHashBcryptRw
-
-export type AuthnHashPbkdf2Name = (typeof AuthnHashPbkdf2Name)[keyof typeof AuthnHashPbkdf2Name]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2Name = {
-  pbkdf2: 'pbkdf2',
-} as const
-
-export type AuthnHashPbkdf2MacFun =
-  (typeof AuthnHashPbkdf2MacFun)[keyof typeof AuthnHashPbkdf2MacFun]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashPbkdf2MacFun = {
-  md4: 'md4',
-  md5: 'md5',
-  ripemd160: 'ripemd160',
-  sha: 'sha',
-  sha224: 'sha224',
-  sha256: 'sha256',
-  sha384: 'sha384',
-  sha512: 'sha512',
-} as const
-
-export interface AuthnHashPbkdf2 {
-  /** @minimum 1 */
-  dk_length?: number
-  /** @minimum 1 */
-  iterations: number
-  mac_fun: AuthnHashPbkdf2MacFun
-  name: AuthnHashPbkdf2Name
-}
-
-export type AuthnHashBcryptRwName =
-  (typeof AuthnHashBcryptRwName)[keyof typeof AuthnHashBcryptRwName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptRwName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcryptRw {
-  name: AuthnHashBcryptRwName
-  /**
-   * @minimum 5
-   * @maximum 10
-   */
-  salt_rounds?: number
-}
-
-export type AuthnHashBcryptName = (typeof AuthnHashBcryptName)[keyof typeof AuthnHashBcryptName]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AuthnHashBcryptName = {
-  bcrypt: 'bcrypt',
-} as const
-
-export interface AuthnHashBcrypt {
-  name: AuthnHashBcryptName
 }

--- a/src/types/schemas/gateways.schemas.ts
+++ b/src/types/schemas/gateways.schemas.ts
@@ -100,6 +100,22 @@ export type GetGatewaysParams = {
   status?: GetGatewaysStatus
 }
 
+export type GatewayOcppUpstreamTopicOverrideMapping = {
+  $name?: string
+}
+
+export interface GatewayOcppUpstream {
+  error_topic: string
+  reply_topic: string
+  topic: string
+  topic_override_mapping?: GatewayOcppUpstreamTopicOverrideMapping
+}
+
+export interface GatewayOcppDnstream {
+  max_mqueue_len?: number
+  topic: string
+}
+
 export type GatewayWebsocketPiggyback =
   (typeof GatewayWebsocketPiggyback)[keyof typeof GatewayWebsocketPiggyback]
 
@@ -109,7 +125,7 @@ export const GatewayWebsocketPiggyback = {
   single: 'single',
 } as const
 
-export type GatewayWebsocketMaxFrameSize = number | 'infinity'
+export type GatewayWebsocketMaxFrameSize = 'infinity' | number
 
 export interface GatewayWebsocket {
   allow_origin_absence?: boolean
@@ -181,13 +197,13 @@ export type GatewaySslServerOptsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GatewaySslServerOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type GatewaySslServerOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type GatewaySslServerOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type GatewaySslServerOptsLogLevel =
   (typeof GatewaySslServerOptsLogLevel)[keyof typeof GatewaySslServerOptsLogLevel]
@@ -358,8 +374,8 @@ export interface GatewayExprotoGrpcServer {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GatewayExprotoGrpcHandlerServiceName = {
-  ConnectionUnaryHandler: 'ConnectionUnaryHandler',
   ConnectionHandler: 'ConnectionHandler',
+  ConnectionUnaryHandler: 'ConnectionUnaryHandler',
 } as const
 
 export interface GatewayExprotoGrpcHandler {
@@ -392,13 +408,13 @@ export type GatewayDtlsOptsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GatewayDtlsOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type GatewayDtlsOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type GatewayDtlsOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type GatewayDtlsOptsLogLevel =
   (typeof GatewayDtlsOptsLogLevel)[keyof typeof GatewayDtlsOptsLogLevel]
@@ -474,337 +490,6 @@ export interface GatewayAnonymousFalse {
   allow_anonymous: false
   authentication: string
   registry: string
-}
-
-export type GatewayOcppUpstreamTopicOverrideMapping = {
-  $name?: string
-}
-
-export interface GatewayOcppUpstream {
-  error_topic: string
-  reply_topic: string
-  topic: string
-  topic_override_mapping?: GatewayOcppUpstreamTopicOverrideMapping
-}
-
-export interface GatewayOcppDnstream {
-  max_mqueue_len?: number
-  topic: string
-}
-
-export interface EmqxTcpOpts {
-  /** @minimum 0 */
-  active_n?: number
-  /** @minimum 1 */
-  backlog?: number
-  buffer?: string
-  high_watermark?: string
-  keepalive?: string
-  nodelay?: boolean
-  nolinger?: boolean
-  recbuf?: string
-  reuseaddr?: boolean
-  send_timeout?: string
-  send_timeout_close?: boolean
-  sndbuf?: string
-}
-
-export type EmqxSslClientOptsVerify =
-  (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
-} as const
-
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
-
-export type EmqxSslClientOptsPartialChain =
-  (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxSslClientOptsLogLevel =
-  (typeof EmqxSslClientOptsLogLevel)[keyof typeof EmqxSslClientOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxSslClientOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxSslClientOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  /** @minimum 0 */
-  depth?: number
-  enable?: boolean
-  hibernate_after?: string
-  keyfile?: string
-  log_level?: EmqxSslClientOptsLogLevel
-  managed_certs?: EmqxManagedCerts
-  middlebox_comp_mode?: boolean
-  partial_chain?: EmqxSslClientOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  server_name_indication?: EmqxSslClientOptsServerNameIndication
-  verify?: EmqxSslClientOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export interface EmqxOcsp {
-  enable_ocsp_stapling?: boolean
-  issuer_pem?: string
-  refresh_http_timeout?: string
-  refresh_interval?: string
-  responder_url?: string
-}
-
-export interface EmqxManagedCertsServer {
-  bundle_name: string
-  namespace?: string
-  sni?: string
-}
-
-export interface EmqxManagedCerts {
-  bundle_name: string
-  namespace?: string
-}
-
-export type EmqxListenerWssOptsVerify =
-  (typeof EmqxListenerWssOptsVerify)[keyof typeof EmqxListenerWssOptsVerify]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
-} as const
-
-export type EmqxListenerWssOptsSessionTickets =
-  (typeof EmqxListenerWssOptsSessionTickets)[keyof typeof EmqxListenerWssOptsSessionTickets]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsSessionTickets = {
-  disabled: 'disabled',
-  stateless: 'stateless',
-  stateless_with_cert: 'stateless_with_cert',
-} as const
-
-export type EmqxListenerWssOptsPartialChain =
-  (typeof EmqxListenerWssOptsPartialChain)[keyof typeof EmqxListenerWssOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
-
-export type EmqxListenerWssOptsLogLevel =
-  (typeof EmqxListenerWssOptsLogLevel)[keyof typeof EmqxListenerWssOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerWssOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxListenerWssOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  client_renegotiation?: boolean
-  /** @minimum 0 */
-  depth?: number
-  dhfile?: string
-  fail_if_no_peer_cert?: boolean
-  handshake_timeout?: string
-  hibernate_after?: string
-  honor_cipher_order?: boolean
-  keyfile?: string
-  log_level?: EmqxListenerWssOptsLogLevel
-  managed_certs?: EmqxListenerWssOptsManagedCerts
-  partial_chain?: EmqxListenerWssOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  session_tickets?: EmqxListenerWssOptsSessionTickets
-  verify?: EmqxListenerWssOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export type EmqxListenerSslOptsVerify =
-  (typeof EmqxListenerSslOptsVerify)[keyof typeof EmqxListenerSslOptsVerify]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsVerify = {
-  verify_none: 'verify_none',
-  verify_peer: 'verify_peer',
-} as const
-
-export type EmqxListenerSslOptsSessionTickets =
-  (typeof EmqxListenerSslOptsSessionTickets)[keyof typeof EmqxListenerSslOptsSessionTickets]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsSessionTickets = {
-  disabled: 'disabled',
-  stateless: 'stateless',
-  stateless_with_cert: 'stateless_with_cert',
-} as const
-
-export type EmqxListenerSslOptsPartialChain =
-  (typeof EmqxListenerSslOptsPartialChain)[keyof typeof EmqxListenerSslOptsPartialChain]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
-  false: false,
-  true: true,
-  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
-} as const
-
-export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
-
-export type EmqxListenerSslOptsLogLevel =
-  (typeof EmqxListenerSslOptsLogLevel)[keyof typeof EmqxListenerSslOptsLogLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxListenerSslOptsLogLevel = {
-  alert: 'alert',
-  all: 'all',
-  critical: 'critical',
-  debug: 'debug',
-  emergency: 'emergency',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface EmqxListenerSslOpts {
-  cacertfile?: string
-  /** @deprecated */
-  cacerts?: boolean
-  certfile?: string
-  ciphers?: string[]
-  client_renegotiation?: boolean
-  /** @minimum 0 */
-  depth?: number
-  dhfile?: string
-  enable_crl_check?: boolean
-  fail_if_no_peer_cert?: boolean
-  gc_after_handshake?: boolean
-  handshake_timeout?: string
-  hibernate_after?: string
-  honor_cipher_order?: boolean
-  keyfile?: string
-  log_level?: EmqxListenerSslOptsLogLevel
-  managed_certs?: EmqxListenerSslOptsManagedCerts
-  ocsp?: EmqxOcsp
-  partial_chain?: EmqxListenerSslOptsPartialChain
-  password?: string
-  reuse_sessions?: boolean
-  secure_renegotiate?: boolean
-  session_tickets?: EmqxListenerSslOptsSessionTickets
-  verify?: EmqxListenerSslOptsVerify
-  verify_peer_ext_key_usage?: string
-  versions?: string[]
-}
-
-export type EmqxDeflateOptsStrategy =
-  (typeof EmqxDeflateOptsStrategy)[keyof typeof EmqxDeflateOptsStrategy]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsStrategy = {
-  default: 'default',
-  filtered: 'filtered',
-  huffman_only: 'huffman_only',
-  rle: 'rle',
-} as const
-
-export type EmqxDeflateOptsServerContextTakeover =
-  (typeof EmqxDeflateOptsServerContextTakeover)[keyof typeof EmqxDeflateOptsServerContextTakeover]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsServerContextTakeover = {
-  no_takeover: 'no_takeover',
-  takeover: 'takeover',
-} as const
-
-export type EmqxDeflateOptsLevel = (typeof EmqxDeflateOptsLevel)[keyof typeof EmqxDeflateOptsLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsLevel = {
-  best_compression: 'best_compression',
-  best_speed: 'best_speed',
-  default: 'default',
-  none: 'none',
-} as const
-
-export type EmqxDeflateOptsClientContextTakeover =
-  (typeof EmqxDeflateOptsClientContextTakeover)[keyof typeof EmqxDeflateOptsClientContextTakeover]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmqxDeflateOptsClientContextTakeover = {
-  no_takeover: 'no_takeover',
-  takeover: 'takeover',
-} as const
-
-export interface EmqxDeflateOpts {
-  client_context_takeover?: EmqxDeflateOptsClientContextTakeover
-  /**
-   * @minimum 8
-   * @maximum 15
-   */
-  client_max_window_bits?: number
-  level?: EmqxDeflateOptsLevel
-  /**
-   * @minimum 1
-   * @maximum 9
-   */
-  mem_level?: number
-  server_context_takeover?: EmqxDeflateOptsServerContextTakeover
-  /**
-   * @minimum 8
-   * @maximum 15
-   */
-  server_max_window_bits?: number
-  strategy?: EmqxDeflateOptsStrategy
 }
 
 export type EmqxGatewayApiWssListenerType =
@@ -928,19 +613,6 @@ export const EmqxGatewayApiStompName = {
   stomp: 'stomp',
 } as const
 
-export type EmqxGatewayApiStompListenersItem = EmqxGatewayApiSslListener | EmqxGatewayApiTcpListener
-
-export interface EmqxGatewayApiStomp {
-  clientinfo_override?: GatewayClientinfoOverride
-  enable?: boolean
-  enable_stats?: boolean
-  frame?: GatewayStompFrame
-  idle_timeout?: string
-  listeners?: EmqxGatewayApiStompListenersItem[]
-  mountpoint?: string
-  name?: EmqxGatewayApiStompName
-}
-
 export type EmqxGatewayApiSslListenerType =
   (typeof EmqxGatewayApiSslListenerType)[keyof typeof EmqxGatewayApiSslListenerType]
 
@@ -970,6 +642,19 @@ export interface EmqxGatewayApiSslListener {
   type?: EmqxGatewayApiSslListenerType
 }
 
+export type EmqxGatewayApiStompListenersItem = EmqxGatewayApiSslListener | EmqxGatewayApiTcpListener
+
+export interface EmqxGatewayApiStomp {
+  clientinfo_override?: GatewayClientinfoOverride
+  enable?: boolean
+  enable_stats?: boolean
+  frame?: GatewayStompFrame
+  idle_timeout?: string
+  listeners?: EmqxGatewayApiStompListenersItem[]
+  mountpoint?: string
+  name?: EmqxGatewayApiStompName
+}
+
 export type EmqxGatewayApiOcppName =
   (typeof EmqxGatewayApiOcppName)[keyof typeof EmqxGatewayApiOcppName]
 
@@ -980,13 +665,13 @@ export const EmqxGatewayApiOcppName = {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxGatewayApiOcppMessageFormatChecking = {
+  all: 'all',
   disable: 'disable',
   dnstream_only: 'dnstream_only',
   upstream_only: 'upstream_only',
-  all: 'all',
 } as const
 
-export type EmqxGatewayApiOcppListenersItem = EmqxGatewayApiWssListener | EmqxGatewayApiWsListener
+export type EmqxGatewayApiOcppListenersItem = EmqxGatewayApiWsListener | EmqxGatewayApiWssListener
 
 export interface EmqxGatewayApiOcpp {
   clientinfo_override?: GatewayClientinfoOverride
@@ -1014,10 +699,10 @@ export const EmqxGatewayApiNatsName = {
 } as const
 
 export type EmqxGatewayApiNatsListenersItem =
-  | EmqxGatewayApiWssListener
-  | EmqxGatewayApiWsListener
   | EmqxGatewayApiSslListener
   | EmqxGatewayApiTcpListener
+  | EmqxGatewayApiWsListener
+  | EmqxGatewayApiWssListener
 
 export type EmqxGatewayApiNatsInternalAuthnItem =
   | GatewayInternalAuthnJwt
@@ -1088,7 +773,7 @@ export type EmqxGatewayApiLwm2mListenersItem =
   | EmqxGatewayApiDtlsListener
   | EmqxGatewayApiUdpListener
 
-export type EmqxGatewayApiLwm2mAutoObserve = string[] | string | boolean
+export type EmqxGatewayApiLwm2mAutoObserve = string[] | boolean | string
 
 export interface EmqxGatewayApiLwm2m {
   auto_observe?: EmqxGatewayApiLwm2mAutoObserve
@@ -1172,20 +857,6 @@ export const EmqxGatewayApiGatewayOverviewStatus = {
   unloaded: 'unloaded',
 } as const
 
-export interface EmqxGatewayApiGatewayOverview {
-  created_at?: string
-  /** @minimum 0 */
-  current_connections?: number
-  listeners?: EmqxGatewayApiGatewayListenerOverview[]
-  /** @minimum 1 */
-  max_connections?: number
-  name?: string
-  node_status?: EmqxGatewayApiGatewayNodeStatus[]
-  started_at?: string
-  status?: EmqxGatewayApiGatewayOverviewStatus
-  stopped_at?: string
-}
-
 export type EmqxGatewayApiGatewayNodeStatusStatus =
   (typeof EmqxGatewayApiGatewayNodeStatusStatus)[keyof typeof EmqxGatewayApiGatewayNodeStatusStatus]
 
@@ -1228,6 +899,20 @@ export interface EmqxGatewayApiGatewayListenerOverview {
   id?: string
   running?: boolean
   type?: EmqxGatewayApiGatewayListenerOverviewType
+}
+
+export interface EmqxGatewayApiGatewayOverview {
+  created_at?: string
+  /** @minimum 0 */
+  current_connections?: number
+  listeners?: EmqxGatewayApiGatewayListenerOverview[]
+  /** @minimum 1 */
+  max_connections?: number
+  name?: string
+  node_status?: EmqxGatewayApiGatewayNodeStatus[]
+  started_at?: string
+  status?: EmqxGatewayApiGatewayOverviewStatus
+  stopped_at?: string
 }
 
 export type EmqxGatewayApiExprotoName =
@@ -1280,9 +965,9 @@ export interface EmqxGatewayApiDtlsListener {
 
 export type EmqxGatewayApiExprotoListenersItem =
   | EmqxGatewayApiDtlsListener
-  | EmqxGatewayApiUdpListener
   | EmqxGatewayApiSslListener
   | EmqxGatewayApiTcpListener
+  | EmqxGatewayApiUdpListener
 
 export type EmqxGatewayApiCoapSubscribeQos =
   (typeof EmqxGatewayApiCoapSubscribeQos)[keyof typeof EmqxGatewayApiCoapSubscribeQos]
@@ -1340,4 +1025,319 @@ export interface EmqxGatewayApiCoap {
   notify_type?: EmqxGatewayApiCoapNotifyType
   publish_qos?: EmqxGatewayApiCoapPublishQos
   subscribe_qos?: EmqxGatewayApiCoapSubscribeQos
+}
+
+export interface EmqxTcpOpts {
+  /** @minimum 0 */
+  active_n?: number
+  /** @minimum 1 */
+  backlog?: number
+  buffer?: string
+  high_watermark?: string
+  keepalive?: string
+  nodelay?: boolean
+  nolinger?: boolean
+  recbuf?: string
+  reuseaddr?: boolean
+  send_timeout?: string
+  send_timeout_close?: boolean
+  sndbuf?: string
+}
+
+export type EmqxSslClientOptsVerify =
+  (typeof EmqxSslClientOptsVerify)[keyof typeof EmqxSslClientOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
+
+export type EmqxSslClientOptsPartialChain =
+  (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxSslClientOptsLogLevel =
+  (typeof EmqxSslClientOptsLogLevel)[keyof typeof EmqxSslClientOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxSslClientOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxOcsp {
+  enable_ocsp_stapling?: boolean
+  issuer_pem?: string
+  refresh_http_timeout?: string
+  refresh_interval?: string
+  responder_url?: string
+}
+
+export interface EmqxManagedCertsServer {
+  bundle_name: string
+  namespace?: string
+  sni?: string
+}
+
+export interface EmqxManagedCerts {
+  bundle_name: string
+  namespace?: string
+}
+
+export interface EmqxSslClientOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  /** @minimum 0 */
+  depth?: number
+  enable?: boolean
+  hibernate_after?: string
+  keyfile?: string
+  log_level?: EmqxSslClientOptsLogLevel
+  managed_certs?: EmqxManagedCerts
+  middlebox_comp_mode?: boolean
+  partial_chain?: EmqxSslClientOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  server_name_indication?: EmqxSslClientOptsServerNameIndication
+  verify?: EmqxSslClientOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export type EmqxListenerWssOptsVerify =
+  (typeof EmqxListenerWssOptsVerify)[keyof typeof EmqxListenerWssOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxListenerWssOptsSessionTickets =
+  (typeof EmqxListenerWssOptsSessionTickets)[keyof typeof EmqxListenerWssOptsSessionTickets]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsSessionTickets = {
+  disabled: 'disabled',
+  stateless: 'stateless',
+  stateless_with_cert: 'stateless_with_cert',
+} as const
+
+export type EmqxListenerWssOptsPartialChain =
+  (typeof EmqxListenerWssOptsPartialChain)[keyof typeof EmqxListenerWssOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
+
+export type EmqxListenerWssOptsLogLevel =
+  (typeof EmqxListenerWssOptsLogLevel)[keyof typeof EmqxListenerWssOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerWssOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxListenerWssOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  client_renegotiation?: boolean
+  /** @minimum 0 */
+  depth?: number
+  dhfile?: string
+  fail_if_no_peer_cert?: boolean
+  handshake_timeout?: string
+  hibernate_after?: string
+  honor_cipher_order?: boolean
+  keyfile?: string
+  log_level?: EmqxListenerWssOptsLogLevel
+  managed_certs?: EmqxListenerWssOptsManagedCerts
+  partial_chain?: EmqxListenerWssOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  session_tickets?: EmqxListenerWssOptsSessionTickets
+  verify?: EmqxListenerWssOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export type EmqxListenerSslOptsVerify =
+  (typeof EmqxListenerSslOptsVerify)[keyof typeof EmqxListenerSslOptsVerify]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsVerify = {
+  verify_none: 'verify_none',
+  verify_peer: 'verify_peer',
+} as const
+
+export type EmqxListenerSslOptsSessionTickets =
+  (typeof EmqxListenerSslOptsSessionTickets)[keyof typeof EmqxListenerSslOptsSessionTickets]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsSessionTickets = {
+  disabled: 'disabled',
+  stateless: 'stateless',
+  stateless_with_cert: 'stateless_with_cert',
+} as const
+
+export type EmqxListenerSslOptsPartialChain =
+  (typeof EmqxListenerSslOptsPartialChain)[keyof typeof EmqxListenerSslOptsPartialChain]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsPartialChain = {
+  false: false,
+  true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
+  two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
+} as const
+
+export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
+
+export type EmqxListenerSslOptsLogLevel =
+  (typeof EmqxListenerSslOptsLogLevel)[keyof typeof EmqxListenerSslOptsLogLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxListenerSslOptsLogLevel = {
+  alert: 'alert',
+  all: 'all',
+  critical: 'critical',
+  debug: 'debug',
+  emergency: 'emergency',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface EmqxListenerSslOpts {
+  cacertfile?: string
+  /** @deprecated */
+  cacerts?: boolean
+  certfile?: string
+  ciphers?: string[]
+  client_renegotiation?: boolean
+  /** @minimum 0 */
+  depth?: number
+  dhfile?: string
+  enable_crl_check?: boolean
+  fail_if_no_peer_cert?: boolean
+  gc_after_handshake?: boolean
+  handshake_timeout?: string
+  hibernate_after?: string
+  honor_cipher_order?: boolean
+  keyfile?: string
+  log_level?: EmqxListenerSslOptsLogLevel
+  managed_certs?: EmqxListenerSslOptsManagedCerts
+  ocsp?: EmqxOcsp
+  partial_chain?: EmqxListenerSslOptsPartialChain
+  password?: string
+  reuse_sessions?: boolean
+  secure_renegotiate?: boolean
+  session_tickets?: EmqxListenerSslOptsSessionTickets
+  verify?: EmqxListenerSslOptsVerify
+  verify_peer_ext_key_usage?: string
+  versions?: string[]
+}
+
+export type EmqxDeflateOptsStrategy =
+  (typeof EmqxDeflateOptsStrategy)[keyof typeof EmqxDeflateOptsStrategy]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsStrategy = {
+  default: 'default',
+  filtered: 'filtered',
+  huffman_only: 'huffman_only',
+  rle: 'rle',
+} as const
+
+export type EmqxDeflateOptsServerContextTakeover =
+  (typeof EmqxDeflateOptsServerContextTakeover)[keyof typeof EmqxDeflateOptsServerContextTakeover]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsServerContextTakeover = {
+  no_takeover: 'no_takeover',
+  takeover: 'takeover',
+} as const
+
+export type EmqxDeflateOptsLevel = (typeof EmqxDeflateOptsLevel)[keyof typeof EmqxDeflateOptsLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsLevel = {
+  best_compression: 'best_compression',
+  best_speed: 'best_speed',
+  default: 'default',
+  none: 'none',
+} as const
+
+export type EmqxDeflateOptsClientContextTakeover =
+  (typeof EmqxDeflateOptsClientContextTakeover)[keyof typeof EmqxDeflateOptsClientContextTakeover]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmqxDeflateOptsClientContextTakeover = {
+  no_takeover: 'no_takeover',
+  takeover: 'takeover',
+} as const
+
+export interface EmqxDeflateOpts {
+  client_context_takeover?: EmqxDeflateOptsClientContextTakeover
+  /**
+   * @minimum 8
+   * @maximum 15
+   */
+  client_max_window_bits?: number
+  level?: EmqxDeflateOptsLevel
+  /**
+   * @minimum 1
+   * @maximum 9
+   */
+  mem_level?: number
+  server_context_takeover?: EmqxDeflateOptsServerContextTakeover
+  /**
+   * @minimum 8
+   * @maximum 15
+   */
+  server_max_window_bits?: number
+  strategy?: EmqxDeflateOptsStrategy
 }

--- a/src/types/schemas/gateways.schemas.ts
+++ b/src/types/schemas/gateways.schemas.ts
@@ -1201,7 +1201,7 @@ export type EmqxGatewayApiGatewayNodeStatusNode =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxGatewayApiGatewayNodeStatusNode = {
-  'emqx@127001': 'emqx@127.0.0.1',
+  'emqx@1721702': 'emqx@172.17.0.2',
 } as const
 
 export interface EmqxGatewayApiGatewayNodeStatus {

--- a/src/types/schemas/gcpDevices.schemas.ts
+++ b/src/types/schemas/gcpDevices.schemas.ts
@@ -47,8 +47,8 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetGcpDevicesParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
 }
 
 export interface PublicMeta {

--- a/src/types/schemas/license.schemas.ts
+++ b/src/types/schemas/license.schemas.ts
@@ -11,7 +11,7 @@ export type PutLicenseSetting400 = {
   message?: string
 }
 
-export type PutLicenseSetting200HighWatermarkTimezone = string | 'system'
+export type PutLicenseSetting200HighWatermarkTimezone = 'system' | string
 
 export type PutLicenseSetting200 = {
   connection_high_watermark?: string
@@ -19,7 +19,7 @@ export type PutLicenseSetting200 = {
   high_watermark_timezone?: PutLicenseSetting200HighWatermarkTimezone
 }
 
-export type PutLicenseSettingBodyHighWatermarkTimezone = string | 'system'
+export type PutLicenseSettingBodyHighWatermarkTimezone = 'system' | string
 
 export type PutLicenseSettingBody = {
   connection_high_watermark?: string
@@ -27,7 +27,7 @@ export type PutLicenseSettingBody = {
   high_watermark_timezone?: PutLicenseSettingBodyHighWatermarkTimezone
 }
 
-export type GetLicenseSetting200HighWatermarkTimezone = string | 'system'
+export type GetLicenseSetting200HighWatermarkTimezone = 'system' | string
 
 export type GetLicenseSetting200 = {
   connection_high_watermark?: string
@@ -45,8 +45,8 @@ export const GetLicenseSessionHwmHistoryPeriod = {
 } as const
 
 export type GetLicenseSessionHwmHistoryParams = {
-  period?: GetLicenseSessionHwmHistoryPeriod
   limit?: number
+  period?: GetLicenseSessionHwmHistoryPeriod
 }
 
 export type PostLicense400Code = (typeof PostLicense400Code)[keyof typeof PostLicense400Code]
@@ -88,7 +88,7 @@ export interface LicenseHttpApiSessionHwmHistory {
   period?: LicenseHttpApiSessionHwmHistoryPeriod
 }
 
-export type LicenseHttpApiKeyLicenseKey = string | 'evaluation' | 'default'
+export type LicenseHttpApiKeyLicenseKey = 'default' | 'evaluation' | string
 
 export interface LicenseHttpApiKeyLicense {
   key: LicenseHttpApiKeyLicenseKey

--- a/src/types/schemas/listeners.schemas.ts
+++ b/src/types/schemas/listeners.schemas.ts
@@ -193,7 +193,7 @@ export const ListenersWssRequiredBindType = {
   wss: 'wss',
 } as const
 
-export type ListenersWssRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWssRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWssRequiredBindEnableAuthn =
   (typeof ListenersWssRequiredBindEnableAuthn)[keyof typeof ListenersWssRequiredBindEnableAuthn]
@@ -201,8 +201,8 @@ export type ListenersWssRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWssRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWssRequiredBind {
@@ -247,7 +247,7 @@ export const ListenersWssNotRequiredBindType = {
   wss: 'wss',
 } as const
 
-export type ListenersWssNotRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWssNotRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWssNotRequiredBindEnableAuthn =
   (typeof ListenersWssNotRequiredBindEnableAuthn)[keyof typeof ListenersWssNotRequiredBindEnableAuthn]
@@ -255,8 +255,8 @@ export type ListenersWssNotRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWssNotRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWssNotRequiredBind {
@@ -301,7 +301,7 @@ export const ListenersWsRequiredBindType = {
   ws: 'ws',
 } as const
 
-export type ListenersWsRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWsRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWsRequiredBindEnableAuthn =
   (typeof ListenersWsRequiredBindEnableAuthn)[keyof typeof ListenersWsRequiredBindEnableAuthn]
@@ -309,8 +309,8 @@ export type ListenersWsRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWsRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWsRequiredBind {
@@ -354,7 +354,7 @@ export const ListenersWsNotRequiredBindType = {
   ws: 'ws',
 } as const
 
-export type ListenersWsNotRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWsNotRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWsNotRequiredBindEnableAuthn =
   (typeof ListenersWsNotRequiredBindEnableAuthn)[keyof typeof ListenersWsNotRequiredBindEnableAuthn]
@@ -362,8 +362,8 @@ export type ListenersWsNotRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWsNotRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWsNotRequiredBind {
@@ -407,7 +407,7 @@ export const ListenersWithNameWssRequiredBindType = {
   wss: 'wss',
 } as const
 
-export type ListenersWithNameWssRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWithNameWssRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWithNameWssRequiredBindEnableAuthn =
   (typeof ListenersWithNameWssRequiredBindEnableAuthn)[keyof typeof ListenersWithNameWssRequiredBindEnableAuthn]
@@ -415,8 +415,8 @@ export type ListenersWithNameWssRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWithNameWssRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWithNameWssRequiredBind {
@@ -461,7 +461,7 @@ export const ListenersWithNameWsRequiredBindType = {
   ws: 'ws',
 } as const
 
-export type ListenersWithNameWsRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWithNameWsRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWithNameWsRequiredBindEnableAuthn =
   (typeof ListenersWithNameWsRequiredBindEnableAuthn)[keyof typeof ListenersWithNameWsRequiredBindEnableAuthn]
@@ -469,8 +469,8 @@ export type ListenersWithNameWsRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWithNameWsRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWithNameWsRequiredBind {
@@ -532,7 +532,7 @@ export const ListenersWithNameTcpRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersWithNameTcpRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWithNameTcpRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWithNameTcpRequiredBindEnableAuthn =
   (typeof ListenersWithNameTcpRequiredBindEnableAuthn)[keyof typeof ListenersWithNameTcpRequiredBindEnableAuthn]
@@ -540,8 +540,8 @@ export type ListenersWithNameTcpRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWithNameTcpRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWithNameTcpRequiredBind {
@@ -595,7 +595,7 @@ export const ListenersWithNameSslRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersWithNameSslRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWithNameSslRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWithNameSslRequiredBindEnableAuthn =
   (typeof ListenersWithNameSslRequiredBindEnableAuthn)[keyof typeof ListenersWithNameSslRequiredBindEnableAuthn]
@@ -603,8 +603,8 @@ export type ListenersWithNameSslRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWithNameSslRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersWithNameSslRequiredBind {
@@ -649,7 +649,7 @@ export const ListenersWithNameQuicRequiredBindType = {
   quic: 'quic',
 } as const
 
-export type ListenersWithNameQuicRequiredBindMaxConnections = number | 'infinity'
+export type ListenersWithNameQuicRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersWithNameQuicRequiredBindEnableAuthn =
   (typeof ListenersWithNameQuicRequiredBindEnableAuthn)[keyof typeof ListenersWithNameQuicRequiredBindEnableAuthn]
@@ -657,8 +657,8 @@ export type ListenersWithNameQuicRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersWithNameQuicRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export type ListenersTcpRequiredBindType =
@@ -687,7 +687,7 @@ export const ListenersTcpRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersTcpRequiredBindMaxConnections = number | 'infinity'
+export type ListenersTcpRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersTcpRequiredBindEnableAuthn =
   (typeof ListenersTcpRequiredBindEnableAuthn)[keyof typeof ListenersTcpRequiredBindEnableAuthn]
@@ -695,8 +695,8 @@ export type ListenersTcpRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersTcpRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersTcpRequiredBind {
@@ -759,7 +759,7 @@ export const ListenersTcpNotRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersTcpNotRequiredBindMaxConnections = number | 'infinity'
+export type ListenersTcpNotRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersTcpNotRequiredBindEnableAuthn =
   (typeof ListenersTcpNotRequiredBindEnableAuthn)[keyof typeof ListenersTcpNotRequiredBindEnableAuthn]
@@ -767,8 +767,8 @@ export type ListenersTcpNotRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersTcpNotRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersTcpNotRequiredBind {
@@ -805,9 +805,9 @@ export interface ListenersTcpNotRequiredBind {
   zone?: string
 }
 
-export type ListenersStatusRunning = boolean | 'inconsistent'
+export type ListenersStatusRunning = 'inconsistent' | boolean
 
-export type ListenersStatusMaxConnections = number | 'infinity'
+export type ListenersStatusMaxConnections = 'infinity' | number
 
 export interface ListenersStatus {
   /** @minimum 0 */
@@ -833,7 +833,7 @@ export const ListenersSslRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersSslRequiredBindMaxConnections = number | 'infinity'
+export type ListenersSslRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersSslRequiredBindEnableAuthn =
   (typeof ListenersSslRequiredBindEnableAuthn)[keyof typeof ListenersSslRequiredBindEnableAuthn]
@@ -841,8 +841,8 @@ export type ListenersSslRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersSslRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersSslRequiredBind {
@@ -896,7 +896,7 @@ export const ListenersSslNotRequiredBindParseUnit = {
   frame: 'frame',
 } as const
 
-export type ListenersSslNotRequiredBindMaxConnections = number | 'infinity'
+export type ListenersSslNotRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersSslNotRequiredBindEnableAuthn =
   (typeof ListenersSslNotRequiredBindEnableAuthn)[keyof typeof ListenersSslNotRequiredBindEnableAuthn]
@@ -904,8 +904,8 @@ export type ListenersSslNotRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersSslNotRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersSslNotRequiredBind {
@@ -950,7 +950,7 @@ export const ListenersQuicRequiredBindType = {
   quic: 'quic',
 } as const
 
-export type ListenersQuicRequiredBindMaxConnections = number | 'infinity'
+export type ListenersQuicRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersQuicRequiredBindEnableAuthn =
   (typeof ListenersQuicRequiredBindEnableAuthn)[keyof typeof ListenersQuicRequiredBindEnableAuthn]
@@ -958,8 +958,8 @@ export type ListenersQuicRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersQuicRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersQuicRequiredBind {
@@ -1000,7 +1000,7 @@ export const ListenersQuicNotRequiredBindType = {
   quic: 'quic',
 } as const
 
-export type ListenersQuicNotRequiredBindMaxConnections = number | 'infinity'
+export type ListenersQuicNotRequiredBindMaxConnections = 'infinity' | number
 
 export type ListenersQuicNotRequiredBindEnableAuthn =
   (typeof ListenersQuicNotRequiredBindEnableAuthn)[keyof typeof ListenersQuicNotRequiredBindEnableAuthn]
@@ -1008,8 +1008,8 @@ export type ListenersQuicNotRequiredBindEnableAuthn =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListenersQuicNotRequiredBindEnableAuthn = {
   false: false,
-  quick_deny_anonymous: 'quick_deny_anonymous',
   true: true,
+  quick_deny_anonymous: 'quick_deny_anonymous',
 } as const
 
 export interface ListenersQuicNotRequiredBind {
@@ -1102,7 +1102,7 @@ export const EmqxWsOptsMqttPiggyback = {
   single: 'single',
 } as const
 
-export type EmqxWsOptsMaxFrameSize = number | 'infinity'
+export type EmqxWsOptsMaxFrameSize = 'infinity' | number
 
 export interface EmqxWsOpts {
   allow_origin_absence?: boolean
@@ -1176,13 +1176,13 @@ export type EmqxListenerWssOptsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxListenerWssOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type EmqxListenerWssOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type EmqxListenerWssOptsLogLevel =
   (typeof EmqxListenerWssOptsLogLevel)[keyof typeof EmqxListenerWssOptsLogLevel]
@@ -1252,13 +1252,13 @@ export type EmqxListenerSslOptsPartialChain =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxListenerSslOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 
-export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type EmqxListenerSslOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export type EmqxListenerSslOptsLogLevel =
   (typeof EmqxListenerSslOptsLogLevel)[keyof typeof EmqxListenerSslOptsLogLevel]
@@ -1316,7 +1316,7 @@ export const EmqxListenerQuicSslOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxListenerQuicSslOptsManagedCerts = EmqxManagedCertsServer[] | EmqxManagedCertsServer
+export type EmqxListenerQuicSslOptsManagedCerts = EmqxManagedCertsServer | EmqxManagedCertsServer[]
 
 export interface EmqxListenerQuicSslOpts {
   cacertfile?: string

--- a/src/types/schemas/messageQueue.schemas.ts
+++ b/src/types/schemas/messageQueue.schemas.ts
@@ -64,7 +64,7 @@ export type GetQueues400 = {
   message?: string
 }
 
-export type GetQueues200Item = MqMessageQueueRegularApiGet | MqMessageQueueLastvalueApiGet
+export type GetQueues200Item = MqMessageQueueLastvalueApiGet | MqMessageQueueRegularApiGet
 
 export type GetQueuesParams = {
   cursor?: PublicCursorParameter
@@ -180,9 +180,9 @@ export type PublicLimitParameter = number
 
 export type PublicCursorParameter = string
 
-export type MqMqIndividualLimitsMaxShardMessageCount = number | 'infinity'
+export type MqMqIndividualLimitsMaxShardMessageCount = 'infinity' | number
 
-export type MqMqIndividualLimitsMaxShardMessageBytes = string | 'infinity'
+export type MqMqIndividualLimitsMaxShardMessageBytes = 'infinity' | string
 
 export interface MqMqIndividualLimits {
   max_shard_message_bytes: MqMqIndividualLimitsMaxShardMessageBytes

--- a/src/types/schemas/messageStream.schemas.ts
+++ b/src/types/schemas/messageStream.schemas.ts
@@ -64,7 +64,7 @@ export type GetStreams400 = {
   message?: string
 }
 
-export type GetStreams200Item = StreamsStreamRegularApiGet | StreamsStreamLastvalueApiGet
+export type GetStreams200Item = StreamsStreamLastvalueApiGet | StreamsStreamRegularApiGet
 
 export type GetStreamsParams = {
   cursor?: PublicCursorParameter
@@ -253,9 +253,9 @@ export const StreamsStreamLastvalueApiGetIsLastvalue = {
   true: true,
 } as const
 
-export type StreamsStreamIndividualLimitsMaxShardMessageCount = number | 'infinity'
+export type StreamsStreamIndividualLimitsMaxShardMessageCount = 'infinity' | number
 
-export type StreamsStreamIndividualLimitsMaxShardMessageBytes = string | 'infinity'
+export type StreamsStreamIndividualLimitsMaxShardMessageBytes = 'infinity' | string
 
 export interface StreamsStreamIndividualLimits {
   max_shard_message_bytes: StreamsStreamIndividualLimitsMaxShardMessageBytes

--- a/src/types/schemas/messageTransformation.schemas.ts
+++ b/src/types/schemas/messageTransformation.schemas.ts
@@ -144,71 +144,6 @@ export type PostMessageTransformations400 = {
   message?: string
 }
 
-export type MessageTransformationTransformationTopics = string[] | string
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MessageTransformationTransformationPayloadEncoder = {
-  payload_serde_external_http: 'payload_serde_external_http',
-  payload_serde_protobuf: 'payload_serde_protobuf',
-  payload_serde_avro: 'payload_serde_avro',
-  payload_serde_json: 'payload_serde_json',
-  payload_serde_none: 'payload_serde_none',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MessageTransformationTransformationPayloadDecoder = {
-  payload_serde_external_http: 'payload_serde_external_http',
-  payload_serde_protobuf: 'payload_serde_protobuf',
-  payload_serde_avro: 'payload_serde_avro',
-  payload_serde_json: 'payload_serde_json',
-  payload_serde_none: 'payload_serde_none',
-} as const
-
-export type MessageTransformationTransformationFailureAction =
-  (typeof MessageTransformationTransformationFailureAction)[keyof typeof MessageTransformationTransformationFailureAction]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MessageTransformationTransformationFailureAction = {
-  disconnect: 'disconnect',
-  drop: 'drop',
-  ignore: 'ignore',
-} as const
-
-export interface MessageTransformationOperation {
-  key: string
-  value: string
-}
-
-export type MessageTransformationLogFailureLevel =
-  (typeof MessageTransformationLogFailureLevel)[keyof typeof MessageTransformationLogFailureLevel]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MessageTransformationLogFailureLevel = {
-  debug: 'debug',
-  error: 'error',
-  info: 'info',
-  none: 'none',
-  notice: 'notice',
-  warning: 'warning',
-} as const
-
-export interface MessageTransformationLogFailure {
-  level?: MessageTransformationLogFailureLevel
-}
-
-export interface MessageTransformationTransformation {
-  description?: string
-  enable?: boolean
-  failure_action: MessageTransformationTransformationFailureAction
-  log_failure?: MessageTransformationLogFailure
-  name: string
-  operations?: MessageTransformationOperation[]
-  payload_decoder?: (typeof MessageTransformationTransformationPayloadDecoder)[keyof typeof MessageTransformationTransformationPayloadDecoder]
-  payload_encoder?: (typeof MessageTransformationTransformationPayloadEncoder)[keyof typeof MessageTransformationTransformationPayloadEncoder]
-  tags?: string[]
-  topics: MessageTransformationTransformationTopics
-}
-
 export interface MessageTransformationHttpApiReorder {
   order: string[]
 }
@@ -237,11 +172,6 @@ export interface MessageTransformationHttpApiGetMetrics {
   node_metrics?: MessageTransformationHttpApiNodeMetrics
 }
 
-export interface MessageTransformationHttpApiDryrunTransformation {
-  message: MessageTransformationHttpApiDryrunInputMessage
-  transformation: MessageTransformationTransformation
-}
-
 export type MessageTransformationHttpApiDryrunInputMessageUserProperty = { [key: string]: unknown }
 
 export type MessageTransformationHttpApiDryrunInputMessagePubProps = { [key: string]: unknown }
@@ -263,4 +193,74 @@ export interface MessageTransformationHttpApiDryrunInputMessage {
   topic: string
   user_property?: MessageTransformationHttpApiDryrunInputMessageUserProperty
   username?: string
+}
+
+export interface MessageTransformationHttpApiDryrunTransformation {
+  message: MessageTransformationHttpApiDryrunInputMessage
+  transformation: MessageTransformationTransformation
+}
+
+export type MessageTransformationTransformationTopics = string[] | string
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MessageTransformationTransformationPayloadEncoder = {
+  payload_serde_avro: 'payload_serde_avro',
+  payload_serde_external_http: 'payload_serde_external_http',
+  payload_serde_json: 'payload_serde_json',
+  payload_serde_none: 'payload_serde_none',
+  payload_serde_protobuf: 'payload_serde_protobuf',
+} as const
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MessageTransformationTransformationPayloadDecoder = {
+  payload_serde_avro: 'payload_serde_avro',
+  payload_serde_external_http: 'payload_serde_external_http',
+  payload_serde_json: 'payload_serde_json',
+  payload_serde_none: 'payload_serde_none',
+  payload_serde_protobuf: 'payload_serde_protobuf',
+} as const
+
+export type MessageTransformationTransformationFailureAction =
+  (typeof MessageTransformationTransformationFailureAction)[keyof typeof MessageTransformationTransformationFailureAction]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MessageTransformationTransformationFailureAction = {
+  disconnect: 'disconnect',
+  drop: 'drop',
+  ignore: 'ignore',
+} as const
+
+export interface MessageTransformationOperation {
+  key: string
+  value: string
+}
+
+export interface MessageTransformationTransformation {
+  description?: string
+  enable?: boolean
+  failure_action: MessageTransformationTransformationFailureAction
+  log_failure?: MessageTransformationLogFailure
+  name: string
+  operations?: MessageTransformationOperation[]
+  payload_decoder?: (typeof MessageTransformationTransformationPayloadDecoder)[keyof typeof MessageTransformationTransformationPayloadDecoder]
+  payload_encoder?: (typeof MessageTransformationTransformationPayloadEncoder)[keyof typeof MessageTransformationTransformationPayloadEncoder]
+  tags?: string[]
+  topics: MessageTransformationTransformationTopics
+}
+
+export type MessageTransformationLogFailureLevel =
+  (typeof MessageTransformationLogFailureLevel)[keyof typeof MessageTransformationLogFailureLevel]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MessageTransformationLogFailureLevel = {
+  debug: 'debug',
+  error: 'error',
+  info: 'info',
+  none: 'none',
+  notice: 'notice',
+  warning: 'warning',
+} as const
+
+export interface MessageTransformationLogFailure {
+  level?: MessageTransformationLogFailureLevel
 }

--- a/src/types/schemas/metrics.schemas.ts
+++ b/src/types/schemas/metrics.schemas.ts
@@ -4,6 +4,19 @@ export type GetStatsParams = {
   aggregate?: EmqxMgmtApiStatsAggregateParameter
 }
 
+export type GetMonitorCurrentNodesNode404Code =
+  (typeof GetMonitorCurrentNodesNode404Code)[keyof typeof GetMonitorCurrentNodesNode404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetMonitorCurrentNodesNode404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type GetMonitorCurrentNodesNode404 = {
+  code?: GetMonitorCurrentNodesNode404Code
+  message?: string
+}
+
 export type GetMonitorNodesNode404Code =
   (typeof GetMonitorNodesNode404Code)[keyof typeof GetMonitorNodesNode404Code]
 
@@ -19,19 +32,6 @@ export type GetMonitorNodesNode404 = {
 
 export type GetMonitorNodesNodeParams = {
   latest?: number
-}
-
-export type GetMonitorCurrentNodesNode404Code =
-  (typeof GetMonitorCurrentNodesNode404Code)[keyof typeof GetMonitorCurrentNodesNode404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetMonitorCurrentNodesNode404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type GetMonitorCurrentNodesNode404 = {
-  code?: GetMonitorCurrentNodesNode404Code
-  message?: string
 }
 
 export type GetMonitor400Code = (typeof GetMonitor400Code)[keyof typeof GetMonitor400Code]
@@ -50,7 +50,7 @@ export type GetMonitorParams = {
   latest?: number
 }
 
-export type GetMetrics200 = EmqxMgmtApiMetricsNodeMetrics[] | EmqxMgmtApiMetricsAggregatedMetrics
+export type GetMetrics200 = EmqxMgmtApiMetricsAggregatedMetrics | EmqxMgmtApiMetricsNodeMetrics[]
 
 export type GetMetricsParams = {
   aggregate?: boolean

--- a/src/types/schemas/monitor.schemas.ts
+++ b/src/types/schemas/monitor.schemas.ts
@@ -314,16 +314,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 

--- a/src/types/schemas/multiTenancy.schemas.ts
+++ b/src/types/schemas/multiTenancy.schemas.ts
@@ -1,3 +1,40 @@
+export type GetMtNsListDetails400Code =
+  (typeof GetMtNsListDetails400Code)[keyof typeof GetMtNsListDetails400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetMtNsListDetails400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type GetMtNsListDetails400 = {
+  code?: GetMtNsListDetails400Code
+  message?: string
+}
+
+export type GetMtNsListDetailsParams = {
+  first_ns?: string
+  last_ns?: string
+  limit?: number
+}
+
+export type GetMtNsList400Code = (typeof GetMtNsList400Code)[keyof typeof GetMtNsList400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetMtNsList400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type GetMtNsList400 = {
+  code?: GetMtNsList400Code
+  message?: string
+}
+
+export type GetMtNsListParams = {
+  first_ns?: string
+  last_ns?: string
+  limit?: number
+}
+
 export type GetMtNsNsMetrics404Code =
   (typeof GetMtNsNsMetrics404Code)[keyof typeof GetMtNsNsMetrics404Code]
 
@@ -103,8 +140,8 @@ export type GetMtNsNsClientList400 = {
 }
 
 export type GetMtNsNsClientListParams = {
-  last_clientid?: string
   first_clientid?: string
+  last_clientid?: string
   limit?: number
 }
 
@@ -150,43 +187,6 @@ export type PostMtNsNs400 = {
   message?: string
 }
 
-export type GetMtNsListDetails400Code =
-  (typeof GetMtNsListDetails400Code)[keyof typeof GetMtNsListDetails400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetMtNsListDetails400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type GetMtNsListDetails400 = {
-  code?: GetMtNsListDetails400Code
-  message?: string
-}
-
-export type GetMtNsListDetailsParams = {
-  last_ns?: string
-  first_ns?: string
-  limit?: number
-}
-
-export type GetMtNsList400Code = (typeof GetMtNsList400Code)[keyof typeof GetMtNsList400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetMtNsList400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type GetMtNsList400 = {
-  code?: GetMtNsList400Code
-  message?: string
-}
-
-export type GetMtNsListParams = {
-  last_ns?: string
-  first_ns?: string
-  limit?: number
-}
-
 export type GetMtManagedNsListDetails400Code =
   (typeof GetMtManagedNsListDetails400Code)[keyof typeof GetMtManagedNsListDetails400Code]
 
@@ -201,8 +201,8 @@ export type GetMtManagedNsListDetails400 = {
 }
 
 export type GetMtManagedNsListDetailsParams = {
-  last_ns?: string
   first_ns?: string
+  last_ns?: string
   limit?: number
 }
 
@@ -220,8 +220,8 @@ export type GetMtManagedNsList400 = {
 }
 
 export type GetMtManagedNsListParams = {
-  last_ns?: string
   first_ns?: string
+  last_ns?: string
   limit?: number
 }
 
@@ -299,7 +299,7 @@ export interface MtTenantLimiterIn {
   messages?: MtLimiterOptions
 }
 
-export type MtSessionConfigInMaxSessions = number | 'infinity'
+export type MtSessionConfigInMaxSessions = 'infinity' | number
 
 export interface MtSessionConfigIn {
   max_sessions?: MtSessionConfigInMaxSessions

--- a/src/types/schemas/plugins.schemas.ts
+++ b/src/types/schemas/plugins.schemas.ts
@@ -1,47 +1,26 @@
-export type PostPluginsInstall400Code =
-  (typeof PostPluginsInstall400Code)[keyof typeof PostPluginsInstall400Code]
+export type PutPluginsNameAction404Code =
+  (typeof PutPluginsNameAction404Code)[keyof typeof PutPluginsNameAction404Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostPluginsInstall400Code = {
-  ALREADY_INSTALLED: 'ALREADY_INSTALLED',
-  BAD_FORM_DATA: 'BAD_FORM_DATA',
-  BAD_PLUGIN_INFO: 'BAD_PLUGIN_INFO',
-  FORBIDDEN: 'FORBIDDEN',
-  UNEXPECTED_ERROR: 'UNEXPECTED_ERROR',
-} as const
-
-export type PostPluginsInstall400 = {
-  code?: PostPluginsInstall400Code
-  message?: string
-}
-
-export type PostPluginsInstallBody = {
-  plugin?: Blob
-}
-
-export type PostPluginsClusterSync404Code =
-  (typeof PostPluginsClusterSync404Code)[keyof typeof PostPluginsClusterSync404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostPluginsClusterSync404Code = {
+export const PutPluginsNameAction404Code = {
   NOT_FOUND: 'NOT_FOUND',
 } as const
 
-export type PostPluginsClusterSync404 = {
-  code?: PostPluginsClusterSync404Code
+export type PutPluginsNameAction404 = {
+  code?: PutPluginsNameAction404Code
   message?: string
 }
 
-export type PostPluginsClusterSync400Code =
-  (typeof PostPluginsClusterSync400Code)[keyof typeof PostPluginsClusterSync400Code]
+export type PutPluginsNameAction400Code =
+  (typeof PutPluginsNameAction400Code)[keyof typeof PutPluginsNameAction400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostPluginsClusterSync400Code = {
-  BAD_PLUGIN_INFO: 'BAD_PLUGIN_INFO',
+export const PutPluginsNameAction400Code = {
+  PARAM_ERROR: 'PARAM_ERROR',
 } as const
 
-export type PostPluginsClusterSync400 = {
-  code?: PostPluginsClusterSync400Code
+export type PutPluginsNameAction400 = {
+  code?: PutPluginsNameAction400Code
   message?: string
 }
 
@@ -223,32 +202,6 @@ export type GetPluginsNameConfig400 = {
   message?: string
 }
 
-export type PutPluginsNameAction404Code =
-  (typeof PutPluginsNameAction404Code)[keyof typeof PutPluginsNameAction404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPluginsNameAction404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PutPluginsNameAction404 = {
-  code?: PutPluginsNameAction404Code
-  message?: string
-}
-
-export type PutPluginsNameAction400Code =
-  (typeof PutPluginsNameAction400Code)[keyof typeof PutPluginsNameAction400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPluginsNameAction400Code = {
-  PARAM_ERROR: 'PARAM_ERROR',
-} as const
-
-export type PutPluginsNameAction400 = {
-  code?: PutPluginsNameAction400Code
-  message?: string
-}
-
 export type GetPluginsName404Code =
   (typeof GetPluginsName404Code)[keyof typeof GetPluginsName404Code]
 
@@ -285,6 +238,53 @@ export const DeletePluginsName400Code = {
 
 export type DeletePluginsName400 = {
   code?: DeletePluginsName400Code
+  message?: string
+}
+
+export type PostPluginsInstall400Code =
+  (typeof PostPluginsInstall400Code)[keyof typeof PostPluginsInstall400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostPluginsInstall400Code = {
+  ALREADY_INSTALLED: 'ALREADY_INSTALLED',
+  BAD_FORM_DATA: 'BAD_FORM_DATA',
+  BAD_PLUGIN_INFO: 'BAD_PLUGIN_INFO',
+  FORBIDDEN: 'FORBIDDEN',
+  UNEXPECTED_ERROR: 'UNEXPECTED_ERROR',
+} as const
+
+export type PostPluginsInstall400 = {
+  code?: PostPluginsInstall400Code
+  message?: string
+}
+
+export type PostPluginsInstallBody = {
+  plugin?: Blob
+}
+
+export type PostPluginsClusterSync404Code =
+  (typeof PostPluginsClusterSync404Code)[keyof typeof PostPluginsClusterSync404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostPluginsClusterSync404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostPluginsClusterSync404 = {
+  code?: PostPluginsClusterSync404Code
+  message?: string
+}
+
+export type PostPluginsClusterSync400Code =
+  (typeof PostPluginsClusterSync400Code)[keyof typeof PostPluginsClusterSync400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostPluginsClusterSync400Code = {
+  BAD_PLUGIN_INFO: 'BAD_PLUGIN_INFO',
+} as const
+
+export type PostPluginsClusterSync400 = {
+  code?: PostPluginsClusterSync400Code
   message?: string
 }
 
@@ -372,7 +372,7 @@ export interface PluginsRunningStatus {
   status?: PluginsRunningStatusStatus
 }
 
-export type PluginsPositionPosition = string | 'rear' | 'front'
+export type PluginsPositionPosition = 'front' | 'rear' | string
 
 export interface PluginsPosition {
   position?: PluginsPositionPosition

--- a/src/types/schemas/plugins.schemas.ts
+++ b/src/types/schemas/plugins.schemas.ts
@@ -59,6 +59,19 @@ export type GetPluginsNameSchema404 = {
   message?: string
 }
 
+export type PostPluginsNameMove404Code =
+  (typeof PostPluginsNameMove404Code)[keyof typeof PostPluginsNameMove404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostPluginsNameMove404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostPluginsNameMove404 = {
+  code?: PostPluginsNameMove404Code
+  message?: string
+}
+
 export type PostPluginsNameMove400Code =
   (typeof PostPluginsNameMove400Code)[keyof typeof PostPluginsNameMove400Code]
 

--- a/src/types/schemas/publish.schemas.ts
+++ b/src/types/schemas/publish.schemas.ts
@@ -31,7 +31,7 @@ export interface EmqxMgmtApiPublishPublishError {
   reason_code?: number
 }
 
-export type PostPublishBulk400 = EmqxMgmtApiPublishPublishError[] | EmqxMgmtApiPublishBadRequest
+export type PostPublishBulk400 = EmqxMgmtApiPublishBadRequest | EmqxMgmtApiPublishPublishError[]
 
 export type EmqxMgmtApiPublishMessagePropertiesUserProperties = { [key: string]: unknown }
 

--- a/src/types/schemas/retainer.schemas.ts
+++ b/src/types/schemas/retainer.schemas.ts
@@ -17,9 +17,9 @@ export type GetMqttRetainerMessages200 = {
 }
 
 export type GetMqttRetainerMessagesParams = {
-  topic?: string
   page?: number
   limit?: number
+  topic?: string
 }
 
 export type GetMqttRetainerMessageTopic404Code =
@@ -100,7 +100,7 @@ export type GetMqttRetainer404 = {
   message?: string
 }
 
-export type RetainerRetainerMsgExpiryIntervalOverride = string | 'disabled'
+export type RetainerRetainerMsgExpiryIntervalOverride = 'disabled' | string
 
 export type RetainerMnesiaConfigType =
   (typeof RetainerMnesiaConfigType)[keyof typeof RetainerMnesiaConfigType]

--- a/src/types/schemas/rules.schemas.ts
+++ b/src/types/schemas/rules.schemas.ts
@@ -169,18 +169,18 @@ export type GetRules200 = {
 }
 
 export type GetRulesParams = {
-  ns?: string
-  only_global?: boolean
+  limit?: PublicLimitParameter
+  page?: PublicPageParameter
+  action?: string[]
   enable?: boolean
   from?: string
-  like_id?: string
-  like_from?: string
   like_description?: string
+  like_from?: string
+  like_id?: string
   match_from?: string
-  action?: string[]
+  ns?: string
+  only_global?: boolean
   source?: string[]
-  page?: PublicPageParameter
-  limit?: PublicLimitParameter
 }
 
 export type PostRuleTest412Code = (typeof PostRuleTest412Code)[keyof typeof PostRuleTest412Code]
@@ -250,24 +250,24 @@ export interface RuleEngineSsrf {
 }
 
 export type RuleEngineRuleTestContext =
-  | RuleEngineCtxUnsub
-  | RuleEngineCtxSub
-  | RuleEngineCtxSchemaValidationFailed
-  | RuleEngineCtxMessageTransformationFailed
-  | RuleEngineCtxPub
-  | RuleEngineCtxDropped
-  | RuleEngineCtxDelivered
   | RuleEngineCtxAcked
-  | RuleEngineCtxDeliveryDropped
-  | RuleEngineCtxPing
-  | RuleEngineCtxDisconnected
-  | RuleEngineCtxConnected
-  | RuleEngineCtxConnack
-  | RuleEngineCtxCheckAuthzComplete
-  | RuleEngineCtxCheckAuthnComplete
-  | RuleEngineCtxAlarmDeactivated
   | RuleEngineCtxAlarmActivated
+  | RuleEngineCtxAlarmDeactivated
   | RuleEngineCtxBridgeMqtt
+  | RuleEngineCtxCheckAuthnComplete
+  | RuleEngineCtxCheckAuthzComplete
+  | RuleEngineCtxConnack
+  | RuleEngineCtxConnected
+  | RuleEngineCtxDelivered
+  | RuleEngineCtxDeliveryDropped
+  | RuleEngineCtxDisconnected
+  | RuleEngineCtxDropped
+  | RuleEngineCtxMessageTransformationFailed
+  | RuleEngineCtxPing
+  | RuleEngineCtxPub
+  | RuleEngineCtxSchemaValidationFailed
+  | RuleEngineCtxSub
+  | RuleEngineCtxUnsub
 
 export interface RuleEngineRuleTest {
   context?: RuleEngineRuleTestContext
@@ -283,9 +283,9 @@ export interface RuleEngineRuleMetrics {
 export type RuleEngineRuleInfoMetadata = { [key: string]: unknown }
 
 export type RuleEngineRuleInfoActionsItem =
-  | RuleEngineUserProvidedFunction
   | RuleEngineBuiltinActionConsole
   | RuleEngineBuiltinActionRepublish
+  | RuleEngineUserProvidedFunction
   | string
 
 export interface RuleEngineRuleInfo {
@@ -311,31 +311,31 @@ export type RuleEngineRuleEventsEvent =
 export const RuleEngineRuleEventsEvent = {
   '$events/auth/check_authn_complete': '$events/auth/check_authn_complete',
   '$events/auth/check_authz_complete': '$events/auth/check_authz_complete',
+  '$events/client/connack': '$events/client/connack',
+  '$events/client/connected': '$events/client/connected',
+  '$events/client/disconnected': '$events/client/disconnected',
+  '$events/client/ping': '$events/client/ping',
   '$events/client_check_authn_complete': '$events/client_check_authn_complete',
   '$events/client_check_authz_complete': '$events/client_check_authz_complete',
   '$events/client_connack': '$events/client_connack',
   '$events/client_connected': '$events/client_connected',
   '$events/client_disconnected': '$events/client_disconnected',
-  '$events/client/connack': '$events/client/connack',
-  '$events/client/connected': '$events/client/connected',
-  '$events/client/disconnected': '$events/client/disconnected',
-  '$events/client/ping': '$events/client/ping',
   '$events/delivery_dropped': '$events/delivery_dropped',
-  '$events/message_acked': '$events/message_acked',
-  '$events/message_delivered': '$events/message_delivered',
-  '$events/message_dropped': '$events/message_dropped',
-  '$events/message_transformation_failed': '$events/message_transformation_failed',
-  '$events/message_transformation/failed': '$events/message_transformation/failed',
   '$events/message/acked': '$events/message/acked',
   '$events/message/delivered': '$events/message/delivered',
   '$events/message/delivery_dropped': '$events/message/delivery_dropped',
   '$events/message/dropped': '$events/message/dropped',
-  '$events/schema_validation_failed': '$events/schema_validation_failed',
+  '$events/message_acked': '$events/message_acked',
+  '$events/message_delivered': '$events/message_delivered',
+  '$events/message_dropped': '$events/message_dropped',
+  '$events/message_transformation/failed': '$events/message_transformation/failed',
+  '$events/message_transformation_failed': '$events/message_transformation_failed',
   '$events/schema_validation/failed': '$events/schema_validation/failed',
-  '$events/session_subscribed': '$events/session_subscribed',
-  '$events/session_unsubscribed': '$events/session_unsubscribed',
+  '$events/schema_validation_failed': '$events/schema_validation_failed',
   '$events/session/subscribed': '$events/session/subscribed',
   '$events/session/unsubscribed': '$events/session/unsubscribed',
+  '$events/session_subscribed': '$events/session_subscribed',
+  '$events/session_unsubscribed': '$events/session_unsubscribed',
   '$events/sys/alarm_activated': '$events/sys/alarm_activated',
   '$events/sys/alarm_deactivated': '$events/sys/alarm_deactivated',
 } as const
@@ -361,9 +361,9 @@ export interface RuleEngineRuleEngine {
 export type RuleEngineRuleCreationMetadata = { [key: string]: unknown }
 
 export type RuleEngineRuleCreationActionsItem =
-  | RuleEngineUserProvidedFunction
   | RuleEngineBuiltinActionConsole
   | RuleEngineBuiltinActionRepublish
+  | RuleEngineUserProvidedFunction
   | string
 
 export interface RuleEngineRuleCreation {
@@ -388,11 +388,11 @@ export interface RuleEngineRepublishMqttProperties {
   'Response-Topic'?: string
 }
 
-export type RuleEngineRepublishArgsRetain = string | boolean
+export type RuleEngineRepublishArgsRetain = boolean | string
 
-export type RuleEngineRepublishArgsQos = string | number
+export type RuleEngineRepublishArgsQos = number | string
 
-export type RuleEngineRepublishArgsDirectDispatch = string | boolean
+export type RuleEngineRepublishArgsDirectDispatch = boolean | string
 
 export interface RuleEngineRepublishArgs {
   direct_dispatch?: RuleEngineRepublishArgsDirectDispatch
@@ -602,24 +602,24 @@ export interface RuleEngineCtxMessageTransformationFailed {
 }
 
 export type RuleEngineRuleApplyTestContext =
-  | RuleEngineCtxUnsub
-  | RuleEngineCtxSub
-  | RuleEngineCtxSchemaValidationFailed
-  | RuleEngineCtxMessageTransformationFailed
-  | RuleEngineCtxPub
-  | RuleEngineCtxDropped
-  | RuleEngineCtxDelivered
   | RuleEngineCtxAcked
-  | RuleEngineCtxDeliveryDropped
-  | RuleEngineCtxPing
-  | RuleEngineCtxDisconnected
-  | RuleEngineCtxConnected
-  | RuleEngineCtxConnack
-  | RuleEngineCtxCheckAuthzComplete
-  | RuleEngineCtxCheckAuthnComplete
-  | RuleEngineCtxAlarmDeactivated
   | RuleEngineCtxAlarmActivated
+  | RuleEngineCtxAlarmDeactivated
   | RuleEngineCtxBridgeMqtt
+  | RuleEngineCtxCheckAuthnComplete
+  | RuleEngineCtxCheckAuthzComplete
+  | RuleEngineCtxConnack
+  | RuleEngineCtxConnected
+  | RuleEngineCtxDelivered
+  | RuleEngineCtxDeliveryDropped
+  | RuleEngineCtxDisconnected
+  | RuleEngineCtxDropped
+  | RuleEngineCtxMessageTransformationFailed
+  | RuleEngineCtxPing
+  | RuleEngineCtxPub
+  | RuleEngineCtxSchemaValidationFailed
+  | RuleEngineCtxSub
+  | RuleEngineCtxUnsub
 
 export type RuleEngineCtxDroppedEventType =
   (typeof RuleEngineCtxDroppedEventType)[keyof typeof RuleEngineCtxDroppedEventType]

--- a/src/types/schemas/schemaRegistry.schemas.ts
+++ b/src/types/schemas/schemaRegistry.schemas.ts
@@ -1,60 +1,3 @@
-export type PutSchemaRegistryName404Code =
-  (typeof PutSchemaRegistryName404Code)[keyof typeof PutSchemaRegistryName404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutSchemaRegistryName404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PutSchemaRegistryName404 = {
-  code?: PutSchemaRegistryName404Code
-  message?: string
-}
-
-export type PutSchemaRegistryName200 =
-  | SchemaRegistryPutAvro
-  | SchemaRegistryPutExternalHttp
-  | SchemaRegistryPutJson
-  | SchemaRegistryPutProtobuf
-
-export type PutSchemaRegistryNameBody =
-  | SchemaRegistryPutAvro
-  | SchemaRegistryPutExternalHttp
-  | SchemaRegistryPutJson
-  | SchemaRegistryPutProtobuf
-
-export type GetSchemaRegistryName404Code =
-  (typeof GetSchemaRegistryName404Code)[keyof typeof GetSchemaRegistryName404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GetSchemaRegistryName404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type GetSchemaRegistryName404 = {
-  code?: GetSchemaRegistryName404Code
-  message?: string
-}
-
-export type GetSchemaRegistryName200 =
-  | SchemaRegistryGetAvro
-  | SchemaRegistryGetExternalHttp
-  | SchemaRegistryGetJson
-  | SchemaRegistryGetProtobuf
-
-export type DeleteSchemaRegistryName404Code =
-  (typeof DeleteSchemaRegistryName404Code)[keyof typeof DeleteSchemaRegistryName404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeleteSchemaRegistryName404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type DeleteSchemaRegistryName404 = {
-  code?: DeleteSchemaRegistryName404Code
-  message?: string
-}
-
 export type PutSchemaRegistryProtobufBundle404Code =
   (typeof PutSchemaRegistryProtobufBundle404Code)[keyof typeof PutSchemaRegistryProtobufBundle404Code]
 
@@ -156,6 +99,63 @@ export type GetSchemaRegistryExternal200 = {
   $name?: GetSchemaRegistryExternal200Name
 }
 
+export type PutSchemaRegistryName404Code =
+  (typeof PutSchemaRegistryName404Code)[keyof typeof PutSchemaRegistryName404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutSchemaRegistryName404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PutSchemaRegistryName404 = {
+  code?: PutSchemaRegistryName404Code
+  message?: string
+}
+
+export type PutSchemaRegistryName200 =
+  | SchemaRegistryPutAvro
+  | SchemaRegistryPutExternalHttp
+  | SchemaRegistryPutJson
+  | SchemaRegistryPutProtobuf
+
+export type PutSchemaRegistryNameBody =
+  | SchemaRegistryPutAvro
+  | SchemaRegistryPutExternalHttp
+  | SchemaRegistryPutJson
+  | SchemaRegistryPutProtobuf
+
+export type GetSchemaRegistryName404Code =
+  (typeof GetSchemaRegistryName404Code)[keyof typeof GetSchemaRegistryName404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetSchemaRegistryName404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type GetSchemaRegistryName404 = {
+  code?: GetSchemaRegistryName404Code
+  message?: string
+}
+
+export type GetSchemaRegistryName200 =
+  | SchemaRegistryGetAvro
+  | SchemaRegistryGetExternalHttp
+  | SchemaRegistryGetJson
+  | SchemaRegistryGetProtobuf
+
+export type DeleteSchemaRegistryName404Code =
+  (typeof DeleteSchemaRegistryName404Code)[keyof typeof DeleteSchemaRegistryName404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DeleteSchemaRegistryName404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type DeleteSchemaRegistryName404 = {
+  code?: DeleteSchemaRegistryName404Code
+  message?: string
+}
+
 export type PostSchemaRegistry400Code =
   (typeof PostSchemaRegistry400Code)[keyof typeof PostSchemaRegistry400Code]
 
@@ -182,10 +182,10 @@ export type PostSchemaRegistryBody =
   | SchemaRegistryPostProtobuf
 
 export type GetSchemaRegistry200Item =
+  | SchemaRegistryGetAvro
   | SchemaRegistryGetExternalHttp
   | SchemaRegistryGetJson
   | SchemaRegistryGetProtobuf
-  | SchemaRegistryGetAvro
 
 export type SchemaRegistryPutProtobufType =
   (typeof SchemaRegistryPutProtobufType)[keyof typeof SchemaRegistryPutProtobufType]
@@ -474,16 +474,16 @@ export const EmqxSslClientOptsVerify = {
   verify_peer: 'verify_peer',
 } as const
 
-export type EmqxSslClientOptsServerNameIndication = string | 'disable'
+export type EmqxSslClientOptsServerNameIndication = 'disable' | string
 
 export type EmqxSslClientOptsPartialChain =
   (typeof EmqxSslClientOptsPartialChain)[keyof typeof EmqxSslClientOptsPartialChain]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmqxSslClientOptsPartialChain = {
-  cacert_from_cacertfile: 'cacert_from_cacertfile',
   false: false,
   true: true,
+  cacert_from_cacertfile: 'cacert_from_cacertfile',
   two_cacerts_from_cacertfile: 'two_cacerts_from_cacertfile',
 } as const
 

--- a/src/types/schemas/schemaValidation.schemas.ts
+++ b/src/types/schemas/schemaValidation.schemas.ts
@@ -131,6 +131,34 @@ export type PostSchemaValidations400 = {
   message?: string
 }
 
+export interface SchemaValidationHttpApiReorder {
+  order: string[]
+}
+
+export interface SchemaValidationHttpApiNodeMetrics {
+  /** @minimum 0 */
+  failed?: number
+  /** @minimum 0 */
+  matched?: number
+  node?: string
+  /** @minimum 0 */
+  succeeded?: number
+}
+
+export interface SchemaValidationHttpApiMetrics {
+  /** @minimum 0 */
+  failed?: number
+  /** @minimum 0 */
+  matched?: number
+  /** @minimum 0 */
+  succeeded?: number
+}
+
+export interface SchemaValidationHttpApiGetMetrics {
+  metrics?: SchemaValidationHttpApiMetrics
+  node_metrics?: SchemaValidationHttpApiNodeMetrics
+}
+
 export type SchemaValidationValidationTopics = string[] | string
 
 export type SchemaValidationValidationStrategy =
@@ -151,13 +179,6 @@ export const SchemaValidationValidationFailureAction = {
   drop: 'drop',
   ignore: 'ignore',
 } as const
-
-export type SchemaValidationValidationChecksItem =
-  | SchemaValidationCheckExternalHttp
-  | SchemaValidationCheckProtobuf
-  | SchemaValidationCheckAvro
-  | SchemaValidationCheckJson
-  | SchemaValidationCheckSql
 
 export type SchemaValidationLogFailureLevel =
   (typeof SchemaValidationLogFailureLevel)[keyof typeof SchemaValidationLogFailureLevel]
@@ -215,6 +236,13 @@ export interface SchemaValidationCheckProtobuf {
   type?: SchemaValidationCheckProtobufType
 }
 
+export type SchemaValidationValidationChecksItem =
+  | SchemaValidationCheckAvro
+  | SchemaValidationCheckExternalHttp
+  | SchemaValidationCheckJson
+  | SchemaValidationCheckProtobuf
+  | SchemaValidationCheckSql
+
 export type SchemaValidationCheckJsonType =
   (typeof SchemaValidationCheckJsonType)[keyof typeof SchemaValidationCheckJsonType]
 
@@ -252,32 +280,4 @@ export const SchemaValidationCheckAvroType = {
 export interface SchemaValidationCheckAvro {
   schema: string
   type?: SchemaValidationCheckAvroType
-}
-
-export interface SchemaValidationHttpApiReorder {
-  order: string[]
-}
-
-export interface SchemaValidationHttpApiNodeMetrics {
-  /** @minimum 0 */
-  failed?: number
-  /** @minimum 0 */
-  matched?: number
-  node?: string
-  /** @minimum 0 */
-  succeeded?: number
-}
-
-export interface SchemaValidationHttpApiMetrics {
-  /** @minimum 0 */
-  failed?: number
-  /** @minimum 0 */
-  matched?: number
-  /** @minimum 0 */
-  succeeded?: number
-}
-
-export interface SchemaValidationHttpApiGetMetrics {
-  metrics?: SchemaValidationHttpApiMetrics
-  node_metrics?: SchemaValidationHttpApiNodeMetrics
 }

--- a/src/types/schemas/slowSubscriptions.schemas.ts
+++ b/src/types/schemas/slowSubscriptions.schemas.ts
@@ -3,8 +3,8 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetSlowSubscriptionsParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
 }
 
 export interface SlowSubscribersStatisticsRecord {

--- a/src/types/schemas/sources.schemas.ts
+++ b/src/types/schemas/sources.schemas.ts
@@ -1,3 +1,88 @@
+export type GetSourcesSummaryParams = {
+  ns?: string
+  only_global?: boolean
+}
+
+export type PostSourcesProbe400Code =
+  (typeof PostSourcesProbe400Code)[keyof typeof PostSourcesProbe400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostSourcesProbe400Code = {
+  TEST_FAILED: 'TEST_FAILED',
+} as const
+
+export type PostSourcesProbe400 = {
+  code?: PostSourcesProbe400Code
+  message?: string
+}
+
+export type PostSourcesProbeBody =
+  | ActionSourceAzureEventGridPostSource
+  | BridgeMqttPublisherPostSource
+  | BridgeRabbitmqPostSource
+  | GcpPubsubConsumerPostSource
+  | KafkaConsumerPostSource
+
+export type PostSourcesProbeParams = {
+  ns?: string
+}
+
+export type PostSourcesIdOperation503Code =
+  (typeof PostSourcesIdOperation503Code)[keyof typeof PostSourcesIdOperation503Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostSourcesIdOperation503Code = {
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+} as const
+
+export type PostSourcesIdOperation503 = {
+  code?: PostSourcesIdOperation503Code
+  message?: string
+}
+
+export type PostSourcesIdOperation501Code =
+  (typeof PostSourcesIdOperation501Code)[keyof typeof PostSourcesIdOperation501Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostSourcesIdOperation501Code = {
+  NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
+} as const
+
+export type PostSourcesIdOperation501 = {
+  code?: PostSourcesIdOperation501Code
+  message?: string
+}
+
+export type PostSourcesIdOperation404Code =
+  (typeof PostSourcesIdOperation404Code)[keyof typeof PostSourcesIdOperation404Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostSourcesIdOperation404Code = {
+  NOT_FOUND: 'NOT_FOUND',
+} as const
+
+export type PostSourcesIdOperation404 = {
+  code?: PostSourcesIdOperation404Code
+  message?: string
+}
+
+export type PostSourcesIdOperation400Code =
+  (typeof PostSourcesIdOperation400Code)[keyof typeof PostSourcesIdOperation400Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostSourcesIdOperation400Code = {
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+export type PostSourcesIdOperation400 = {
+  code?: PostSourcesIdOperation400Code
+  message?: string
+}
+
+export type PostSourcesIdOperationParams = {
+  ns?: string
+}
+
 export type PutSourcesIdMetricsReset404Code =
   (typeof PutSourcesIdMetricsReset404Code)[keyof typeof PutSourcesIdMetricsReset404Code]
 
@@ -64,62 +149,6 @@ export type PutSourcesIdEnableEnable404 = {
 }
 
 export type PutSourcesIdEnableEnableParams = {
-  ns?: string
-}
-
-export type PostSourcesIdOperation503Code =
-  (typeof PostSourcesIdOperation503Code)[keyof typeof PostSourcesIdOperation503Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostSourcesIdOperation503Code = {
-  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
-} as const
-
-export type PostSourcesIdOperation503 = {
-  code?: PostSourcesIdOperation503Code
-  message?: string
-}
-
-export type PostSourcesIdOperation501Code =
-  (typeof PostSourcesIdOperation501Code)[keyof typeof PostSourcesIdOperation501Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostSourcesIdOperation501Code = {
-  NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
-} as const
-
-export type PostSourcesIdOperation501 = {
-  code?: PostSourcesIdOperation501Code
-  message?: string
-}
-
-export type PostSourcesIdOperation404Code =
-  (typeof PostSourcesIdOperation404Code)[keyof typeof PostSourcesIdOperation404Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostSourcesIdOperation404Code = {
-  NOT_FOUND: 'NOT_FOUND',
-} as const
-
-export type PostSourcesIdOperation404 = {
-  code?: PostSourcesIdOperation404Code
-  message?: string
-}
-
-export type PostSourcesIdOperation400Code =
-  (typeof PostSourcesIdOperation400Code)[keyof typeof PostSourcesIdOperation400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostSourcesIdOperation400Code = {
-  BAD_REQUEST: 'BAD_REQUEST',
-} as const
-
-export type PostSourcesIdOperation400 = {
-  code?: PostSourcesIdOperation400Code
-  message?: string
-}
-
-export type PostSourcesIdOperationParams = {
   ns?: string
 }
 
@@ -245,35 +274,6 @@ export type DeleteSourcesIdParams = {
   ns?: string
 }
 
-export type GetSourcesSummaryParams = {
-  ns?: string
-  only_global?: boolean
-}
-
-export type PostSourcesProbe400Code =
-  (typeof PostSourcesProbe400Code)[keyof typeof PostSourcesProbe400Code]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PostSourcesProbe400Code = {
-  TEST_FAILED: 'TEST_FAILED',
-} as const
-
-export type PostSourcesProbe400 = {
-  code?: PostSourcesProbe400Code
-  message?: string
-}
-
-export type PostSourcesProbeBody =
-  | ActionSourceAzureEventGridPostSource
-  | BridgeMqttPublisherPostSource
-  | BridgeRabbitmqPostSource
-  | GcpPubsubConsumerPostSource
-  | KafkaConsumerPostSource
-
-export type PostSourcesProbeParams = {
-  ns?: string
-}
-
 export type PostSources400Code = (typeof PostSources400Code)[keyof typeof PostSources400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -305,11 +305,11 @@ export type PostSourcesParams = {
 }
 
 export type GetSources200Item =
-  | BridgeRabbitmqGetSource
-  | BridgeMqttPublisherGetSource
-  | KafkaConsumerGetSource
-  | GcpPubsubConsumerGetSource
   | ActionSourceAzureEventGridGetSource
+  | BridgeMqttPublisherGetSource
+  | BridgeRabbitmqGetSource
+  | GcpPubsubConsumerGetSource
+  | KafkaConsumerGetSource
 
 export type GetSourcesParams = {
   ns?: string

--- a/src/types/schemas/sources.schemas.ts
+++ b/src/types/schemas/sources.schemas.ts
@@ -495,6 +495,7 @@ export interface GcpPubsubConsumerSourceResourceOpts {
 }
 
 export interface GcpPubsubConsumerSourceParameters {
+  ack_deadline?: string
   /** @minimum 1 */
   pull_max_messages?: number
   topic: string

--- a/src/types/schemas/subscriptions.schemas.ts
+++ b/src/types/schemas/subscriptions.schemas.ts
@@ -29,15 +29,15 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetSubscriptionsParams = {
-  page?: PublicPageParameter
   limit?: PublicLimitParameter
+  page?: PublicPageParameter
   node?: string
   clientid?: string
-  qos?: number
-  topic?: string
-  match_topic?: string
-  share_group?: string
   durable?: boolean
+  match_topic?: string
+  qos?: number
+  share_group?: string
+  topic?: string
 }
 
 export interface EmqxMgmtApiSubscriptionsSubscription {

--- a/src/types/schemas/tlsManagement.schemas.ts
+++ b/src/types/schemas/tlsManagement.schemas.ts
@@ -80,8 +80,8 @@ export const DeleteCertsNsNamespaceNameNameKind = {
 } as const
 
 export type DeleteCertsNsNamespaceNameNameParams = {
-  kind?: DeleteCertsNsNamespaceNameNameKind
   force_delete?: boolean
+  kind?: DeleteCertsNsNamespaceNameNameKind
 }
 
 export type GetCertsNsNamespaceList500Code =
@@ -179,8 +179,8 @@ export const DeleteCertsGlobalNameNameKind = {
 } as const
 
 export type DeleteCertsGlobalNameNameParams = {
-  kind?: DeleteCertsGlobalNameNameKind
   force_delete?: boolean
+  kind?: DeleteCertsGlobalNameNameKind
 }
 
 export type GetCertsGlobalList500Code =

--- a/src/types/schemas/topics.schemas.ts
+++ b/src/types/schemas/topics.schemas.ts
@@ -21,10 +21,10 @@ export type PublicPageParameter = number
 export type PublicLimitParameter = number
 
 export type GetTopicsParams = {
+  limit?: PublicLimitParameter
+  page?: PublicPageParameter
   topic?: string
   node?: string
-  page?: PublicPageParameter
-  limit?: PublicLimitParameter
 }
 
 export interface PublicMeta {

--- a/src/types/schemas/trace.schemas.ts
+++ b/src/types/schemas/trace.schemas.ts
@@ -90,7 +90,7 @@ export type GetTraceNameLog400 = {
   message?: string
 }
 
-export type GetTraceNameLog200MetaPosition = string | number
+export type GetTraceNameLog200MetaPosition = number | string
 
 export type GetTraceNameLog200MetaHint =
   (typeof GetTraceNameLog200MetaHint)[keyof typeof GetTraceNameLog200MetaHint]
@@ -118,8 +118,8 @@ export type GetTraceNameLog200 = {
 
 export type GetTraceNameLogParams = {
   bytes?: TraceBytesParameter
-  position?: TracePositionParameter
   node?: TraceNodeParameter
+  position?: TracePositionParameter
 }
 
 export type GetTraceNameDownload404Code =
@@ -184,7 +184,7 @@ export type PostTraceParams = {
   ns?: string
 }
 
-export type TracePositionParameter = string | number
+export type TracePositionParameter = number | string
 
 export type TraceNodeParameter = string
 
@@ -200,7 +200,7 @@ export const TraceTraceParamsType = {
   topic: 'topic',
 } as const
 
-export type TraceTraceParamsStartAt = number | string
+export type TraceTraceParamsStartAt = string | number
 
 export type TraceTraceParamsPayloadEncode =
   (typeof TraceTraceParamsPayloadEncode)[keyof typeof TraceTraceParamsPayloadEncode]
@@ -215,7 +215,7 @@ export const TraceTraceParamsPayloadEncode = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TraceTraceParamsFormatter = { json: 'json', text: 'text' } as const
 
-export type TraceTraceParamsEndAt = number | string
+export type TraceTraceParamsEndAt = string | number
 
 export interface TraceTraceParams {
   clientid?: string
@@ -250,7 +250,7 @@ export const TraceTraceStatus = {
   waiting: 'waiting',
 } as const
 
-export type TraceTraceStartAt = number | string
+export type TraceTraceStartAt = string | number
 
 export type TraceTracePayloadEncode =
   (typeof TraceTracePayloadEncode)[keyof typeof TraceTracePayloadEncode]
@@ -267,7 +267,7 @@ export type TraceTraceLogSizeItem = { [key: string]: unknown }
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TraceTraceFormatter = { json: 'json', text: 'text' } as const
 
-export type TraceTraceEndAt = number | string
+export type TraceTraceEndAt = string | number
 
 export interface TraceTrace {
   clientid?: string

--- a/src/types/schemas/trace.schemas.ts
+++ b/src/types/schemas/trace.schemas.ts
@@ -1,3 +1,15 @@
+export type PutTracing403Code = (typeof PutTracing403Code)[keyof typeof PutTracing403Code]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutTracing403Code = {
+  UNAUTHORIZED_ROLE: 'UNAUTHORIZED_ROLE',
+} as const
+
+export type PutTracing403 = {
+  code?: PutTracing403Code
+  message?: string
+}
+
 export type PutTracing400Code = (typeof PutTracing400Code)[keyof typeof PutTracing400Code]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/src/views/General/resource_dict.json
+++ b/src/views/General/resource_dict.json
@@ -983,6 +983,14 @@
       },
       {
         "method": "delete",
+        "path": "/mqtt/topic_metrics2",
+        "name_label": {
+          "en": "Delete every topic-metric collection visible to the caller",
+          "zh": "删除调用方可见的所有主题监控集合"
+        }
+      },
+      {
+        "method": "delete",
         "path": "/mqtt/delayed/messages/:node/:msgid",
         "name_label": {
           "en": "Delete delayed message",


### PR DESCRIPTION
Generate an ephemeral dashboard password and use a bearer token to download the authenticated Swagger document.

Reuse the local Swagger file for schema generation and audit checks, improve schema diff detection, use frozen pnpm installs, and always clean up test containers.