### PR TITLE
feat(auth): support dynamic hostname resolution for HTTP backends

### DIFF
--- a/src/hooks/Auth/useAuthnCreate.ts
+++ b/src/hooks/Auth/useAuthnCreate.ts
@@ -51,6 +51,12 @@ export default function useAuthnCreate() {
       oauth2: {
         enable: false,
       },
+      ...(type === 'password_based'
+        ? {
+            hostname_resolution: 'static',
+            allowed_hosts: [],
+          }
+        : {}),
       ...(type === 'scram'
         ? {
             algorithm: 'sha256',

--- a/src/hooks/Auth/useAuthzCreate.ts
+++ b/src/hooks/Auth/useAuthzCreate.ts
@@ -85,6 +85,8 @@ export default function useAuthzCreate() {
       oauth2: {
         enable: false,
       },
+      hostname_resolution: 'static',
+      allowed_hosts: [],
     }
   }
   const getMongodbConfig = () => {

--- a/src/hooks/Auth/useHTTPConfigForm.ts
+++ b/src/hooks/Auth/useHTTPConfigForm.ts
@@ -1,21 +1,88 @@
 import { FormRules } from '@/types/common'
 import { isJSONString } from '@emqx/shared-ui-utils'
 
-export default (): {
+const HOSTNAME_REG = /^[a-z0-9-]+(?:\.[a-z0-9-]+)*$/i
+const MAX_HOSTNAME_LENGTH = 253
+
+const isTemplatedURLHost = (url: string): boolean => {
+  const authority = url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1]
+  return authority?.includes('${') ?? false
+}
+
+const isValidAllowedHost = (value: string): boolean => {
+  const hostname = value.startsWith('*.') ? value.slice(2) : value
+  return (
+    hostname.length > 0 && hostname.length <= MAX_HOSTNAME_LENGTH && HOSTNAME_REG.test(hostname)
+  )
+}
+
+export default (
+  httpConfig: Ref<Record<string, any>>,
+  supportsDynamicHostname: () => boolean,
+): {
   formCom: Ref<any>
   rules: ComputedRef<FormRules>
   validate: () => any
 } => {
   const { t, tl } = useI18nTl('Auth')
-  const { createRequiredRule } = useFormRules()
+  const { createRequiredRule, createIntFieldRule } = useFormRules()
   const formCom = ref()
   const rules: ComputedRef<FormRules> = computed(() => {
+    const isDynamic = httpConfig.value.hostname_resolution === 'dynamic'
     const ret: FormRules = {
       method: createRequiredRule(tl('method'), 'select'),
-      url: createRequiredRule('URL'),
+      url: [
+        ...createRequiredRule('URL'),
+        {
+          validator(_rule, value: string, callback) {
+            if (!value || !isTemplatedURLHost(value)) {
+              return callback()
+            }
+            if (!supportsDynamicHostname()) {
+              return callback(new Error(tl('templatedHostnameNotSupported')))
+            }
+            if (!isDynamic) {
+              return callback(new Error(tl('templatedHostnameRequiresDynamic')))
+            }
+            callback()
+          },
+        },
+      ],
+      hostname_resolution: [
+        ...createRequiredRule(tl('hostnameResolution'), 'select'),
+        {
+          validator(_rule, value: string, callback) {
+            if (value === 'dynamic' && httpConfig.value.oauth2?.enable) {
+              return callback(new Error(tl('dynamicHostnameOAuth2Conflict')))
+            }
+            callback()
+          },
+        },
+      ],
+      allowed_hosts: [
+        {
+          validator(_rule, value: unknown, callback) {
+            const allowedHosts = Array.isArray(value) ? value : []
+            if (
+              isDynamic &&
+              isTemplatedURLHost(httpConfig.value.url) &&
+              allowedHosts.length === 0
+            ) {
+              return callback(new Error(tl('templatedHostnameRequiresAllowedHosts')))
+            }
+            if (
+              allowedHosts.some((item) => typeof item !== 'string' || !isValidAllowedHost(item))
+            ) {
+              return callback(new Error(tl('invalidAllowedHost')))
+            }
+            callback()
+          },
+        },
+      ],
+      pool_size: createIntFieldRule(isDynamic ? 0 : 1),
       body: [
         {
-          validator(rules, value, callback) {
+          validator(_rule, value, callback) {
             if (!value || isJSONString(value)) {
               return callback()
             }

--- a/src/hooks/Auth/useProcessAuthData.ts
+++ b/src/hooks/Auth/useProcessAuthData.ts
@@ -21,6 +21,9 @@ export default function useProcessAuthData() {
     try {
       const tempData = cloneDeep(data)
       const { body } = data
+      if (tempData.hostname_resolution === 'static') {
+        delete tempData.allowed_hosts
+      }
       if (body !== '' && body !== undefined) {
         tempData.body = parseJSONSelectively(body)
       } else {

--- a/src/i18n/Auth.ts
+++ b/src/i18n/Auth.ts
@@ -319,6 +319,54 @@ export default {
     zh: 'HTTP 管道',
     en: 'HTTP Pipelining',
   },
+  hostnameResolution: {
+    zh: '主机名解析方式',
+    en: 'Hostname Resolution',
+  },
+  hostnameResolutionDesc: {
+    zh: '静态模式使用固定主机名和持久连接池；动态模式会在每次请求时解析主机名，并支持 URL 主机中的模板变量。',
+    en: 'Static mode uses a fixed hostname and persistent connection pool. Dynamic mode resolves the hostname for each request and supports template variables in the URL host.',
+  },
+  hostnameResolutionStatic: {
+    zh: '静态',
+    en: 'Static',
+  },
+  hostnameResolutionDynamic: {
+    zh: '动态',
+    en: 'Dynamic',
+  },
+  allowedHosts: {
+    zh: '允许的主机',
+    en: 'Allowed Hosts',
+  },
+  allowedHostsDesc: {
+    zh: 'URL 主机包含模板变量时必须配置。多个条目使用英文逗号分隔；每项可以是精确主机名（如 auth.example.com）或以 *. 开头的通配符模式（如 *.auth.example.com），不能包含端口、路径或空格。',
+    en: 'Required when the URL host contains template variables. Separate multiple entries with commas. Each entry must be an exact hostname (such as auth.example.com) or a wildcard pattern starting with *. (such as *.auth.example.com); ports, paths, and spaces are not allowed.',
+  },
+  httpURLDesc: {
+    zh: "动态解析模式下，主机部分可以包含模板变量，例如 https://${'{'}client_attrs.tns{'}'}.auth.example.com/auth。",
+    en: "In dynamic resolution mode, the host may contain template variables, for example https://${'{'}client_attrs.tns{'}'}.auth.example.com/auth.",
+  },
+  templatedHostnameNotSupported: {
+    zh: '当前认证方式不支持 URL 主机模板变量。',
+    en: 'The current authentication mechanism does not support template variables in the URL host.',
+  },
+  templatedHostnameRequiresDynamic: {
+    zh: 'URL 主机包含模板变量时，主机名解析方式必须选择动态。',
+    en: 'Dynamic hostname resolution is required when the URL host contains template variables.',
+  },
+  templatedHostnameRequiresAllowedHosts: {
+    zh: 'URL 主机包含模板变量时，必须至少配置一个允许的主机。',
+    en: 'At least one allowed host is required when the URL host contains template variables.',
+  },
+  dynamicHostnameOAuth2Conflict: {
+    zh: '动态主机名解析不能与 OAuth2 同时启用。',
+    en: 'Dynamic hostname resolution cannot be used with OAuth2.',
+  },
+  invalidAllowedHost: {
+    zh: '请输入有效的主机名或以 *. 开头的通配符模式，不能包含端口、路径或空格。',
+    en: 'Enter a valid hostname or a wildcard pattern starting with *.; ports, paths, and spaces are not allowed.',
+  },
   isSuperuser: {
     zh: '是否为超级用户',
     en: 'Is superuser',

--- a/src/views/Auth/components/HttpConfig.vue
+++ b/src/views/Auth/components/HttpConfig.vue
@@ -20,10 +20,42 @@
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="URL" required prop="url">
+            <el-form-item required prop="url">
+              <template #label>
+                <FormItemLabel label="URL" :desc="tl('httpURLDesc')" desc-marked />
+              </template>
               <el-input v-model="httpConfig.url" />
             </el-form-item>
           </el-col>
+          <template v-if="supportsDynamicHostname">
+            <el-col :span="12">
+              <el-form-item prop="hostname_resolution" required>
+                <template #label>
+                  <FormItemLabel
+                    :label="tl('hostnameResolution')"
+                    :desc="tl('hostnameResolutionDesc')"
+                    desc-marked
+                  />
+                </template>
+                <el-select v-model="httpConfig.hostname_resolution">
+                  <el-option value="static" :label="tl('hostnameResolutionStatic')" />
+                  <el-option value="dynamic" :label="tl('hostnameResolutionDynamic')" />
+                </el-select>
+              </el-form-item>
+            </el-col>
+            <el-col v-if="isDynamicHostname" :span="12">
+              <el-form-item prop="allowed_hosts" :required="requiresAllowedHosts">
+                <template #label>
+                  <FormItemLabel
+                    :label="tl('allowedHosts')"
+                    :desc="tl('allowedHostsDesc')"
+                    desc-marked
+                  />
+                </template>
+                <ArrayEditorInput v-model="httpConfig.allowed_hosts" />
+              </el-form-item>
+            </el-col>
+          </template>
           <PreconditionFormItem v-model="httpConfig.precondition" :auth-type="authType" />
 
           <el-col :span="24">
@@ -85,8 +117,8 @@
         <AdvancedSettingContainer>
           <el-row :gutter="20">
             <el-col :span="12">
-              <el-form-item :label="$t('RuleEngine.connectionPoolSize')">
-                <el-input v-model.number="httpConfig.pool_size" />
+              <el-form-item :label="$t('RuleEngine.connectionPoolSize')" prop="pool_size">
+                <CustomInputNumber v-model="httpConfig.pool_size" :min="minPoolSize" />
               </el-form-item>
             </el-col>
             <el-col :span="12">
@@ -171,10 +203,24 @@ export default defineComponent({
     }
     const defaultContent = JSON.stringify(httpJSON, null, 2)
     const httpConfig = ref(props.modelValue)
+    const supportsDynamicHostname = computed(() => props.type !== 'scram')
+    const ensureHostnameResolutionFields = () => {
+      if (!supportsDynamicHostname.value) {
+        return
+      }
+      httpConfig.value.hostname_resolution ??= 'static'
+      if (!Array.isArray(httpConfig.value.allowed_hosts)) {
+        httpConfig.value.allowed_hosts = []
+      }
+    }
+    ensureHostnameResolutionFields()
     if (!httpConfig.value.oauth2) {
       httpConfig.value.oauth2 = { enable: false }
     }
-    const { formCom, rules, validate } = useHTTPConfigForm()
+    const { formCom, rules, validate } = useHTTPConfigForm(
+      httpConfig,
+      () => supportsDynamicHostname.value,
+    )
     watch(httpConfig.value, (value) => {
       ctx.emit('update:modelValue', value)
     })
@@ -184,6 +230,7 @@ export default defineComponent({
       (val) => {
         if (!isEqual(val, httpConfig.value)) {
           httpConfig.value = val
+          ensureHostnameResolutionFields()
           stringifyBody()
         }
       },
@@ -192,6 +239,14 @@ export default defineComponent({
     const needHelp = ref(false)
 
     const isMethodGet = computed(() => httpConfig.value.method === 'get')
+    const isDynamicHostname = computed(
+      () => supportsDynamicHostname.value && httpConfig.value.hostname_resolution === 'dynamic',
+    )
+    const requiresAllowedHosts = computed(() => {
+      const authority = httpConfig.value.url?.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1]
+      return isDynamicHostname.value && (authority?.includes('${') ?? false)
+    })
+    const minPoolSize = computed(() => (isDynamicHostname.value ? 0 : 1))
     const { factory } = useAuthnCreate()
     const { headers: defaultHeaders } = factory('password_based', 'http')
     const handleMethodChanged = () => {
@@ -234,6 +289,10 @@ export default defineComponent({
       formCom,
       rules,
       isMethodGet,
+      supportsDynamicHostname,
+      isDynamicHostname,
+      requiresAllowedHosts,
+      minPoolSize,
       handleMethodChanged,
       validate,
       toggleNeedHelp,


### PR DESCRIPTION
- Add hostname resolution and allowed host controls
- Validate templated hosts, OAuth2 conflicts, and dynamic pool sizes
- Omit allowed_hosts from static resolution payloads

closes #3827 