### PR TITLE
fix(backup): add namespace selector for global admins

### DIFF
--- a/src/api/systemModule.ts
+++ b/src/api/systemModule.ts
@@ -9,9 +9,14 @@ import {
 } from '@/types/systemModule'
 import { AuditLogItem, GetAuditParams } from '@/types/typeAlias'
 import {
+  DeleteDataFilesFilenameParams,
   EmqxMgmtApiDataBackupFilesResponse,
   EmqxMgmtApiDataBackupBackupFileInfo,
   EmqxMgmtApiDataBackupImportRequestBody,
+  GetDataFilesFilenameParams,
+  GetDataFilesParams,
+  PostDataFilesParams,
+  PostDataImportParams,
 } from '@/types/schemas/dataBackup.schemas'
 
 // API key
@@ -63,33 +68,42 @@ export const queryAuditLogs = (
 
 // Data Backup
 export const getBackups = (
-  params = { page: 1, limit: 1000 },
+  params: GetDataFilesParams = { page: 1, limit: 1000 },
 ): Promise<EmqxMgmtApiDataBackupFilesResponse> => {
   return http.get('/data/files', { params })
 }
 export const createBackup = (): Promise<EmqxMgmtApiDataBackupBackupFileInfo> => {
   return http.post('/data/export')
 }
-export const deleteBackup = (fileName: string, node?: string): Promise<void> => {
-  const params = node ? { node } : undefined
+export const deleteBackup = (
+  fileName: string,
+  params?: DeleteDataFilesFilenameParams,
+): Promise<void> => {
   return http.delete(`/data/files/${fileName}`, { params })
 }
-export const restoreBackup = (payload: EmqxMgmtApiDataBackupImportRequestBody): Promise<void> => {
-  return http.post(`/data/import`, payload, { timeout: 600000 })
+export const restoreBackup = (
+  payload: EmqxMgmtApiDataBackupImportRequestBody,
+  params?: PostDataImportParams,
+): Promise<void> => {
+  return http.post(`/data/import`, payload, { params, timeout: 600000 })
 }
 export const downloadBackup = (
   fileName: string,
-  node?: string,
+  params?: GetDataFilesFilenameParams,
 ): Promise<{
   data: Blob
 }> => {
-  const params = node ? { node } : undefined
   return http.get(`/data/files/${fileName}`, { responseType: 'blob', params })
 }
-export const uploadBackup = (fileName: string, file: File): Promise<unknown> => {
+export const uploadBackup = (
+  fileName: string,
+  file: File,
+  params?: PostDataFilesParams,
+): Promise<unknown> => {
   const formData = new FormData()
   formData.append(fileName, file)
   return http.post('/data/files', formData, {
+    params,
     timeout: 600000,
   })
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -51,6 +51,7 @@ declare module 'vue' {
     Monaco: typeof import('./components/Monaco.vue')['default']
     MQTTIds: typeof import('./components/Connector/MQTTIds.vue')['default']
     MQTTNode: typeof import('./components/Connector/MQTTNode.vue')['default']
+    NamespaceSelect: typeof import('./components/Namespace/NamespaceSelect.vue')['default']
     ObjectArrayEditor: typeof import('./components/ObjectArrayEditor.vue')['default']
     Oneof: typeof import('./components/Oneof.vue')['default']
     OneofRefs: typeof import('./components/OneofRefs.vue')['default']

--- a/src/components/Namespace/NamespaceSelect.vue
+++ b/src/components/Namespace/NamespaceSelect.vue
@@ -1,0 +1,101 @@
+<!-- Backported from the newer enterprise branch and adapted to the current namespace API. -->
+<template>
+  <el-select
+    v-model="namespace"
+    class="namespace-select"
+    :clearable="clearable"
+    :disabled="disabled"
+    :loading="loading"
+    :placeholder="placeholder ?? t('BasicConfig.namespace')"
+    @change="handleChange"
+  >
+    <el-option
+      v-for="{ label, value } in namespaceOptions"
+      :key="value"
+      :label="label"
+      :value="value"
+    />
+  </el-select>
+</template>
+
+<script setup lang="ts">
+import { getManagedNamespaceList } from '@/api/config'
+import { OptionList } from '@/types/common'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string
+    global?: {
+      enable?: boolean
+      value?: string
+    }
+    placeholder?: string
+    clearable?: boolean
+    disabled?: boolean
+  }>(),
+  {
+    global: () => ({ enable: true, value: undefined }),
+    clearable: true,
+    disabled: false,
+  },
+)
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: string | undefined): void
+  (e: 'change', val: string | undefined): void
+  (e: 'loaded'): void
+}>()
+
+const toModelValue = (val: string | undefined) =>
+  val === GLOBAL_NAMESPACE ? props.global.value : val
+
+const namespace = computed({
+  get() {
+    if (props.global.enable && props.modelValue === props.global.value) {
+      return GLOBAL_NAMESPACE
+    }
+    return props.modelValue
+  },
+  set(val) {
+    emit('update:modelValue', toModelValue(val))
+  },
+})
+
+const { t } = useI18n()
+const store = useStore()
+const loading = ref(false)
+const namespaceOptions = ref<OptionList<string>>([])
+
+const globalNamespaceOption = computed(() => ({
+  label: t('BasicConfig.global'),
+  value: GLOBAL_NAMESPACE,
+}))
+const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
+const currentUserNamespace = computed(() => store.state.user.namespace)
+
+const loadNamespaceOptions = async () => {
+  loading.value = true
+  try {
+    const { data } = await getManagedNamespaceList({ limit: 10000 })
+    const availableNamespaces = isNamespaceUser.value
+      ? data.filter((item) => item === currentUserNamespace.value)
+      : data
+    namespaceOptions.value = [
+      ...(props.global.enable ? [globalNamespaceOption.value] : []),
+      ...availableNamespaces
+        .filter((item) => item && item !== GLOBAL_NAMESPACE)
+        .map((item) => ({ label: item, value: item })),
+    ]
+  } catch (error) {
+    namespaceOptions.value = props.global.enable ? [globalNamespaceOption.value] : []
+  } finally {
+    loading.value = false
+    emit('loaded')
+  }
+}
+
+const handleChange = (val: string | undefined) => {
+  emit('change', toModelValue(val))
+}
+
+loadNamespaceOptions()
+</script>

--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -509,9 +509,25 @@ export default {
     zh: '确认使用当前备份恢复?',
     en: 'Confirm to restore with current backup?',
   },
+  confirmNamespaceRestore: {
+    zh: '确认使用当前备份恢复命名空间 {namespace}？',
+    en: 'Restore namespace {namespace} from this backup?',
+  },
   restoreSuccess: {
     zh: '恢复成功',
     en: 'Restore successfully',
+  },
+  namespaceRestoreSuccess: {
+    zh: '备份已成功恢复至命名空间 {namespace}。',
+    en: 'Backup restored to namespace {namespace} successfully.',
+  },
+  namespaceUploadSuccess: {
+    zh: '备份已成功上传至命名空间 {namespace}。',
+    en: 'Backup uploaded to namespace {namespace} successfully.',
+  },
+  namespaceBackupOperationTip: {
+    zh: '当前正在管理命名空间 {namespace} 的备份。上传、下载、删除和恢复操作将作用于此命名空间。',
+    en: 'You are managing backups for namespace {namespace}. Upload, download, delete, and restore operations apply to this namespace.',
   },
   clearAllRetainedConfirm: {
     zh: '是否确定要清除全部保留消息？',

--- a/src/views/General/Backup.vue
+++ b/src/views/General/Backup.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="backup app-wrapper">
     <div class="section-header">
-      <div></div>
+      <div>
+        <NamespaceSelect
+          v-if="isGlobalAdmin"
+          v-model="selectedNamespace"
+          class="namespace-select"
+          :clearable="false"
+          :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+          @change="handleNamespaceChanged"
+        />
+      </div>
       <el-upload
         ref="UploadRef"
         class="upload-container"
@@ -16,8 +25,20 @@
           {{ tl('upload') }}
         </el-button>
       </el-upload>
-      <CreateButton :loading="createLoading" @click="handleCreateBackup" />
+      <CreateButton
+        :disabled="!$hasPermission('post') || isNamespaceBackupView"
+        :loading="createLoading"
+        @click="handleCreateBackup"
+      />
     </div>
+    <el-alert
+      v-if="isNamespaceBackupView"
+      class="ns-alert"
+      show-icon
+      type="info"
+      :closable="false"
+      :title="tl('namespaceBackupOperationTip', { namespace: namespaceParam ?? '' })"
+    />
     <el-table class="backup-table" :data="backupList" v-loading.lock="isTableLoading">
       <el-table-column prop="filename" min-width="125" :label="tl('filename')" />
       <el-table-column prop="node" min-width="128" :label="t('Dashboard.nodeName')" />
@@ -61,7 +82,9 @@ import {
   uploadBackup,
 } from '@/api/systemModule'
 import { PageData } from '@/types/common'
+import { UserRole } from '@/types/enum'
 import { EmqxMgmtApiDataBackupBackupFileInfo } from '@/types/schemas/dataBackup.schemas'
+import NamespaceSelect from '@/components/Namespace/NamespaceSelect.vue'
 import { Upload } from '@element-plus/icons-vue'
 import { createDownloadBlobLink, formatSizeUnit } from '@emqx/shared-ui-utils'
 import {
@@ -82,13 +105,27 @@ const createLoading = ref(false)
 const uploading = ref(false)
 const backupList = ref<BackupItem[]>([])
 const UploadRef = ref<UploadInstance>()
+const selectedNamespace = ref<string | undefined>(GLOBAL_NAMESPACE)
+const uploadingNamespace = ref<string | undefined>()
+
+const store = useStore()
+const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
+const isGlobalAdmin = computed(
+  () => !isNamespaceUser.value && store.state.user.role === UserRole.Admin,
+)
+const namespaceParam = computed(() =>
+  selectedNamespace.value === GLOBAL_NAMESPACE ? undefined : selectedNamespace.value,
+)
+const isNamespaceBackupView = computed(
+  () => isGlobalAdmin.value && namespaceParam.value !== undefined,
+)
 
 const { pageParams, pageMeta, initPageMeta, setPageMeta } = usePaginationWithHasNext()
 const { t, tl } = useI18nTl('General')
 
 const loadBackupFiles = async (params = {}) => {
   isTableLoading.value = true
-  const sendParams = { ...pageParams.value, ...params }
+  const sendParams = { ...pageParams.value, ...params, namespace: namespaceParam.value }
   try {
     const { data, meta } = await getBackups(sendParams)
     backupList.value = data as BackupItem[]
@@ -109,6 +146,10 @@ const refreshListData = () => {
   loadBackupFiles()
 }
 
+const handleNamespaceChanged = () => {
+  refreshListData()
+}
+
 const handleCreateBackup = async () => {
   createLoading.value = true
   try {
@@ -122,9 +163,12 @@ const handleCreateBackup = async () => {
   }
 }
 
-const store = useStore()
 const handleRestoreBackup = async (backup: BackupItem) => {
-  ElMessageBox.confirm(tl('confirmRestore'), {
+  const targetNamespace = namespaceParam.value
+  const confirmMessage = targetNamespace
+    ? tl('confirmNamespaceRestore', { namespace: targetNamespace })
+    : tl('confirmRestore')
+  ElMessageBox.confirm(confirmMessage, {
     confirmButtonText: t('Base.confirm'),
     cancelButtonText: t('Base.cancel'),
     type: 'info',
@@ -133,8 +177,15 @@ const handleRestoreBackup = async (backup: BackupItem) => {
         instance.confirmButtonLoading = true
         try {
           const { filename, node } = backup
-          await restoreBackup({ filename, node })
-          ElMessage.success(tl('restoreSuccess'))
+          await restoreBackup(
+            { filename, node },
+            targetNamespace ? { namespace: targetNamespace } : undefined,
+          )
+          ElMessage.success(
+            targetNamespace
+              ? tl('namespaceRestoreSuccess', { namespace: targetNamespace })
+              : tl('restoreSuccess'),
+          )
           done()
         } catch (error) {
           done()
@@ -148,6 +199,7 @@ const handleRestoreBackup = async (backup: BackupItem) => {
 }
 
 const handleDeleteBackup = async ({ filename, node }: BackupItem) => {
+  const targetNamespace = namespaceParam.value
   ElMessageBox.confirm(t('Base.confirmDelete'), {
     confirmButtonText: t('Base.confirm'),
     cancelButtonText: t('Base.cancel'),
@@ -157,7 +209,7 @@ const handleDeleteBackup = async ({ filename, node }: BackupItem) => {
       if (action === 'confirm') {
         instance.confirmButtonLoading = true
         try {
-          await deleteBackup(filename, node)
+          await deleteBackup(filename, { node, namespace: targetNamespace })
           ElMessage.success(t('Base.deleteSuccess'))
           refreshListData()
           done()
@@ -172,7 +224,8 @@ const handleDeleteBackup = async ({ filename, node }: BackupItem) => {
 }
 
 const handleDownloadBackup = async ({ filename, node }: BackupItem) => {
-  const res = await downloadBackup(filename, node)
+  const targetNamespace = namespaceParam.value
+  const res = await downloadBackup(filename, { node, namespace: targetNamespace })
   if (res.data) {
     createDownloadBlobLink(res.data, filename)
   }
@@ -180,13 +233,20 @@ const handleDownloadBackup = async ({ filename, node }: BackupItem) => {
 
 const handleUploadSuccess = () => {
   uploading.value = false
-  ElMessage.success(t('Dashboard.uploadedSuccessfully'))
+  const targetNamespace = uploadingNamespace.value
+  ElMessage.success(
+    targetNamespace
+      ? tl('namespaceUploadSuccess', { namespace: targetNamespace })
+      : t('Dashboard.uploadedSuccessfully'),
+  )
+  uploadingNamespace.value = undefined
   loadBackupFiles()
   UploadRef.value?.clearFiles()
 }
 
 const handleUploadError = () => {
   uploading.value = false
+  uploadingNamespace.value = undefined
   loadBackupFiles()
   UploadRef.value?.clearFiles()
 }
@@ -196,7 +256,13 @@ const customUploadRequest: UploadRequestHandler = async (
 ): Promise<unknown> => {
   uploading.value = true
   const { filename, file } = options
-  return await uploadBackup(filename, file)
+  const targetNamespace = namespaceParam.value
+  uploadingNamespace.value = targetNamespace
+  return await uploadBackup(
+    filename,
+    file,
+    targetNamespace ? { namespace: targetNamespace } : undefined,
+  )
 }
 </script>
 
@@ -207,5 +273,13 @@ const customUploadRequest: UploadRequestHandler = async (
   align-items: center;
   justify-content: space-around;
   gap: 12px;
+}
+
+.namespace-select {
+  width: 240px;
+}
+
+.ns-alert {
+  margin-bottom: 16px;
 }
 </style>


### PR DESCRIPTION
- backport the namespace selector using the managed namespace API
- scope backup listing and operations to the selected namespace
- correct namespace restore confirmation and operation guidance