### PR TITLE
feat(api key): support role-default scopes

### DIFF
--- a/src/common/scopes.ts
+++ b/src/common/scopes.ts
@@ -1,21 +1,11 @@
 import type { DashboardScopes, UnsetScopes } from '@/types/systemModule'
 
 export const UNSET_SCOPES: UnsetScopes = 'unset'
-export const LEGACY_UNSET_SCOPES = UNSET_SCOPES
 
 export const isUnsetScopes = (scopes: unknown): scopes is UnsetScopes => scopes === UNSET_SCOPES
-
-export const isLegacyUnsetScopes = isUnsetScopes
 
 export const normalizeScopes = (scopes: DashboardScopes): string[] | undefined =>
   Array.isArray(scopes) ? scopes : undefined
 
 export const hasSelectedScopes = (scopes: DashboardScopes): scopes is string[] =>
   Array.isArray(scopes) && scopes.length > 0
-
-export const sanitizeScopesForSubmit = <T extends { scopes?: DashboardScopes }>(data: T): T => {
-  if (!Array.isArray(data.scopes) || data.scopes.length === 0) {
-    delete data.scopes
-  }
-  return data
-}

--- a/src/i18n/APIKey.ts
+++ b/src/i18n/APIKey.ts
@@ -71,9 +71,25 @@ export default {
     zh: '未选择时，不授予任何权限范围',
     en: 'When empty, grant no scopes',
   },
-  useRoleDefaultScopes: {
-    zh: '使用角色默认权限',
-    en: 'Use Role Default Scopes',
+  scopeMode: {
+    zh: '权限模式',
+    en: 'Permission Mode',
+  },
+  scopeModeDesc: {
+    zh: `选择 API 密钥的权限配置方式：
+
+- **角色默认权限**：自动使用当前角色的默认权限。管理员和查看者可访问全部管理功能类别，发布者仅可发布消息；以后角色默认权限发生变化时，新权限会自动生效。
+- **系统级权限**：仅授予“系统设置”权限范围，可访问核心配置、监听器、插件、数据备份与恢复、OpenTelemetry 等系统功能。
+- **自定义受限权限**：从连接、消息发布、数据集成、监控等非系统权限范围中按需选择。未选择任何权限时，API 密钥不能访问受权限范围保护的接口。
+
+无论选择哪种模式，具体可执行的操作和可查看的数据仍受角色和命名空间限制。各角色的默认权限如下。`,
+    en: `Choose how permissions are assigned to the API key:
+
+- **Role Default Scopes**: Automatically use the current role's defaults. Administrators and viewers can access all management feature areas, while publishers can only publish messages. Future changes to the role defaults take effect automatically.
+- **System-level Permissions**: Grant only the System scope, covering core configuration, listeners, plugins, data backup and restore, OpenTelemetry, and other system functions. 
+- **Custom Restricted Permissions**: Select non-system scopes such as Connections, Publish, Data Integration, and Monitoring. When no scope is selected, the API key cannot access scope-protected APIs.
+
+In every mode, available operations and visible data remain restricted by the role and Namespace. The default scopes for each role are listed below.`,
   },
   roleDefaultScopes: {
     zh: '角色默认权限',
@@ -83,9 +99,21 @@ export default {
     zh: '无权限范围',
     en: 'No Scopes',
   },
-  roleDefaultScopesFormDesc: {
-    zh: '开启后，API 密钥会自动使用当前角色的默认权限。以后角色的默认权限发生变化时，新权限也会自动生效。',
-    en: "When enabled, the API key automatically uses its role's default scopes. If the role defaults change later, the updated permissions take effect automatically.",
+  scopeModeSystem: {
+    zh: '系统级权限',
+    en: 'System-level Permissions',
+  },
+  scopeModeCustom: {
+    zh: '自定义受限权限',
+    en: 'Custom Restricted Permissions',
+  },
+  customScopesSystemError: {
+    zh: '自定义受限权限不能包含“系统设置”权限范围，请移除该权限或选择“系统级权限”。',
+    en: 'Custom restricted permissions cannot include the System scope. Remove it or select System-level Permissions.',
+  },
+  mixedScopesMigrationDesc: {
+    zh: '此 API 密钥保存了旧版的混合权限配置。请移除“系统设置”后继续使用自定义受限权限，或改选“系统级权限”或“角色默认权限”。',
+    en: 'This API key contains a legacy mixed-scope configuration. Remove System to keep custom restricted permissions, or select System-level Permissions or Role Default Scopes.',
   },
   scopesColumnDesc: {
     zh: '权限范围用于限定 API 密钥可以访问的功能类别。显示“角色默认权限”表示自动继承当前角色的默认设置；具体权限标签表示使用显式配置；“无权限范围”表示该密钥不能访问受权限范围保护的接口。具体可执行的操作仍受角色和命名空间限制。',

--- a/src/i18n/APIKey.ts
+++ b/src/i18n/APIKey.ts
@@ -68,16 +68,44 @@ export default {
     en: 'Scopes',
   },
   scopesPlaceholder: {
-    zh: '未选择时按角色默认权限授权',
-    en: 'When empty, fall back to the role default',
+    zh: '未选择时，不授予任何权限范围',
+    en: 'When empty, grant no scopes',
   },
-  allScopes: {
-    zh: '全部',
-    en: 'All',
+  useRoleDefaultScopes: {
+    zh: '使用角色默认权限',
+    en: 'Use Role Default Scopes',
   },
-  legacyScopesTip: {
-    zh: '该 API 密钥的权限范围未设置，请编辑并保存权限范围。',
-    en: 'This API key has no scopes set. Edit and save its scopes.',
+  roleDefaultScopes: {
+    zh: '角色默认权限',
+    en: 'Role Default Scopes',
+  },
+  noScopes: {
+    zh: '无权限范围',
+    en: 'No Scopes',
+  },
+  roleDefaultScopesFormDesc: {
+    zh: '开启后，API 密钥会自动使用当前角色的默认权限。以后角色的默认权限发生变化时，新权限也会自动生效。',
+    en: "When enabled, the API key automatically uses its role's default scopes. If the role defaults change later, the updated permissions take effect automatically.",
+  },
+  scopesColumnDesc: {
+    zh: '权限范围用于限定 API 密钥可以访问的功能类别。显示“角色默认权限”表示自动继承当前角色的默认设置；具体权限标签表示使用显式配置；“无权限范围”表示该密钥不能访问受权限范围保护的接口。具体可执行的操作仍受角色和命名空间限制。',
+    en: 'Scopes limit which feature areas an API key can access. “Role Default Scopes” means the key automatically inherits the defaults of its current role; individual scope tags indicate an explicit configuration; “No Scopes” means the key cannot access scope-protected APIs. Allowed operations are still restricted by the role and Namespace.',
+  },
+  roleDefaultScopesByRoleDesc: {
+    zh: `**各角色的默认权限**
+
+- **全局管理员 / 全局查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
+- **命名空间管理员 / 命名空间查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
+- **发布者**：消息发布`,
+    en: `**Default permissions by role**
+
+- **Global Administrator / Global Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
+- **Namespace Administrator / Namespace Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
+- **Publisher**: Publish`,
+  },
+  roleDefaultScopesRestrictionDesc: {
+    zh: '上述权限范围决定 API 密钥可访问的功能类别；具体可执行的操作和可查看的数据仍受角色和命名空间限制。发布者只能使用消息发布权限。',
+    en: 'These scopes determine which feature areas the API key can access. Allowed operations and visible data are still restricted by its role and Namespace. Publishers can only use the Publish scope.',
   },
   scopeLabel_connections: {
     zh: '连接',

--- a/src/types/systemModule.d.ts
+++ b/src/types/systemModule.d.ts
@@ -2,7 +2,6 @@ import { ExhookFailedAction, ExhookStatus, UserRole } from './enum'
 import { SSL } from './common'
 
 export type UnsetScopes = 'unset'
-export type LegacyUnsetScopes = UnsetScopes
 
 export type DashboardScopes = string[] | UnsetScopes | null | undefined
 

--- a/src/views/General/APIKey.vue
+++ b/src/views/General/APIKey.vue
@@ -24,16 +24,18 @@
         </template>
       </el-table-column>
       <el-table-column prop="scopes" :label="tl('scopes')">
+        <template #header>
+          <FormItemLabel
+            :label="tl('scopes')"
+            :desc="scopesColumnDesc"
+            desc-marked
+            :max-height="400"
+            popper-class="role-default-scopes-tooltip"
+          />
+        </template>
         <template #default="{ row }">
-          <span v-if="row.role === UserRole.Publisher">-</span>
-          <template v-else-if="isLegacyUnsetScopes(row.scopes)">
-            <span>{{ tl('allScopes') }}</span>
-            <el-tooltip :content="tl('legacyScopesTip')" placement="top">
-              <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
-            </el-tooltip>
-          </template>
-          <span v-else-if="!hasSelectedScopes(row.scopes)">{{ tl('allScopes') }}</span>
-          <template v-else>
+          <span v-if="isUnsetScopes(row.scopes)">{{ tl('roleDefaultScopes') }}</span>
+          <template v-else-if="hasSelectedScopes(row.scopes)">
             <el-tag
               v-for="scope in row.scopes"
               :key="scope"
@@ -45,6 +47,7 @@
               {{ getScopeLabel(scope) }}
             </el-tag>
           </template>
+          <span v-else>{{ tl('noScopes') }}</span>
         </template>
       </el-table-column>
       <el-table-column :label="t('BasicConfig.namespace')">
@@ -88,14 +91,15 @@ import APIKeyDialog, { OperationType } from './components/APIKeyDialog.vue'
 import { deleteAPIKey, loadAPIKeyList, updateAPIKey } from '@/api/systemModule'
 import { GLOBAL_NAMESPACE } from '@/common/constants'
 import dayjs from 'dayjs'
-import { UserRole } from '@/types/enum'
-import { hasSelectedScopes, isLegacyUnsetScopes } from '@/common/scopes'
-import { Warning } from '@element-plus/icons-vue'
+import { hasSelectedScopes, isUnsetScopes } from '@/common/scopes'
 
 const { t, te } = useI18n()
 const tl = function (key: string, collection = 'APIKey') {
   return t(collection + '.' + key)
 }
+const buildRoleDefaultScopesDesc = (intro: string) =>
+  [intro, tl('roleDefaultScopesByRoleDesc'), tl('roleDefaultScopesRestrictionDesc')].join('\n\n')
+const scopesColumnDesc = computed(() => buildRoleDefaultScopesDesc(tl('scopesColumnDesc')))
 
 const isTableLoading = ref(false)
 const keyList: Ref<Array<APIKey>> = ref([])
@@ -183,11 +187,9 @@ getList()
     cursor: pointer;
     color: var(--el-color-primary);
   }
-  .legacy-scopes-icon {
-    margin-left: 4px;
-    color: var(--el-color-warning);
-    cursor: help;
-    vertical-align: -2px;
-  }
+}
+
+.role-default-scopes-tooltip {
+  max-width: 720px;
 }
 </style>

--- a/src/views/General/components/APIKeyDialog.vue
+++ b/src/views/General/components/APIKeyDialog.vue
@@ -106,23 +106,34 @@
           </el-form-item>
         </el-col>
         <el-col :span="24" v-if="!isPublisherRole">
-          <el-form-item>
+          <el-form-item prop="scopeMode">
             <template #label>
               <FormItemLabel
-                :label="tl('useRoleDefaultScopes')"
-                :desc="roleDefaultScopesFormDesc"
+                :label="tl('scopeMode')"
+                :desc="scopeModeDesc"
                 desc-marked
                 :max-height="400"
-                popper-class="role-default-scopes-tooltip"
+                popper-class="scope-mode-tooltip"
               />
             </template>
-            <el-switch
-              v-model="formData.useRoleDefaultScopes"
+            <el-radio-group
+              v-model="formData.scopeMode"
               :disabled="operationType === 'view'"
-            />
+              @change="handleScopeModeChanged"
+            >
+              <el-radio :value="ScopeMode.RoleDefault">
+                {{ tl('roleDefaultScopes') }}
+              </el-radio>
+              <el-radio :value="ScopeMode.System">
+                {{ tl('scopeModeSystem') }}
+              </el-radio>
+              <el-radio :value="ScopeMode.Custom">
+                {{ tl('scopeModeCustom') }}
+              </el-radio>
+            </el-radio-group>
           </el-form-item>
         </el-col>
-        <el-col :span="24" v-if="!isPublisherRole && !formData.useRoleDefaultScopes">
+        <el-col :span="24" v-if="!isPublisherRole && formData.scopeMode === ScopeMode.Custom">
           <el-form-item :label="tl('scopes')" prop="scopes">
             <el-select
               v-model="formData.scopes"
@@ -133,7 +144,7 @@
               style="width: 100%"
             >
               <el-option
-                v-for="scope in availableScopes"
+                v-for="scope in customScopeOptions"
                 :key="scope.name"
                 :value="scope.name"
                 :label="getScopeLabel(scope.name)"
@@ -145,6 +156,14 @@
               </el-option>
             </el-select>
           </el-form-item>
+          <el-alert
+            v-if="hasLegacyMixedScopes"
+            class="mixed-scopes-alert"
+            type="warning"
+            :title="tl('mixedScopesMigrationDesc')"
+            :closable="false"
+            show-icon
+          />
         </el-col>
         <el-col :span="24">
           <el-form-item :label="t('Base.note')" prop="description">
@@ -187,10 +206,19 @@ import { isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import APIKeyResultDialog from './APIKeyResultDialog.vue'
 
 export type OperationType = 'create' | 'view' | 'edit'
+enum ScopeMode {
+  RoleDefault = 'role_default',
+  System = 'system',
+  Custom = 'custom',
+}
+
+const SYSTEM_SCOPE = 'system'
+const PUBLISH_SCOPE = 'publish'
+
 type APIKeyFormData = Omit<APIKeyFormWhenCreating, 'scopes'> &
   Partial<Omit<APIKey, 'scopes'>> & {
     scopes: string[]
-    useRoleDefaultScopes: boolean
+    scopeMode: ScopeMode
   }
 
 const props = defineProps({
@@ -216,10 +244,8 @@ const { t, te } = useI18n()
 const tl = (key: string, collection = 'APIKey') => {
   return t(collection + '.' + key)
 }
-const buildRoleDefaultScopesDesc = (intro: string) =>
-  [intro, tl('roleDefaultScopesByRoleDesc'), tl('roleDefaultScopesRestrictionDesc')].join('\n\n')
-const roleDefaultScopesFormDesc = computed(() =>
-  buildRoleDefaultScopesDesc(tl('roleDefaultScopesFormDesc')),
+const scopeModeDesc = computed(() =>
+  [tl('scopeModeDesc'), tl('roleDefaultScopesByRoleDesc')].join('\n\n'),
 )
 
 const createRawFormData = () => ({
@@ -229,7 +255,7 @@ const createRawFormData = () => ({
   enable: true,
   role: 'administrator',
   scopes: [] as string[],
-  useRoleDefaultScopes: true,
+  scopeMode: ScopeMode.RoleDefault,
 })
 
 const formCom = ref()
@@ -237,6 +263,17 @@ const formData: Ref<APIKeyFormData> = ref(createRawFormData())
 const availableScopes: Ref<APIKeyScope[]> = ref([])
 const lastRole = ref<UserRole>(UserRole.Admin)
 const { createLetterStartRule } = useFormRules()
+const validateCustomScopes = (
+  _rule: unknown,
+  value: string[],
+  callback: (error?: Error) => void,
+) => {
+  if (formData.value.scopeMode === ScopeMode.Custom && value.includes(SYSTEM_SCOPE)) {
+    callback(new Error(tl('customScopesSystemError')))
+    return
+  }
+  callback()
+}
 const rules = {
   name: [
     {
@@ -245,6 +282,7 @@ const rules = {
     },
     ...createLetterStartRule(),
   ],
+  scopes: [{ validator: validateCustomScopes, trigger: 'change' }],
 }
 const isEnableOptions = [
   {
@@ -298,15 +336,43 @@ const loadAvailableScopes = () =>
     return scopes
   })
 
+const isSameScopeSet = (left: string[], right: string[]) => {
+  const leftSet = new Set(left)
+  const rightSet = new Set(right)
+  return leftSet.size === rightSet.size && [...leftSet].every((scope) => rightSet.has(scope))
+}
+
+const getRoleDefaultScopes = (role: string, scopes: APIKeyScope[]) =>
+  role === UserRole.Publisher ? [PUBLISH_SCOPE] : scopes.map(({ name }) => name)
+
+const resolveScopeMode = (
+  scopes: APIKey['scopes'],
+  role: string,
+  availableScopeList: APIKeyScope[],
+) => {
+  if (scopes == null || isUnsetScopes(scopes)) {
+    return ScopeMode.RoleDefault
+  }
+  const normalizedScopes = normalizeScopes(scopes) ?? []
+  if (isSameScopeSet(normalizedScopes, getRoleDefaultScopes(role, availableScopeList))) {
+    return ScopeMode.RoleDefault
+  }
+  if (normalizedScopes.length === 1 && normalizedScopes[0] === SYSTEM_SCOPE) {
+    return ScopeMode.System
+  }
+  return ScopeMode.Custom
+}
+
 watch(showDialog, async (val) => {
   if (val) {
-    loadAvailableScopes()
+    const availableScopesPromise = loadAvailableScopes().catch(() => [])
     if (props.operationType !== 'create') {
       const data = props.APIKeyData as APIKey
+      const loadedScopes = await availableScopesPromise
       formData.value = {
         ...data,
         scopes: normalizeScopes(data.scopes) ?? [],
-        useRoleDefaultScopes: data.scopes == null || isUnsetScopes(data.scopes),
+        scopeMode: resolveScopeMode(data.scopes, data.role, loadedScopes),
       }
       lastRole.value = formData.value.role as UserRole
       if (props.operationType === 'view') {
@@ -329,10 +395,24 @@ const { copyText } = useCopy()
 
 const { apiKeyRoleOptions } = useRole()
 const isPublisherRole = computed(() => formData.value.role === UserRole.Publisher)
+const customScopeOptions = computed(() =>
+  availableScopes.value.filter(({ name }) => name !== SYSTEM_SCOPE),
+)
+const hasLegacyMixedScopes = computed(
+  () =>
+    formData.value.scopeMode === ScopeMode.Custom && formData.value.scopes.includes(SYSTEM_SCOPE),
+)
+
+const handleScopeModeChanged = (mode: string | number | boolean | undefined) => {
+  if (mode === ScopeMode.Custom) {
+    formData.value.scopes = formData.value.scopes.filter((scope) => scope !== SYSTEM_SCOPE)
+  }
+  nextTick(() => formCom.value?.clearValidate('scopes'))
+}
 
 const handleRoleChanged = () => {
   if (formData.value.role === UserRole.Publisher || lastRole.value === UserRole.Publisher) {
-    formData.value.useRoleDefaultScopes = true
+    formData.value.scopeMode = ScopeMode.RoleDefault
     formData.value.scopes = []
   }
   lastRole.value = formData.value.role as UserRole
@@ -356,10 +436,16 @@ type APIKeyFormDataWithoutName = Omit<APIKeyFormData, 'name'>
 const handleDataForSubmitting = <T extends APIKeyFormData | APIKeyFormDataWithoutName>(
   formData: T,
 ) => {
-  const { useRoleDefaultScopes, ...data } = formData
+  const { scopeMode, ...data } = formData
+  const scopes =
+    scopeMode === ScopeMode.RoleDefault
+      ? UNSET_SCOPES
+      : scopeMode === ScopeMode.System
+        ? [SYSTEM_SCOPE]
+        : data.scopes
   const ret = {
     ...data,
-    scopes: useRoleDefaultScopes ? UNSET_SCOPES : data.scopes,
+    scopes,
   }
   // The interface convention is that when the api key is never expired,
   // do not submit expired_at
@@ -432,6 +518,13 @@ const submit = async () => {
       margin-left: 8px;
     }
   }
+  .mixed-scopes-alert {
+    margin-top: -8px;
+    margin-bottom: 18px;
+  }
+}
+.scope-mode-tooltip {
+  max-width: 720px;
 }
 .scope-desc {
   color: var(--el-text-color-secondary);

--- a/src/views/General/components/APIKeyDialog.vue
+++ b/src/views/General/components/APIKeyDialog.vue
@@ -106,17 +106,24 @@
           </el-form-item>
         </el-col>
         <el-col :span="24" v-if="!isPublisherRole">
-          <el-form-item prop="scopes">
+          <el-form-item>
             <template #label>
-              <span>{{ tl('scopes') }}</span>
-              <el-tooltip
-                v-if="formData.scopesNeedUpdate"
-                :content="tl('legacyScopesTip')"
-                placement="top"
-              >
-                <el-icon class="legacy-scopes-icon"><Warning /></el-icon>
-              </el-tooltip>
+              <FormItemLabel
+                :label="tl('useRoleDefaultScopes')"
+                :desc="roleDefaultScopesFormDesc"
+                desc-marked
+                :max-height="400"
+                popper-class="role-default-scopes-tooltip"
+              />
             </template>
+            <el-switch
+              v-model="formData.useRoleDefaultScopes"
+              :disabled="operationType === 'view'"
+            />
+          </el-form-item>
+        </el-col>
+        <el-col :span="24" v-if="!isPublisherRole && !formData.useRoleDefaultScopes">
+          <el-form-item :label="tl('scopes')" prop="scopes">
             <el-select
               v-model="formData.scopes"
               multiple
@@ -175,23 +182,16 @@ import { UserRole } from '@/types/enum'
 import { getManagedNamespaceList } from '@/api/config'
 import { createAPIKey, updateAPIKey, getAPIKeyScopes } from '@/api/systemModule'
 import { GLOBAL_NAMESPACE } from '@/common/constants'
-import {
-  APIKey,
-  APIKeyFormWhenCreating,
-  APIKeyFormWhenEditing,
-  APIKeyScope,
-} from '@/types/systemModule'
-import { isLegacyUnsetScopes, normalizeScopes, sanitizeScopesForSubmit } from '@/common/scopes'
+import { APIKey, APIKeyFormWhenCreating, APIKeyScope } from '@/types/systemModule'
+import { isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import APIKeyResultDialog from './APIKeyResultDialog.vue'
-import { Warning } from '@element-plus/icons-vue'
 
 export type OperationType = 'create' | 'view' | 'edit'
 type APIKeyFormData = Omit<APIKeyFormWhenCreating, 'scopes'> &
   Partial<Omit<APIKey, 'scopes'>> & {
-    scopes?: string[]
-    scopesNeedUpdate?: boolean
+    scopes: string[]
+    useRoleDefaultScopes: boolean
   }
-const PUBLISHER_SCOPES = ['publish']
 
 const props = defineProps({
   modelValue: {
@@ -216,6 +216,11 @@ const { t, te } = useI18n()
 const tl = (key: string, collection = 'APIKey') => {
   return t(collection + '.' + key)
 }
+const buildRoleDefaultScopesDesc = (intro: string) =>
+  [intro, tl('roleDefaultScopesByRoleDesc'), tl('roleDefaultScopesRestrictionDesc')].join('\n\n')
+const roleDefaultScopesFormDesc = computed(() =>
+  buildRoleDefaultScopesDesc(tl('roleDefaultScopesFormDesc')),
+)
 
 const createRawFormData = () => ({
   name: '',
@@ -223,14 +228,13 @@ const createRawFormData = () => ({
   desc: '',
   enable: true,
   role: 'administrator',
-  scopes: undefined as string[] | undefined,
+  scopes: [] as string[],
+  useRoleDefaultScopes: true,
 })
 
 const formCom = ref()
 const formData: Ref<APIKeyFormData> = ref(createRawFormData())
 const availableScopes: Ref<APIKeyScope[]> = ref([])
-const availableScopesPromise: Ref<Promise<APIKeyScope[]> | undefined> = ref(undefined)
-const initialRole = ref<UserRole>(UserRole.Admin)
 const lastRole = ref<UserRole>(UserRole.Admin)
 const { createLetterStartRule } = useFormRules()
 const rules = {
@@ -288,13 +292,11 @@ const showDialog = computed({
   },
 })
 
-const loadAvailableScopes = () => {
-  availableScopesPromise.value = getAPIKeyScopes().then((scopes) => {
+const loadAvailableScopes = () =>
+  getAPIKeyScopes().then((scopes) => {
     availableScopes.value = scopes
     return scopes
   })
-  return availableScopesPromise.value
-}
 
 watch(showDialog, async (val) => {
   if (val) {
@@ -303,17 +305,15 @@ watch(showDialog, async (val) => {
       const data = props.APIKeyData as APIKey
       formData.value = {
         ...data,
-        scopes: normalizeScopes(data.scopes),
-        scopesNeedUpdate: isLegacyUnsetScopes(data.scopes),
+        scopes: normalizeScopes(data.scopes) ?? [],
+        useRoleDefaultScopes: data.scopes == null || isUnsetScopes(data.scopes),
       }
-      initialRole.value = formData.value.role as UserRole
       lastRole.value = formData.value.role as UserRole
       if (props.operationType === 'view') {
         await nextTick()
       }
     } else {
       await nextTick()
-      initialRole.value = formData.value.role as UserRole
       lastRole.value = formData.value.role as UserRole
       formCom.value.clearValidate()
     }
@@ -321,7 +321,6 @@ watch(showDialog, async (val) => {
       !!formData.value.namespace && formData.value.namespace !== GLOBAL_NAMESPACE
   } else {
     formData.value = createRawFormData()
-    initialRole.value = UserRole.Admin
     lastRole.value = UserRole.Admin
   }
 })
@@ -331,20 +330,9 @@ const { copyText } = useCopy()
 const { apiKeyRoleOptions } = useRole()
 const isPublisherRole = computed(() => formData.value.role === UserRole.Publisher)
 
-const isOnlyPublisherScope = (scopes: APIKeyFormData['scopes']) =>
-  Array.isArray(scopes) && scopes.length === 1 && scopes[0] === PUBLISHER_SCOPES[0]
-
-const getAllScopeNames = () => availableScopes.value.map(({ name }) => name)
-
-const isChangingFromPublisher = (role?: string) =>
-  initialRole.value === UserRole.Publisher && role !== UserRole.Publisher
-
 const handleRoleChanged = () => {
-  if (formData.value.role === UserRole.Publisher) {
-    formData.value.scopes = [...PUBLISHER_SCOPES]
-  } else if (lastRole.value === UserRole.Publisher && formData.value.role === UserRole.Admin) {
-    formData.value.scopes = getAllScopeNames()
-  } else if (lastRole.value === UserRole.Publisher && isOnlyPublisherScope(formData.value.scopes)) {
+  if (formData.value.role === UserRole.Publisher || lastRole.value === UserRole.Publisher) {
+    formData.value.useRoleDefaultScopes = true
     formData.value.scopes = []
   }
   lastRole.value = formData.value.role as UserRole
@@ -363,21 +351,16 @@ const getScopeDesc = (name: string): string => {
 const todayStartTime = new Date().setHours(0, 0, 0, 0)
 const isItEarlierThanToday = (date: Date) => date.getTime() < todayStartTime
 
-const handleDataForSubmitting = <T extends APIKeyFormData | Omit<APIKeyFormData, 'name'>>(
+type APIKeyFormDataWithoutName = Omit<APIKeyFormData, 'name'>
+
+const handleDataForSubmitting = <T extends APIKeyFormData | APIKeyFormDataWithoutName>(
   formData: T,
 ) => {
-  const ret = { ...formData }
-  delete ret.scopesNeedUpdate
-  if (ret.role === UserRole.Publisher) {
-    ret.scopes = [...PUBLISHER_SCOPES]
+  const { useRoleDefaultScopes, ...data } = formData
+  const ret = {
+    ...data,
+    scopes: useRoleDefaultScopes ? UNSET_SCOPES : data.scopes,
   }
-  if (
-    isChangingFromPublisher(ret.role) &&
-    (!Array.isArray(ret.scopes) || ret.scopes.length === 0)
-  ) {
-    ret.scopes = getAllScopeNames()
-  }
-  sanitizeScopesForSubmit(ret)
   // The interface convention is that when the api key is never expired,
   // do not submit expired_at
   if (!ret.expired_at) {
@@ -393,15 +376,9 @@ const { processUserRecordForSubmit, processAPIKeyRecordForUpdating } = useNamesp
 const submitAddedData = () =>
   createAPIKey(processUserRecordForSubmit(handleDataForSubmitting(formData.value)))
 
-const submitUpdatedData = async () => {
-  const { name, ...data } = formData.value as APIKeyFormWhenEditing
-  if (isChangingFromPublisher(data.role) && availableScopes.value.length === 0) {
-    await (availableScopesPromise.value ?? loadAvailableScopes())
-  }
-  return updateAPIKey(
-    name,
-    processAPIKeyRecordForUpdating(handleDataForSubmitting(data as APIKeyFormData)),
-  )
+const submitUpdatedData = () => {
+  const { name, ...data } = formData.value
+  return updateAPIKey(name, processAPIKeyRecordForUpdating(handleDataForSubmitting(data)))
 }
 
 const submit = async () => {
@@ -461,11 +438,5 @@ const submit = async () => {
   margin-left: 8px;
   font-size: 12px;
   font-weight: normal;
-}
-.legacy-scopes-icon {
-  margin-left: 4px;
-  color: var(--el-color-warning);
-  cursor: help;
-  vertical-align: -2px;
 }
 </style>


### PR DESCRIPTION
- distinguish role defaults from explicitly empty scopes
- add scope guidance to the API key table and form
- document defaults for global, namespace, and publisher roles