### PR TITLE
fix(api key): prevent publish scope on namespaced keys

### DIFF
--- a/src/i18n/APIKey.ts
+++ b/src/i18n/APIKey.ts
@@ -80,14 +80,14 @@ export default {
 
 - **角色默认权限**：自动使用当前角色的默认权限。管理员和查看者可访问全部管理功能类别，发布者仅可发布消息；以后角色默认权限发生变化时，新权限会自动生效。
 - **系统级权限**：仅授予“系统设置”权限范围，可访问核心配置、监听器、插件、数据备份与恢复、OpenTelemetry 等系统功能。
-- **自定义受限权限**：从连接、消息发布、数据集成、监控等非系统权限范围中按需选择。未选择任何权限时，API 密钥不能访问受权限范围保护的接口。
+- **自定义受限权限**：从连接、消息发布、数据集成、监控等非系统权限范围中按需选择。命名空间 API 密钥不能选择消息发布。未选择任何权限时，API 密钥不能访问受权限范围保护的接口。
 
 无论选择哪种模式，具体可执行的操作和可查看的数据仍受角色和命名空间限制。各角色的默认权限如下。`,
     en: `Choose how permissions are assigned to the API key:
 
 - **Role Default Scopes**: Automatically use the current role's defaults. Administrators and viewers can access all management feature areas, while publishers can only publish messages. Future changes to the role defaults take effect automatically.
 - **System-level Permissions**: Grant only the System scope, covering core configuration, listeners, plugins, data backup and restore, OpenTelemetry, and other system functions. 
-- **Custom Restricted Permissions**: Select non-system scopes such as Connections, Publish, Data Integration, and Monitoring. When no scope is selected, the API key cannot access scope-protected APIs.
+- **Custom Restricted Permissions**: Select non-system scopes such as Connections, Publish, Data Integration, and Monitoring. Namespaced API keys cannot select Publish. When no scope is selected, the API key cannot access scope-protected APIs.
 
 In every mode, available operations and visible data remain restricted by the role and Namespace. The default scopes for each role are listed below.`,
   },
@@ -111,9 +111,17 @@ In every mode, available operations and visible data remain restricted by the ro
     zh: '自定义受限权限不能包含“系统设置”权限范围，请移除该权限或选择“系统级权限”。',
     en: 'Custom restricted permissions cannot include the System scope. Remove it or select System-level Permissions.',
   },
+  namespacedPublishError: {
+    zh: '命名空间 API 密钥不能包含“消息发布”权限范围，请移除该权限。',
+    en: 'Namespaced API keys cannot include the Publish scope. Remove it before saving.',
+  },
   mixedScopesMigrationDesc: {
     zh: '此 API 密钥保存了旧版的混合权限配置。请移除“系统设置”后继续使用自定义受限权限，或改选“系统级权限”或“角色默认权限”。',
     en: 'This API key contains a legacy mixed-scope configuration. Remove System to keep custom restricted permissions, or select System-level Permissions or Role Default Scopes.',
+  },
+  namespacedPublishMigrationDesc: {
+    zh: '此命名空间 API 密钥保存了旧版的“消息发布”权限。修改角色或权限范围时，请先移除“消息发布”。',
+    en: 'This namespaced API key contains the legacy Publish scope. Remove Publish before changing its role or scopes.',
   },
   scopesColumnDesc: {
     zh: '权限范围用于限定 API 密钥可以访问的功能类别。显示“角色默认权限”表示自动继承当前角色的默认设置；具体权限标签表示使用显式配置；“无权限范围”表示该密钥不能访问受权限范围保护的接口。具体可执行的操作仍受角色和命名空间限制。',
@@ -123,12 +131,14 @@ In every mode, available operations and visible data remain restricted by the ro
     zh: `**各角色的默认权限**
 
 - **全局管理员 / 全局查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
-- **命名空间管理员 / 命名空间查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
+- **命名空间管理员**：连接、监控、数据集成、访问控制、系统设置、集群管理、License
+- **命名空间查看者**：连接、消息发布、数据集成、访问控制、网关、监控、集群管理、系统设置、审计日志、License
 - **发布者**：消息发布`,
     en: `**Default permissions by role**
 
 - **Global Administrator / Global Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
-- **Namespace Administrator / Namespace Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
+- **Namespace Administrator**: Connections, Monitoring, Data Integration, Access Control, System, Cluster, and License
+- **Namespace Viewer**: Connections, Publish, Data Integration, Access Control, Gateways, Monitoring, Cluster, System, Audit Log, and License
 - **Publisher**: Publish`,
   },
   roleDefaultScopesRestrictionDesc: {

--- a/src/views/General/components/APIKeyDialog.vue
+++ b/src/views/General/components/APIKeyDialog.vue
@@ -164,6 +164,14 @@
             :closable="false"
             show-icon
           />
+          <el-alert
+            v-if="hasLegacyNamespacedPublishScopes"
+            class="mixed-scopes-alert"
+            type="warning"
+            :title="tl('namespacedPublishMigrationDesc')"
+            :closable="false"
+            show-icon
+          />
         </el-col>
         <el-col :span="24">
           <el-form-item :label="t('Base.note')" prop="description">
@@ -213,6 +221,7 @@ enum ScopeMode {
 
 const SYSTEM_SCOPE = 'system'
 const PUBLISH_SCOPE = 'publish'
+const isNamespacedNamespace = (namespace?: string) => !!namespace && namespace !== GLOBAL_NAMESPACE
 
 type APIKeyFormData = Omit<APIKeyFormWhenCreating, 'scopes'> &
   Partial<Omit<APIKey, 'scopes'>> & {
@@ -259,6 +268,11 @@ const createRawFormData = () => ({
 
 const formCom = ref()
 const formData: Ref<APIKeyFormData> = ref(createRawFormData())
+const originalAPIKeyScopeState = ref<{
+  namespace?: string
+  role: string
+  scopes: string[]
+}>()
 const availableScopes: Ref<APIKeyScope[]> = ref([])
 const lastRole = ref<UserRole>(UserRole.Admin)
 const { createLetterStartRule } = useFormRules()
@@ -269,6 +283,15 @@ const validateCustomScopes = (
 ) => {
   if (formData.value.scopeMode === ScopeMode.Custom && value.includes(SYSTEM_SCOPE)) {
     callback(new Error(tl('customScopesSystemError')))
+    return
+  }
+  if (
+    formData.value.scopeMode === ScopeMode.Custom &&
+    isNamespacedKey.value &&
+    value.includes(PUBLISH_SCOPE) &&
+    !isUnchangedLegacyNamespacedScopes.value
+  ) {
+    callback(new Error(tl('namespacedPublishError')))
     return
   }
   callback()
@@ -303,6 +326,9 @@ const showResultDialog: Ref<boolean> = ref(false)
 const { datePickerShortcuts } = useDatePickerShortcuts()
 
 const isNamespaceEnabled = ref(false)
+const isNamespacedKey = computed(
+  () => isNamespaceEnabled.value || isNamespacedNamespace(formData.value.namespace),
+)
 const namespaceOptions = ref<Array<string>>([])
 const isNamespaceOptionsLoaded = ref(false)
 const { getNamespaceOptions } = useManagedNamespaceOptions()
@@ -316,8 +342,11 @@ const queryNamespaceList = async () => {
   }
 }
 const toggleNamespaceEnabled = () => {
-  if (isNamespaceEnabled.value && !isNamespaceOptionsLoaded.value) {
-    queryNamespaceList()
+  if (isNamespaceEnabled.value) {
+    formData.value.scopes = formData.value.scopes.filter((scope) => scope !== PUBLISH_SCOPE)
+    if (!isNamespaceOptionsLoaded.value) {
+      queryNamespaceList()
+    }
   } else if (!isNamespaceEnabled.value && formData.value.namespace) {
     formData.value.namespace = ''
   }
@@ -342,6 +371,24 @@ const isSameScopeSet = (left: string[], right: string[]) => {
   return leftSet.size === rightSet.size && [...leftSet].every((scope) => rightSet.has(scope))
 }
 
+const isUnchangedLegacyNamespacedScopes = computed(() => {
+  const original = originalAPIKeyScopeState.value
+  if (
+    props.operationType === 'create' ||
+    !original ||
+    !isNamespacedNamespace(original.namespace) ||
+    !original.scopes.includes(PUBLISH_SCOPE) ||
+    isSameScopeSet(original.scopes, [PUBLISH_SCOPE])
+  ) {
+    return false
+  }
+  return (
+    formData.value.namespace === original.namespace &&
+    formData.value.role === original.role &&
+    isSameScopeSet(formData.value.scopes, original.scopes)
+  )
+})
+
 const getRoleDefaultScopes = (role: string, scopes: APIKeyScope[]) =>
   role === UserRole.Publisher ? [PUBLISH_SCOPE] : scopes.map(({ name }) => name)
 
@@ -349,11 +396,19 @@ const resolveScopeMode = (
   scopes: APIKey['scopes'],
   role: string,
   availableScopeList: APIKeyScope[],
+  namespace?: string,
 ) => {
   if (scopes == null || isUnsetScopes(scopes)) {
     return ScopeMode.RoleDefault
   }
   const normalizedScopes = normalizeScopes(scopes) ?? []
+  if (
+    role !== UserRole.Publisher &&
+    isNamespacedNamespace(namespace) &&
+    normalizedScopes.includes(PUBLISH_SCOPE)
+  ) {
+    return ScopeMode.Custom
+  }
   if (isSameScopeSet(normalizedScopes, getRoleDefaultScopes(role, availableScopeList))) {
     return ScopeMode.RoleDefault
   }
@@ -369,16 +424,23 @@ watch(showDialog, async (val) => {
     if (props.operationType !== 'create') {
       const data = props.APIKeyData as APIKey
       const loadedScopes = await availableScopesPromise
+      const normalizedScopes = normalizeScopes(data.scopes) ?? []
+      originalAPIKeyScopeState.value = {
+        namespace: data.namespace,
+        role: data.role,
+        scopes: [...normalizedScopes],
+      }
       formData.value = {
         ...data,
-        scopes: normalizeScopes(data.scopes) ?? [],
-        scopeMode: resolveScopeMode(data.scopes, data.role, loadedScopes),
+        scopes: [...normalizedScopes],
+        scopeMode: resolveScopeMode(data.scopes, data.role, loadedScopes, data.namespace),
       }
       lastRole.value = formData.value.role as UserRole
       if (props.operationType === 'view') {
         await nextTick()
       }
     } else {
+      originalAPIKeyScopeState.value = undefined
       await nextTick()
       lastRole.value = formData.value.role as UserRole
       formCom.value.clearValidate()
@@ -387,6 +449,7 @@ watch(showDialog, async (val) => {
       !!formData.value.namespace && formData.value.namespace !== GLOBAL_NAMESPACE
   } else {
     formData.value = createRawFormData()
+    originalAPIKeyScopeState.value = undefined
     lastRole.value = UserRole.Admin
   }
 })
@@ -396,11 +459,16 @@ const { copyText } = useCopy()
 const { apiKeyRoleOptions } = useRole()
 const isPublisherRole = computed(() => formData.value.role === UserRole.Publisher)
 const customScopeOptions = computed(() =>
-  availableScopes.value.filter(({ name }) => name !== SYSTEM_SCOPE),
+  availableScopes.value.filter(
+    ({ name }) => name !== SYSTEM_SCOPE && !(isNamespacedKey.value && name === PUBLISH_SCOPE),
+  ),
 )
 const hasLegacyMixedScopes = computed(
   () =>
     formData.value.scopeMode === ScopeMode.Custom && formData.value.scopes.includes(SYSTEM_SCOPE),
+)
+const hasLegacyNamespacedPublishScopes = computed(
+  () => isNamespacedKey.value && formData.value.scopes.includes(PUBLISH_SCOPE),
 )
 
 const handleScopeModeChanged = (mode: string | number | boolean | undefined) => {


### PR DESCRIPTION
Filter Publish from namespaced API key scopes and validate it before submission.

Preserve unchanged legacy scope lists with an immutable snapshot, and align permission descriptions with backend defaults.

fixes #3851
