### PR TITLE
fix(certificates): remove force delete for referenced certificates

### DIFF
--- a/src/api/tlsManagement.ts
+++ b/src/api/tlsManagement.ts
@@ -23,11 +23,11 @@ export const getGlobalCertBundleInfo = (name: string): Promise<CertBundleInfo> =
 
 export const deleteGlobalCertBundle = (
   name: string,
-  options?: { kind?: CertKind; forceDelete?: boolean },
+  options?: { kind?: CertKind },
 ): Promise<void> => {
-  const { kind, forceDelete } = options ?? {}
+  const { kind } = options ?? {}
   return http.delete(`/certs/global/name/${encodeURIComponent(name)}`, {
-    params: { kind, ...(forceDelete ? { force_delete: true } : {}) },
+    params: { kind },
     errorsHandleCustom: CERT_CUSTOM_ERRORS,
   })
 }
@@ -57,13 +57,13 @@ export const getNamespaceCertBundleInfo = (
 export const deleteNamespaceCertBundle = (
   namespace: string,
   name: string,
-  options?: { kind?: CertKind; forceDelete?: boolean },
+  options?: { kind?: CertKind },
 ): Promise<void> => {
-  const { kind, forceDelete } = options ?? {}
+  const { kind } = options ?? {}
   return http.delete(
     `/certs/ns/${encodeURIComponent(namespace)}/name/${encodeURIComponent(name)}`,
     {
-      params: { kind, ...(forceDelete ? { force_delete: true } : {}) },
+      params: { kind },
       errorsHandleCustom: CERT_CUSTOM_ERRORS,
     },
   )

--- a/src/components/TLSConfig/CertBundleDrawer.vue
+++ b/src/components/TLSConfig/CertBundleDrawer.vue
@@ -32,7 +32,6 @@
     v-model="isInUseDialogShow"
     :referencing-configs="certInUseError?.referencingConfigs"
     is-cert-file
-    @force-delete="handleForceDelete"
   />
 </template>
 
@@ -147,7 +146,7 @@ const isSubmitting = ref(false)
 const isInUseDialogShow = ref(false)
 const certInUseError = ref<CertInUseError | null>(null)
 
-const { submitCertBundle, removeUselessCerts, forceRemoveCerts } = useCertBundle()
+const { submitCertBundle, removeUselessCerts } = useCertBundle()
 
 const finishSubmit = () => {
   const message = isEditing.value ? t('Base.updateSuccess') : t('Base.createSuccess')
@@ -165,7 +164,7 @@ const submit = async () => {
       try {
         await removeUselessCerts(formData.value, initialFormData)
       } catch (removeError: any) {
-        if (removeError?.failedKinds) {
+        if (removeError?.referencingConfigs) {
           certInUseError.value = removeError
           isInUseDialogShow.value = true
           return
@@ -178,18 +177,6 @@ const submit = async () => {
     //
   } finally {
     isSubmitting.value = false
-  }
-}
-
-const handleForceDelete = async () => {
-  if (!certInUseError.value) {
-    return
-  }
-  try {
-    await forceRemoveCerts(formData.value, certInUseError.value.failedKinds)
-    finishSubmit()
-  } catch (error) {
-    //
   }
 }
 </script>

--- a/src/components/TLSConfig/CertBundleForm.vue
+++ b/src/components/TLSConfig/CertBundleForm.vue
@@ -37,7 +37,6 @@
     <template v-if="confMethod === CertBundleType.Regular">
       <el-form-item prop="chain" label="TLS Cert">
         <CertFileInput
-          class="TLS-input"
           v-model="record.chain"
           :is-edit="isEditing"
           :placeholder="t('Base.certPlaceholder')"
@@ -45,7 +44,6 @@
       </el-form-item>
       <el-form-item prop="key" label="TLS Key">
         <CertFileInput
-          class="TLS-input"
           v-model="record.key"
           :is-edit="isEditing"
           :placeholder="t('Base.keyFilePlaceholder')"
@@ -53,7 +51,6 @@
       </el-form-item>
       <el-form-item prop="key_password" :label="t('Base.keyPassword')">
         <CertFileInput
-          class="TLS-input"
           v-model="record.key_password"
           :is-edit="isEditing"
           :placeholder="t('Base.keyFilePlaceholder')"
@@ -72,7 +69,6 @@
 
     <el-form-item v-else prop="acc_key" :label="t('Base.acmeKey')">
       <CertFileInput
-        class="TLS-input"
         v-model="record.acc_key"
         :is-edit="isEditing"
         :accept="`${CER_FILE_ACCEPTS},.json`"
@@ -81,7 +77,6 @@
 
     <el-form-item prop="ca" label="CA Cert">
       <CertFileInput
-        class="TLS-input"
         v-model="record.ca"
         :is-edit="isEditing"
         :placeholder="t('Base.certPlaceholder')"

--- a/src/components/TLSConfig/CertBundleInUseDialog.vue
+++ b/src/components/TLSConfig/CertBundleInUseDialog.vue
@@ -29,9 +29,6 @@
     </ul>
     <template #footer>
       <CancelButton @click="isVisible = false" />
-      <el-button type="danger" @click="handleForceDelete">
-        {{ tl('forceDelete') }}
-      </el-button>
     </template>
   </el-dialog>
 </template>
@@ -58,7 +55,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
-  (e: 'forceDelete'): void
 }>()
 
 const { tl } = useI18nTl('BasicConfig')
@@ -196,11 +192,6 @@ const moduleGroups = computed((): RefGroup[] => {
     },
   )
 })
-
-const handleForceDelete = () => {
-  isVisible.value = false
-  emit('forceDelete')
-}
 </script>
 
 <style lang="scss">

--- a/src/hooks/useCertBundle.ts
+++ b/src/hooks/useCertBundle.ts
@@ -21,7 +21,6 @@ export type ReferencingConfigs = Record<string, ReferencingConfigPath[] | undefi
 
 export interface CertInUseError {
   referencingConfigs: ReferencingConfigs
-  failedKinds: CertKind[]
 }
 
 export enum CertBundleType {
@@ -69,12 +68,12 @@ const useCertBundle = () => {
     }
   }
 
-  const deleteCertFile = (formData: CertBundleForm, kind: CertKind, forceDelete?: boolean) => {
+  const deleteCertFile = (formData: CertBundleForm, kind: CertKind) => {
     const { name, namespace } = formData
     if (namespace) {
-      return deleteNamespaceCertBundle(namespace, name, { kind, forceDelete })
+      return deleteNamespaceCertBundle(namespace, name, { kind })
     }
-    return deleteGlobalCertBundle(name, { kind, forceDelete })
+    return deleteGlobalCertBundle(name, { kind })
   }
 
   const removeUselessCerts = async (currentForm: CertBundleForm, initialForm: CertBundleForm) => {
@@ -89,14 +88,14 @@ const useCertBundle = () => {
     const results = await Promise.allSettled(
       keysNeedRemove.map((kind: CertKind) => deleteCertFile(currentForm, kind)),
     )
-    const failedKinds: CertKind[] = []
+    let hasReferenceError = false
     const allReferencingConfigs: ReferencingConfigs = {}
     let firstUnhandledError: unknown
-    results.forEach((result, i) => {
+    results.forEach((result) => {
       if (result.status === 'rejected') {
         const referencingConfigs = (result.reason as any)?.response?.data?.referencing_configs
         if (referencingConfigs && typeof referencingConfigs === 'object') {
-          failedKinds.push(keysNeedRemove[i])
+          hasReferenceError = true
           Object.entries(referencingConfigs as ReferencingConfigs).forEach(
             ([namespace, entries]) => {
               if (!Array.isArray(entries)) {
@@ -122,17 +121,12 @@ const useCertBundle = () => {
     if (firstUnhandledError) {
       return Promise.reject(firstUnhandledError)
     }
-    if (failedKinds.length > 0) {
+    if (hasReferenceError) {
       const error: CertInUseError = {
         referencingConfigs: allReferencingConfigs,
-        failedKinds,
       }
       return Promise.reject(error)
     }
-  }
-
-  const forceRemoveCerts = (form: CertBundleForm, kinds: CertKind[]) => {
-    return Promise.all(kinds.map((kind) => deleteCertFile(form, kind, true)))
   }
 
   const getCertBundleList = async (namespace?: string) => {
@@ -142,11 +136,11 @@ const useCertBundle = () => {
     return await getGlobalCertBundleList()
   }
 
-  const deleteCertBundle = async (name: string, namespace?: string, forceDelete?: boolean) => {
+  const deleteCertBundle = async (name: string, namespace?: string) => {
     if (namespace) {
-      return deleteNamespaceCertBundle(namespace, name, { forceDelete })
+      return deleteNamespaceCertBundle(namespace, name)
     }
-    return deleteGlobalCertBundle(name, { forceDelete })
+    return deleteGlobalCertBundle(name)
   }
 
   const getCertBundleInfo = async (name: string, namespace?: string) => {
@@ -176,7 +170,6 @@ const useCertBundle = () => {
     createEmptyCertBundle,
     createEmptyCertBundleForm,
     removeUselessCerts,
-    forceRemoveCerts,
     submitCertBundle,
     getCertBundleList,
     deleteCertBundle,

--- a/src/i18n/BasicConfig.ts
+++ b/src/i18n/BasicConfig.ts
@@ -535,16 +535,12 @@ See EMQX documentation for expression syntax.`,
     en: 'Bundle In Use',
   },
   certBundleInUseDesc: {
-    zh: '以下配置正在使用该证书包，强制删除后可能导致相关配置失效',
-    en: 'The following configurations are currently using this bundle. Force deleting it may cause dependent configurations to fail.',
+    zh: '以下配置正在使用该证书包，请先移除引用后再删除',
+    en: 'The following configurations are currently using this bundle. Remove the references before deleting it.',
   },
   certBundleFileInUseDesc: {
-    zh: '以下配置正在使用该证书包，强制删除证书文件后可能导致相关配置失效',
-    en: 'The following configurations are currently using this bundle. Force deleting the cert file may cause dependent configurations to fail.',
-  },
-  forceDelete: {
-    zh: '强制删除',
-    en: 'Force Delete',
+    zh: '以下配置正在使用该证书包，请先移除引用后再删除证书文件',
+    en: 'The following configurations are currently using this bundle. Remove the references before deleting the certificate file.',
   },
   viewPage: {
     zh: '前往页面',

--- a/src/views/Config/BasicConfig/CertsManagement.vue
+++ b/src/views/Config/BasicConfig/CertsManagement.vue
@@ -41,11 +41,7 @@
     :namespace="selectedNamespace"
     @submit="handleSubmit"
   />
-  <CertBundleInUseDialog
-    v-model="isInUseDialogShow"
-    :referencing-configs="referencingConfigs"
-    @force-delete="handleForceDelete"
-  />
+  <CertBundleInUseDialog v-model="isInUseDialogShow" :referencing-configs="referencingConfigs" />
 </template>
 
 <script setup lang="ts">
@@ -99,7 +95,6 @@ const handleSubmit = async ({ namespace: ns }: ManagedCerts) => {
 
 const isInUseDialogShow = ref(false)
 const referencingConfigs = ref<ReferencingConfigs>({})
-const pendingDeleteName = ref('')
 
 const { confirmDel } = useOperationConfirm()
 const handleDelete = async (row: CertBundleOut) => {
@@ -114,21 +109,10 @@ const handleDelete = async (row: CertBundleOut) => {
     const refConfigs = error?.response?.data?.referencing_configs
     if (refConfigs) {
       referencingConfigs.value = refConfigs
-      pendingDeleteName.value = name
       isInUseDialogShow.value = true
     } else if (error.response) {
       CustomMessage.error(getErrorMessage(error.response.data, error.response.status))
     }
-  }
-}
-
-const handleForceDelete = async () => {
-  try {
-    await deleteCertBundle(pendingDeleteName.value, selectedNamespace.value, true)
-    ElMessage.success(t('Base.deleteSuccess'))
-    getCertBundleList()
-  } catch (error) {
-    //
   }
 }
 


### PR DESCRIPTION
- remove force-delete actions and query parameters from certificate deletion
- keep reference details visible and require dependencies to be removed first
- remove TLS input class bindings from certificate bundle fields

Fixes #3823