### PR TITLE
feat(user): support role-default scopes

### DIFF
--- a/src/common/scopes.ts
+++ b/src/common/scopes.ts
@@ -1,9 +1,11 @@
-import type { DashboardScopes, LegacyUnsetScopes } from '@/types/systemModule'
+import type { DashboardScopes, UnsetScopes } from '@/types/systemModule'
 
-export const LEGACY_UNSET_SCOPES = 'unset'
+export const UNSET_SCOPES: UnsetScopes = 'unset'
+export const LEGACY_UNSET_SCOPES = UNSET_SCOPES
 
-export const isLegacyUnsetScopes = (scopes: unknown): scopes is LegacyUnsetScopes =>
-  scopes === LEGACY_UNSET_SCOPES
+export const isUnsetScopes = (scopes: unknown): scopes is UnsetScopes => scopes === UNSET_SCOPES
+
+export const isLegacyUnsetScopes = isUnsetScopes
 
 export const normalizeScopes = (scopes: DashboardScopes): string[] | undefined =>
   Array.isArray(scopes) ? scopes : undefined

--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -56,16 +56,50 @@ export default {
     en: 'Scopes',
   },
   userScopesPlaceholder: {
-    zh: '未选择时按角色默认权限授权',
-    en: 'When empty, fall back to the role default',
+    zh: '未选择时，不授予任何权限范围',
+    en: 'When empty, grant no scopes',
+  },
+  useRoleDefaultScopes: {
+    zh: '使用角色默认权限',
+    en: 'Use Role Default Scopes',
+  },
+  roleDefaultScopes: {
+    zh: '角色默认权限',
+    en: 'Role Default Scopes',
+  },
+  noUserScopes: {
+    zh: '无权限范围',
+    en: 'No Scopes',
+  },
+  roleDefaultScopesFormDesc: {
+    zh: '开启后，用户会自动获得其角色和所属范围（全局或命名空间）的默认权限。以后角色的默认权限发生变化时，新权限也会自动生效，无需再次编辑用户。',
+    en: 'When enabled, the user automatically receives the default permissions for its role and scope (Global or Namespace). If the role defaults change later, the updated permissions take effect automatically without editing the user again.',
+  },
+  userScopesColumnDesc: {
+    zh: '权限范围用于限定用户可以访问的功能类别。显示“角色默认权限”表示用户会自动继承当前角色的默认设置；显示具体权限标签表示用户使用显式配置。',
+    en: 'Scopes limit which feature areas a user can access. “Role Default Scopes” means the user automatically inherits the defaults of its current role; individual scope tags indicate an explicit configuration.',
+  },
+  roleDefaultScopesByRoleDesc: {
+    zh: `**各角色的默认权限**
+
+- **全局管理员**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License、用户管理、MFA 管理、SSO 管理、API 密钥管理
+- **全局查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
+- **命名空间管理员**：连接、监控、数据集成、访问控制、系统设置、集群管理、License、用户管理、API 密钥管理
+- **命名空间查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License`,
+    en: `**Default permissions by role**
+
+- **Global Administrator**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, License, User Management, MFA Management, SSO Management, and API Key Management
+- **Global Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
+- **Namespace Administrator**: Connections, Monitoring, Data Integration, Access Control, System, Cluster, License, User Management, and API Key Management
+- **Namespace Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License`,
+  },
+  roleDefaultScopesRestrictionDesc: {
+    zh: '上述权限范围决定用户可访问的功能类别；具体可执行的操作和可查看的数据，仍受角色和命名空间限制。',
+    en: "These permissions determine which feature areas the user can access. The allowed operations and visible data are still restricted by the user's role and Namespace.",
   },
   userScopesAdminOnlyTip: {
     zh: '仅管理员可持有此权限范围',
     en: 'Only administrators may hold this scope',
-  },
-  legacyUserScopesTip: {
-    zh: '该用户的权限范围未设置，请编辑并保存权限范围。',
-    en: 'This user has no scopes set. Edit and save the scopes.',
   },
   source: {
     zh: '来源',

--- a/src/types/schemas/dashboard.schemas.ts
+++ b/src/types/schemas/dashboard.schemas.ts
@@ -150,7 +150,7 @@ export type PutUsersUsername200 = {
 export type PutUsersUsernameBody = {
   description?: string
   role?: string
-  scopes?: string[]
+  scopes?: string[] | 'unset'
 }
 
 export type PutUsersUsernameBackend =
@@ -236,7 +236,7 @@ export type PostUsersBody = {
   /** @maxLength 100 */
   password?: string
   role?: string
-  scopes?: string[]
+  scopes?: string[] | 'unset'
   /** @maxLength 100 */
   username?: string
 }

--- a/src/types/systemModule.d.ts
+++ b/src/types/systemModule.d.ts
@@ -1,9 +1,10 @@
 import { ExhookFailedAction, ExhookStatus, UserRole } from './enum'
 import { SSL } from './common'
 
-export type LegacyUnsetScopes = 'unset'
+export type UnsetScopes = 'unset'
+export type LegacyUnsetScopes = UnsetScopes
 
-export type DashboardScopes = string[] | LegacyUnsetScopes | null | undefined
+export type DashboardScopes = string[] | UnsetScopes | null | undefined
 
 export interface APIKeyScope {
   name: string

--- a/src/views/General/Users.vue
+++ b/src/views/General/Users.vue
@@ -18,14 +18,18 @@
           {{ getSourceLabel(row.backend) }}
         </template>
       </el-table-column>
-      <el-table-column :label="tl('userScopes')" :min-width="220">
+      <el-table-column :label="tl('userScopes')" :min-width="200">
+        <template #header>
+          <FormItemLabel
+            :label="tl('userScopes')"
+            :desc="userScopesColumnDesc"
+            desc-marked
+            :max-height="400"
+            popper-class="role-default-scopes-tooltip"
+          />
+        </template>
         <template #default="{ row }">
-          <template v-if="isLegacyUnsetScopes(row.scopes)">
-            <span>{{ t('APIKey.allScopes') }}</span>
-            <el-tooltip :content="tl('legacyUserScopesTip')" placement="top">
-              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
-            </el-tooltip>
-          </template>
+          <span v-if="usesRoleDefaultScopes(row.scopes)">{{ tl('roleDefaultScopes') }}</span>
           <template v-else-if="hasSelectedScopes(row.scopes)">
             <el-tag
               v-for="scope in row.scopes"
@@ -37,11 +41,10 @@
               {{ getScopeLabel(scope) }}
             </el-tag>
           </template>
-          <span v-else-if="row.scopes === null"> {{ t('APIKey.allScopes') }}</span>
-          <span v-else>-</span>
+          <span v-else>{{ tl('noUserScopes') }}</span>
         </template>
       </el-table-column>
-      <el-table-column :label="tl('mfa')" :min-width="280">
+      <el-table-column prop="mfa" :label="tl('mfa')" :min-width="isZh ? 128 : 230" sortable>
         <template #default="{ row }">
           <el-tag v-if="row.mfa" :type="isMFAEnabled(row.mfa) ? 'success' : 'info'" effect="light">
             {{ isMFAEnabled(row.mfa) ? t('Base.enabled') : getMFAMethodLabel(row.mfa) }}
@@ -56,7 +59,7 @@
           {{ row.namespace }}
         </template>
       </el-table-column>
-      <el-table-column :label="$t('Base.operation')" :min-width="386">
+      <el-table-column :label="$t('Base.operation')" :min-width="isZh ? 308 : 386">
         <template #default="{ row }">
           <TableButton :disabled="!$hasPermission('put')" @click="showDialog('edit', row)">
             {{ $t('Base.edit') }}
@@ -137,17 +140,23 @@
             </el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="accessType !== 'chPass'" prop="scopes">
+        <el-form-item v-if="accessType !== 'chPass'">
           <template #label>
-            <span>{{ tl('userScopes') }}</span>
-            <el-tooltip
-              v-if="record.scopesNeedUpdate"
-              :content="tl('legacyUserScopesTip')"
-              placement="top"
-            >
-              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
-            </el-tooltip>
+            <FormItemLabel
+              :label="tl('useRoleDefaultScopes')"
+              :desc="roleDefaultScopesFormDesc"
+              desc-marked
+              :max-height="400"
+              popper-class="role-default-scopes-tooltip"
+            />
           </template>
+          <el-switch v-model="record.useRoleDefaultScopes" />
+        </el-form-item>
+        <el-form-item
+          v-if="accessType !== 'chPass' && !record.useRoleDefaultScopes"
+          :label="tl('userScopes')"
+          prop="scopes"
+        >
           <el-select
             v-model="record.scopes"
             multiple
@@ -240,20 +249,22 @@
 import { getManagedNamespaceList } from '@/api/config'
 import { changePassword, createUser, destroyUser, loadUser, updateUser } from '@/api/function.ts'
 import { getLoginUserScopes } from '@/api/systemModule.ts'
-import {
-  hasSelectedScopes,
-  isLegacyUnsetScopes,
-  normalizeScopes,
-  sanitizeScopesForSubmit,
-} from '@/common/scopes'
+import { hasSelectedScopes, isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import { UserRole } from '@/types/enum.ts'
 import UserMFASettingDialog from './components/UserMFASettingDialog.vue'
-import { Warning } from '@element-plus/icons-vue'
 
 const SOURCE_LOCAL = 'local'
 
 const store = useStore()
 const { tl, t, te } = useI18nTl('General')
+const isZh = computed(() => /zh/.test(store.state.lang))
+
+const buildRoleDefaultScopesDesc = (intro) =>
+  [intro, tl('roleDefaultScopesByRoleDesc'), tl('roleDefaultScopesRestrictionDesc')].join('\n\n')
+const roleDefaultScopesFormDesc = computed(() =>
+  buildRoleDefaultScopesDesc(tl('roleDefaultScopesFormDesc')),
+)
+const userScopesColumnDesc = computed(() => buildRoleDefaultScopesDesc(tl('userScopesColumnDesc')))
 
 const dialogVisible = ref(false)
 const tableData = ref([])
@@ -289,6 +300,8 @@ const toggleNamespaceEnabled = () => {
 const { userRoleOptions } = useRole()
 
 const isAdminRole = computed(() => record.value.role === UserRole.Admin)
+
+const usesRoleDefaultScopes = (scopes) => scopes == null || isUnsetScopes(scopes)
 
 const getScopeLabel = (name) => {
   const key = `APIKey.scopeLabel_${name}`
@@ -418,6 +431,7 @@ const generateRawForm = () => ({
   password: '',
   namespace: '',
   scopes: [],
+  useRoleDefaultScopes: true,
 })
 
 const isCurrentUser = (user) => user === currentUser.value.username
@@ -433,7 +447,7 @@ const showDialog = (type = 'create', item = {}) => {
   if (type === 'edit') {
     record.value = Object.assign({}, item, {
       scopes: normalizeScopes(item.scopes) ?? [],
-      scopesNeedUpdate: isLegacyUnsetScopes(item.scopes),
+      useRoleDefaultScopes: usesRoleDefaultScopes(item.scopes),
     })
   } else if (type === 'chPass') {
     record.value = {
@@ -470,23 +484,13 @@ const getRecordForUpdating = () => {
   const ret = processUserRecordForSubmit(record.value)
   return buildUserPayload(ret, ['description', 'role', 'scopes'])
 }
-// Build the payload sent to POST/PUT /users.
-//
-// The backend distinguishes three states for the `scopes` field:
-//   - field absent / undefined → fall back to the user's role default
-//     (administrator, viewer, and SSO users all get the default scope list
-//     that belongs to their role).
-//   - explicit []              → reject every mapped path (rarely the
-//     intended meaning of "leave it empty" in the UI).
-//   - explicit [..names..]     → only those scopes are granted.
-//
-// The form's empty multi-select therefore must NOT be submitted as `[]`,
-// or the user would be silently locked out of every scope-mapped path.
-// Strip the field entirely when no scope is selected so the backend
-// applies the role default.
+// The role-default switch maps to the backend's `unset` sentinel. When the
+// switch is off, preserve the explicit array, including [] (deny all mapped
+// paths), so the two states are never conflated.
 const buildUserPayload = (rec, fields) => {
   const payload = pick(rec, fields)
-  return sanitizeScopesForSubmit(payload)
+  payload.scopes = rec.useRoleDefaultScopes ? UNSET_SCOPES : (normalizeScopes(rec.scopes) ?? [])
+  return payload
 }
 
 const save = async () => {
@@ -559,15 +563,13 @@ onBeforeMount(async () => {
   .el-tag {
     margin-right: 4px;
   }
-  .legacy-scopes-icon {
-    margin-left: 4px;
-    color: var(--el-color-warning);
-    cursor: help;
-    vertical-align: -2px;
-  }
   .mfa-label {
     text-wrap: nowrap;
   }
+}
+
+.role-default-scopes-tooltip {
+  max-width: 720px;
 }
 </style>
 


### PR DESCRIPTION
Add a switch to let users inherit the default scopes of their assigned role while preserving explicit scope selections, including empty arrays.

Document the default permissions for each role in the form and user table, distinguish inherited scopes from no scopes, and update API types to support the unset sentinel.

Improve user table column sizing and make the MFA column sortable.

fixes #3788 