### PR TITLE
feat(user): add context-aware scope permission modes

### DIFF
--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -63,6 +63,46 @@ export default {
     zh: '使用角色默认权限',
     en: 'Use Role Default Scopes',
   },
+  scopeMode: {
+    zh: '权限模式',
+    en: 'Permission Mode',
+  },
+  scopeModeDesc: {
+    zh: `选择全局用户的权限配置方式：
+
+- **角色默认权限**：自动使用当前角色的默认权限；以后角色默认权限发生变化时，新权限会自动生效。
+- **管理权限范围**：从系统设置、用户管理、API 密钥管理和 SSO 管理中按需选择。
+- **自定义受限权限**：从连接、消息发布、数据集成、监控和 MFA 管理等非管理权限范围中按需选择。未选择任何权限时，用户不能访问受权限范围保护的接口。
+
+具体可选择的权限仍受用户角色限制。各角色和所属范围的默认权限如下。`,
+    en: `Choose how permissions are assigned to the global user:
+
+- **Role Default Scopes**: Automatically use the current role's defaults. Future changes to the role defaults take effect automatically.
+- **Privilege Scopes**: Select System, User Management, API Key Management, and SSO Management scopes as needed. 
+- **Custom Restricted Permissions**: Select non-privilege scopes such as Connections, Publish, Data Integration, Monitoring, and MFA Management. When no scope is selected, the user cannot access scope-protected APIs.
+
+Available scopes are still restricted by the user's role. The default scopes for each role and scope are listed below.`,
+  },
+  scopeModePrivilege: {
+    zh: '管理权限范围',
+    en: 'Privilege Scopes',
+  },
+  scopeModeCustom: {
+    zh: '自定义受限权限',
+    en: 'Custom Restricted Permissions',
+  },
+  mixedGlobalScopesDesc: {
+    zh: '当前权限同时包含管理权限范围和自定义受限权限，全局用户不能使用这种组合。请选择“管理权限范围”“自定义受限权限”或“角色默认权限”后再保存。',
+    en: 'The current selection combines privilege and restricted scopes, which is not allowed for global users. Select Privilege Scopes, Custom Restricted Permissions, or Role Default Scopes before saving.',
+  },
+  mixedGlobalScopesError: {
+    zh: '全局用户不能同时选择管理权限范围和自定义受限权限，请重新选择权限模式。',
+    en: 'Global users cannot combine privilege and restricted scopes. Select a permission mode again.',
+  },
+  incompatibleScopesRemoved: {
+    zh: '已移除当前角色或所属范围不支持的权限：{scopes}',
+    en: 'Removed scopes that are not supported by the current role or Namespace: {scopes}',
+  },
   roleDefaultScopes: {
     zh: '角色默认权限',
     en: 'Role Default Scopes',
@@ -72,8 +112,8 @@ export default {
     en: 'No Scopes',
   },
   roleDefaultScopesFormDesc: {
-    zh: '开启后，用户会自动获得其角色和所属范围（全局或命名空间）的默认权限。以后角色的默认权限发生变化时，新权限也会自动生效，无需再次编辑用户。',
-    en: 'When enabled, the user automatically receives the default permissions for its role and scope (Global or Namespace). If the role defaults change later, the updated permissions take effect automatically without editing the user again.',
+    zh: '开启后，命名空间用户会自动获得当前角色的默认权限，以后默认权限发生变化时也会自动生效。关闭后，可以从该角色在命名空间内允许持有的所有权限范围中直接选择。',
+    en: "When enabled, the namespace user automatically receives its role's default permissions, including future changes to those defaults. When disabled, select directly from all scopes that the role may hold within a Namespace.",
   },
   userScopesColumnDesc: {
     zh: '权限范围用于限定用户可以访问的功能类别。显示“角色默认权限”表示用户会自动继承当前角色的默认设置；显示具体权限标签表示用户使用显式配置。',

--- a/src/views/General/Users.vue
+++ b/src/views/General/Users.vue
@@ -56,7 +56,7 @@
       </el-table-column>
       <el-table-column :label="t('BasicConfig.namespace')" :min-width="120">
         <template #default="{ row }">
-          {{ row.namespace }}
+          {{ row.namespace && row.namespace !== GLOBAL_NAMESPACE ? row.namespace : '' }}
         </template>
       </el-table-column>
       <el-table-column :label="$t('Base.operation')" :min-width="isZh ? 308 : 386">
@@ -140,45 +140,6 @@
             </el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="accessType !== 'chPass'">
-          <template #label>
-            <FormItemLabel
-              :label="tl('useRoleDefaultScopes')"
-              :desc="roleDefaultScopesFormDesc"
-              desc-marked
-              :max-height="400"
-              popper-class="role-default-scopes-tooltip"
-            />
-          </template>
-          <el-switch v-model="record.useRoleDefaultScopes" />
-        </el-form-item>
-        <el-form-item
-          v-if="accessType !== 'chPass' && !record.useRoleDefaultScopes"
-          :label="tl('userScopes')"
-          prop="scopes"
-        >
-          <el-select
-            v-model="record.scopes"
-            multiple
-            clearable
-            :placeholder="tl('userScopesPlaceholder')"
-            style="width: 100%"
-          >
-            <el-option
-              v-for="scope in availableUserScopes"
-              :key="scope.name"
-              :value="scope.name"
-              :label="getScopeLabel(scope.name)"
-              :disabled="scope.admin_only && !isAdminRole"
-            >
-              <span>{{ getScopeLabel(scope.name) }}</span>
-              <span class="scope-desc">
-                {{ getScopeDesc(scope.name) }}
-                <template v-if="scope.admin_only"> ({{ tl('userScopesAdminOnlyTip') }}) </template>
-              </span>
-            </el-option>
-          </el-select>
-        </el-form-item>
         <el-form-item
           v-if="accessType !== 'chPass'"
           :label="t('BasicConfig.namespace')"
@@ -194,11 +155,83 @@
               v-if="isNamespaceEnabled"
               v-model="record.namespace"
               :disabled="accessType === 'edit'"
+              @change="handleNamespaceChanged"
             >
               <el-option v-for="item in namespaceOptions" :key="item" :value="item" :label="item" />
             </el-select>
           </div>
         </el-form-item>
+        <el-form-item v-if="accessType !== 'chPass' && !isNamespaceEnabled" prop="scopeMode">
+          <template #label>
+            <FormItemLabel
+              :label="tl('scopeMode')"
+              :desc="scopeModeDesc"
+              desc-marked
+              :max-height="400"
+              popper-class="scope-mode-tooltip"
+            />
+          </template>
+          <el-radio-group v-model="record.scopeMode" @change="handleScopeModeChanged">
+            <el-radio :value="ScopeMode.RoleDefault">
+              {{ tl('roleDefaultScopes') }}
+            </el-radio>
+            <el-radio :value="ScopeMode.Privilege">
+              {{ tl('scopeModePrivilege') }}
+            </el-radio>
+            <el-radio :value="ScopeMode.Custom">
+              {{ tl('scopeModeCustom') }}
+            </el-radio>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item v-if="accessType !== 'chPass' && isNamespaceEnabled">
+          <template #label>
+            <FormItemLabel
+              :label="tl('useRoleDefaultScopes')"
+              :desc="roleDefaultScopesFormDesc"
+              desc-marked
+              :max-height="400"
+              popper-class="role-default-scopes-tooltip"
+            />
+          </template>
+          <el-switch
+            v-model="record.useRoleDefaultScopes"
+            @change="handleRoleDefaultScopesChanged"
+          />
+        </el-form-item>
+        <el-form-item
+          v-if="accessType !== 'chPass' && shouldShowScopesSelect"
+          :label="scopeSelectLabel"
+          prop="scopes"
+        >
+          <el-select
+            v-model="record.scopes"
+            multiple
+            clearable
+            :placeholder="tl('userScopesPlaceholder')"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="scope in currentScopeOptions"
+              :key="scope.name"
+              :value="scope.name"
+              :label="getScopeLabel(scope.name)"
+            >
+              <span>{{ getScopeLabel(scope.name) }}</span>
+              <span class="scope-desc">
+                {{ getScopeDesc(scope.name) }}
+                <template v-if="scope.admin_only"> ({{ tl('userScopesAdminOnlyTip') }}) </template>
+              </span>
+            </el-option>
+          </el-select>
+        </el-form-item>
+        <el-alert
+          v-if="accessType !== 'chPass' && hasMixedGlobalScopes"
+          class="mixed-scopes-alert"
+          type="warning"
+          :title="tl('mixedGlobalScopesDesc')"
+          :closable="false"
+          show-icon
+        />
         <div v-if="accessType === 'chPass'">
           <el-input class="username-placeholder" v-model="record.username" disabled />
           <el-form-item prop="newPassword" :label="tl('newPassword')">
@@ -249,11 +282,41 @@
 import { getManagedNamespaceList } from '@/api/config'
 import { changePassword, createUser, destroyUser, loadUser, updateUser } from '@/api/function.ts'
 import { getLoginUserScopes } from '@/api/systemModule.ts'
+import { GLOBAL_NAMESPACE } from '@/common/constants'
 import { hasSelectedScopes, isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import { UserRole } from '@/types/enum.ts'
 import UserMFASettingDialog from './components/UserMFASettingDialog.vue'
 
 const SOURCE_LOCAL = 'local'
+const ScopeMode = {
+  RoleDefault: 'role_default',
+  Privilege: 'privilege',
+  Custom: 'custom',
+  Mixed: 'mixed',
+}
+const PRIVILEGE_SCOPES = new Set([
+  'system',
+  'user_management',
+  'api_key_management',
+  'sso_management',
+])
+const LOGIN_ONLY_SCOPES = new Set([
+  'user_management',
+  'mfa_management',
+  'sso_management',
+  'api_key_management',
+])
+const NS_ADMIN_ALLOWED_SCOPES = new Set([
+  'connections',
+  'monitoring',
+  'data_integration',
+  'access_control',
+  'system',
+  'cluster_operations',
+  'license',
+  'user_management',
+  'api_key_management',
+])
 
 const store = useStore()
 const { tl, t, te } = useI18nTl('General')
@@ -264,6 +327,7 @@ const buildRoleDefaultScopesDesc = (intro) =>
 const roleDefaultScopesFormDesc = computed(() =>
   buildRoleDefaultScopesDesc(tl('roleDefaultScopesFormDesc')),
 )
+const scopeModeDesc = computed(() => buildRoleDefaultScopesDesc(tl('scopeModeDesc')))
 const userScopesColumnDesc = computed(() => buildRoleDefaultScopesDesc(tl('userScopesColumnDesc')))
 
 const dialogVisible = ref(false)
@@ -274,6 +338,7 @@ const record = ref({})
 const submitLoading = ref(false)
 const formCom = ref()
 const availableUserScopes = ref([])
+const shouldResolveRoleDefaultScopes = ref(false)
 
 const { processUserRecordForSubmit } = useNamespaceUser()
 
@@ -289,12 +354,22 @@ const queryNamespaceList = async () => {
     //
   }
 }
-const toggleNamespaceEnabled = () => {
-  if (isNamespaceEnabled.value && !isNamespaceOptionsLoaded.value) {
+const toggleNamespaceEnabled = (enabled) => {
+  if (enabled && !isNamespaceOptionsLoaded.value) {
     queryNamespaceList()
-  } else if (!isNamespaceEnabled.value && record.value.namespace) {
-    record.value.namespace = ''
   }
+  if (enabled) {
+    record.value.useRoleDefaultScopes = record.value.scopeMode === ScopeMode.RoleDefault
+    if (!record.value.useRoleDefaultScopes) {
+      filterSelectedScopes()
+    }
+  } else {
+    record.value.namespace = ''
+    record.value.scopeMode = record.value.useRoleDefaultScopes
+      ? ScopeMode.RoleDefault
+      : resolveExplicitGlobalScopeMode(record.value.scopes)
+  }
+  nextTick(() => formCom.value?.clearValidate(['namespace', 'scopeMode', 'scopes']))
 }
 
 const { userRoleOptions } = useRole()
@@ -312,20 +387,146 @@ const getScopeDesc = (name) => {
   return te(key) ? t(key) : ''
 }
 
-const handleRoleChanged = () => {
-  // When switching to a non-admin role, drop any admin-only scopes the
-  // user picked while on admin (server-side schema would reject them).
-  if (!isAdminRole.value && Array.isArray(record.value.scopes)) {
-    const adminOnly = new Set(
-      availableUserScopes.value.filter((s) => s.admin_only).map((s) => s.name),
+const roleCompatibleScopeOptions = computed(() =>
+  availableUserScopes.value.filter((scope) => {
+    if (!isAdminRole.value && scope.admin_only) {
+      return false
+    }
+    return !(
+      isNamespaceEnabled.value &&
+      isAdminRole.value &&
+      !NS_ADMIN_ALLOWED_SCOPES.has(scope.name)
     )
-    record.value.scopes = record.value.scopes.filter((name) => !adminOnly.has(name))
+  }),
+)
+
+const currentScopeOptions = computed(() => {
+  if (isNamespaceEnabled.value || record.value.scopeMode === ScopeMode.Mixed) {
+    return roleCompatibleScopeOptions.value
   }
+  if (record.value.scopeMode === ScopeMode.Privilege) {
+    return roleCompatibleScopeOptions.value.filter(({ name }) => PRIVILEGE_SCOPES.has(name))
+  }
+  return roleCompatibleScopeOptions.value.filter(({ name }) => !PRIVILEGE_SCOPES.has(name))
+})
+
+const shouldShowScopesSelect = computed(
+  () =>
+    (isNamespaceEnabled.value && !record.value.useRoleDefaultScopes) ||
+    (!isNamespaceEnabled.value && record.value.scopeMode !== ScopeMode.RoleDefault),
+)
+
+const scopeSelectLabel = computed(() => {
+  if (isNamespaceEnabled.value || record.value.scopeMode === ScopeMode.Mixed) {
+    return tl('userScopes')
+  }
+  return record.value.scopeMode === ScopeMode.Privilege
+    ? tl('scopeModePrivilege')
+    : tl('scopeModeCustom')
+})
+
+const partitionScopes = (scopes) =>
+  (normalizeScopes(scopes) ?? []).reduce(
+    (result, scope) => {
+      result[PRIVILEGE_SCOPES.has(scope) ? 'privilege' : 'restricted'].push(scope)
+      return result
+    },
+    { privilege: [], restricted: [] },
+  )
+
+const resolveExplicitGlobalScopeMode = (scopes) => {
+  const { privilege, restricted } = partitionScopes(scopes)
+  if (privilege.length && restricted.length) {
+    return ScopeMode.Mixed
+  }
+  return privilege.length ? ScopeMode.Privilege : ScopeMode.Custom
+}
+
+const isSameScopeSet = (left, right) => {
+  const leftSet = new Set(left)
+  const rightSet = new Set(right)
+  return leftSet.size === rightSet.size && [...leftSet].every((scope) => rightSet.has(scope))
+}
+
+const getRoleDefaultScopes = () => {
+  if (isNamespaceEnabled.value && isAdminRole.value) {
+    return availableUserScopes.value
+      .filter(({ name }) => NS_ADMIN_ALLOWED_SCOPES.has(name))
+      .map(({ name }) => name)
+  }
+  if (isAdminRole.value) {
+    return availableUserScopes.value.map(({ name }) => name)
+  }
+  return availableUserScopes.value
+    .filter(({ name }) => !LOGIN_ONLY_SCOPES.has(name))
+    .map(({ name }) => name)
+}
+
+const resolveRoleDefaultScopeState = () => {
+  const isRoleDefault =
+    record.value.useRoleDefaultScopes ||
+    isSameScopeSet(normalizeScopes(record.value.scopes) ?? [], getRoleDefaultScopes())
+  record.value.useRoleDefaultScopes = isRoleDefault
+  if (!isNamespaceEnabled.value) {
+    record.value.scopeMode = isRoleDefault
+      ? ScopeMode.RoleDefault
+      : resolveExplicitGlobalScopeMode(record.value.scopes)
+  }
+}
+
+const hasMixedGlobalScopes = computed(
+  () => !isNamespaceEnabled.value && record.value.scopeMode === ScopeMode.Mixed,
+)
+
+const filterSelectedScopes = (showMessage = true) => {
+  if (
+    !shouldShowScopesSelect.value ||
+    !Array.isArray(record.value.scopes) ||
+    availableUserScopes.value.length === 0
+  ) {
+    return
+  }
+  const allowedScopes = new Set(currentScopeOptions.value.map(({ name }) => name))
+  const removedScopes = record.value.scopes.filter((scope) => !allowedScopes.has(scope))
+  if (removedScopes.length === 0) {
+    return
+  }
+  record.value.scopes = record.value.scopes.filter((scope) => allowedScopes.has(scope))
+  if (showMessage) {
+    ElMessage.warning(
+      tl('incompatibleScopesRemoved', {
+        scopes: removedScopes.map(getScopeLabel).join(', '),
+      }),
+    )
+  }
+}
+
+const handleScopeModeChanged = () => {
+  shouldResolveRoleDefaultScopes.value = false
+  filterSelectedScopes()
+  nextTick(() => formCom.value?.clearValidate(['scopeMode', 'scopes']))
+}
+
+const handleRoleDefaultScopesChanged = () => {
+  shouldResolveRoleDefaultScopes.value = false
+}
+
+const handleRoleChanged = () => {
+  filterSelectedScopes()
+}
+
+const handleNamespaceChanged = () => {
+  filterSelectedScopes()
 }
 
 const loadUserScopes = async () => {
   try {
     availableUserScopes.value = await getLoginUserScopes()
+    if (shouldResolveRoleDefaultScopes.value) {
+      resolveRoleDefaultScopeState()
+      shouldResolveRoleDefaultScopes.value = false
+    }
+    filterSelectedScopes(false)
   } catch (e) {
     availableUserScopes.value = []
   }
@@ -362,9 +563,17 @@ const { createNoChineseRule, createRequiredRule } = useFormRules()
 const pwdMismatchMsg =
   tl('passwordRequirement1') + tl('semicolon') + tl('passwordRequirement2').toLowerCase()
 const rules = computed(() => {
+  const validateScopeMode = (_rule, value, callback) => {
+    if (!isNamespaceEnabled.value && value === ScopeMode.Mixed) {
+      callback(new Error(tl('mixedGlobalScopesError')))
+      return
+    }
+    callback()
+  }
   const ret = {
     username: [{ required: true, message: tl('enterOneUserName') }, ...createNoChineseRule()],
     role: createRequiredRule(t('Dashboard.role'), 'select'),
+    scopeMode: [{ validator: validateScopeMode, trigger: 'change' }],
     password: [
       {
         required: true,
@@ -402,6 +611,9 @@ const rules = computed(() => {
       message: pwdMismatchMsg,
       trigger: ['blur'],
     })
+    if (isNamespaceEnabled.value) {
+      ret.namespace = createRequiredRule(t('BasicConfig.namespace'), 'select')
+    }
   }
   return ret
 })
@@ -432,6 +644,7 @@ const generateRawForm = () => ({
   namespace: '',
   scopes: [],
   useRoleDefaultScopes: true,
+  scopeMode: ScopeMode.RoleDefault,
 })
 
 const isCurrentUser = (user) => user === currentUser.value.username
@@ -440,14 +653,13 @@ const showDialog = (type = 'create', item = {}) => {
   dialogVisible.value = true
   formCom.value?.resetFields()
 
-  if (type !== 'chPass' && availableUserScopes.value.length === 0) {
-    loadUserScopes()
-  }
-
   if (type === 'edit') {
     record.value = Object.assign({}, item, {
       scopes: normalizeScopes(item.scopes) ?? [],
       useRoleDefaultScopes: usesRoleDefaultScopes(item.scopes),
+      scopeMode: usesRoleDefaultScopes(item.scopes)
+        ? ScopeMode.RoleDefault
+        : resolveExplicitGlobalScopeMode(item.scopes),
     })
   } else if (type === 'chPass') {
     record.value = {
@@ -459,7 +671,19 @@ const showDialog = (type = 'create', item = {}) => {
   } else {
     record.value = generateRawForm()
   }
-  isNamespaceEnabled.value = !!record.value.namespace
+  isNamespaceEnabled.value = !!record.value.namespace && record.value.namespace !== GLOBAL_NAMESPACE
+  if (type === 'edit') {
+    if (availableUserScopes.value.length > 0) {
+      resolveRoleDefaultScopeState()
+    } else {
+      shouldResolveRoleDefaultScopes.value = true
+    }
+  } else {
+    shouldResolveRoleDefaultScopes.value = false
+  }
+  if (type !== 'chPass' && availableUserScopes.value.length === 0) {
+    loadUserScopes()
+  }
   accessType.value = type
 }
 
@@ -481,15 +705,22 @@ const trimUserName = () => {
 const getBackend = (backend) => (backend === SOURCE_LOCAL ? undefined : backend)
 
 const getRecordForUpdating = () => {
-  const ret = processUserRecordForSubmit(record.value)
+  const normalizedRecord = {
+    ...record.value,
+    namespace: record.value.namespace === GLOBAL_NAMESPACE ? '' : record.value.namespace,
+  }
+  const ret = processUserRecordForSubmit(normalizedRecord)
   return buildUserPayload(ret, ['description', 'role', 'scopes'])
 }
-// The role-default switch maps to the backend's `unset` sentinel. When the
-// switch is off, preserve the explicit array, including [] (deny all mapped
-// paths), so the two states are never conflated.
+// Both the global role-default radio and the namespace role-default switch
+// map to the backend's `unset` sentinel. Explicit mode preserves the array,
+// including [] (deny all mapped paths), so the states are never conflated.
 const buildUserPayload = (rec, fields) => {
   const payload = pick(rec, fields)
-  payload.scopes = rec.useRoleDefaultScopes ? UNSET_SCOPES : (normalizeScopes(rec.scopes) ?? [])
+  const useRoleDefaultScopes = isNamespaceEnabled.value
+    ? rec.useRoleDefaultScopes
+    : rec.scopeMode === ScopeMode.RoleDefault
+  payload.scopes = useRoleDefaultScopes ? UNSET_SCOPES : (normalizeScopes(rec.scopes) ?? [])
   return payload
 }
 
@@ -571,6 +802,10 @@ onBeforeMount(async () => {
 .role-default-scopes-tooltip {
   max-width: 720px;
 }
+
+.scope-mode-tooltip {
+  max-width: 720px;
+}
 </style>
 
 <style lang="scss" scoped>
@@ -583,5 +818,14 @@ onBeforeMount(async () => {
     flex-grow: 1;
     margin-left: 8px;
   }
+}
+.mixed-scopes-alert {
+  margin-bottom: 18px;
+}
+.scope-desc {
+  color: var(--el-text-color-secondary);
+  float: right;
+  font-size: 12px;
+  margin-left: 20px;
 }
 </style>


### PR DESCRIPTION
- add role-default, privilege, and custom modes for global users
- allow namespace users to select all role-compatible scopes directly
- filter incompatible scopes when roles or namespaces change
- preserve legacy scope states and normalize the global namespace